### PR TITLE
Add missing SA30 source codes

### DIFF
--- a/src/arcam/fmj/__init__.py
+++ b/src/arcam/fmj/__init__.py
@@ -408,7 +408,7 @@ RC5CODE_SOURCE = {
         SourceCodes.NET: bytes([16, 92]),
         SourceCodes.USB: bytes([16, 93]),
         SourceCodes.GAME: bytes([16, 97]),
-        SourceCodes.ARC_ERC: bytes([16, 125]),
+        SourceCodes.ARC_ERC: bytes([16, 125])
     },
     (ApiModel.APISA_SERIES, 2): {
         SourceCodes.PHONO: bytes([16, 117]),
@@ -422,7 +422,7 @@ RC5CODE_SOURCE = {
         SourceCodes.NET: bytes([16, 92]),
         SourceCodes.USB: bytes([16, 93]),
         SourceCodes.GAME: bytes([16, 97]),
-        SourceCodes.ARC_ERC: bytes([16, 125]),
+        SourceCodes.ARC_ERC: bytes([16, 125])
     }
 }
 

--- a/src/arcam/fmj/__init__.py
+++ b/src/arcam/fmj/__init__.py
@@ -238,6 +238,7 @@ class SourceCodes(IntOrTypeEnum):
     STB = 0x10
     GAME = 0x11
     PHONO = 0x12
+    ARC_ERC = 0x13
 
 
 class MenuCodes(IntOrTypeEnum):
@@ -403,7 +404,11 @@ RC5CODE_SOURCE = {
         SourceCodes.PVR: bytes([16, 96]),
         SourceCodes.AV: bytes([16, 94]),
         SourceCodes.AUX: bytes([16, 99]),
-        SourceCodes.STB: bytes([16, 100])
+        SourceCodes.STB: bytes([16, 100]),
+        SourceCodes.NET: bytes([16, 92]),
+        SourceCodes.USB: bytes([16, 93]),
+        SourceCodes.GAME: bytes([16, 97]),
+        SourceCodes.ARC_ERC: bytes([16, 125]),
     },
     (ApiModel.APISA_SERIES, 2): {
         SourceCodes.PHONO: bytes([16, 117]),
@@ -413,7 +418,11 @@ RC5CODE_SOURCE = {
         SourceCodes.PVR: bytes([16, 96]),
         SourceCodes.AV: bytes([16, 94]),
         SourceCodes.AUX: bytes([16, 99]),
-        SourceCodes.STB: bytes([16, 100])
+        SourceCodes.STB: bytes([16, 100]),
+        SourceCodes.NET: bytes([16, 92]),
+        SourceCodes.USB: bytes([16, 93]),
+        SourceCodes.GAME: bytes([16, 97]),
+        SourceCodes.ARC_ERC: bytes([16, 125]),
     }
 }
 


### PR DESCRIPTION
I missed one other new source (ARC/eARC) which can be found on page 26 of the [SA30 PDF](http://www.arcam.co.uk/ugc/tor/SA30/Custom%20Installation%20Notes/SH306E_RS232_SA30_4.pdf). Furthermore the SA30 supports more sources than its counterparts.

Should we split the `ApiModel` entry into two separate ones or just combine the sources like this PR is doing?