### PR TITLE
Add non RC5 commands for power on/off

### DIFF
--- a/src/arcam/fmj/__init__.py
+++ b/src/arcam/fmj/__init__.py
@@ -282,6 +282,25 @@ class DecodeModeMCH(IntOrTypeEnum):
     DTS_VIRTUAL_X = 0x0C, APIVERSION_860_SERIES
 
 
+NONRC5_CODE_POWER = {
+    (ApiModel.API450_SERIES, 1): {
+    },
+    (ApiModel.API450_SERIES, 2): {
+    },
+    (ApiModel.API860_SERIES, 1): {
+    },
+    (ApiModel.API860_SERIES, 2): {
+    },
+    (ApiModel.APISA_SERIES, 1): {
+        True: bytes([0x01]),
+        False: bytes([0x00])
+    },
+    (ApiModel.APISA_SERIES, 2): {
+        True: bytes([0x01]),
+        False: bytes([0x00])
+    }
+}
+
 RC5CODE_DECODE_MODE_MCH: Dict[Tuple[ApiModel, int], Dict[DecodeModeMCH, bytes]] = {
     (ApiModel.API450_SERIES, 1): {
         DecodeModeMCH.STEREO_DOWNMIX: bytes([16, 107]),
@@ -448,8 +467,8 @@ RC5CODE_POWER = {
         False: bytes([16, 124])
     },
     (ApiModel.APISA_SERIES, 2): {
-        True: bytes([23, 123]),
-        False: bytes([23, 124])
+        True: bytes([16, 123]),
+        False: bytes([16, 124])
     }
 }
 

--- a/src/arcam/fmj/__init__.py
+++ b/src/arcam/fmj/__init__.py
@@ -282,23 +282,8 @@ class DecodeModeMCH(IntOrTypeEnum):
     DTS_VIRTUAL_X = 0x0C, APIVERSION_860_SERIES
 
 
-NONRC5_CODE_POWER = {
-    (ApiModel.API450_SERIES, 1): {
-    },
-    (ApiModel.API450_SERIES, 2): {
-    },
-    (ApiModel.API860_SERIES, 1): {
-    },
-    (ApiModel.API860_SERIES, 2): {
-    },
-    (ApiModel.APISA_SERIES, 1): {
-        True: bytes([0x01]),
-        False: bytes([0x00])
-    },
-    (ApiModel.APISA_SERIES, 2): {
-        True: bytes([0x01]),
-        False: bytes([0x00])
-    }
+POWER_WRITE_SUPPORTED = {
+    ApiModel.APISA_SERIES
 }
 
 RC5CODE_DECODE_MODE_MCH: Dict[Tuple[ApiModel, int], Dict[DecodeModeMCH, bytes]] = {

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -23,7 +23,7 @@ from . import (
     ResponseException,
     ResponsePacket,
     SourceCodes,
-    NONRC5_CODE_POWER,
+    POWER_WRITE_SUPPORTED,
     RC5CODE_SOURCE,
     RC5CODE_POWER,
     RC5CODE_MUTE,
@@ -116,7 +116,7 @@ class State():
             return self._amxduet.device_revision
         return None
 
-    def get_code_from_dict(self, table: Dict[Tuple[ApiModel, int], Dict[_T, bytes]], value: _T) -> bytes:
+    def get_rc5code(self, table: Dict[Tuple[ApiModel, int], Dict[_T, bytes]], value: _T) -> bytes:
         lookup = table.get((self._api_model, self._zn))
         if not lookup:
             raise ValueError("Unkown mapping for model {} and zone {}".format(self._api_model, self._zn))
@@ -144,7 +144,7 @@ class State():
         return DecodeMode2CH.from_bytes(value)
 
     async def set_decode_mode_2ch(self, mode: DecodeMode2CH):
-        command = self.get_code_from_dict(RC5CODE_DECODE_MODE_2CH, mode)
+        command = self.get_rc5code(RC5CODE_DECODE_MODE_2CH, mode)
         await self._client.request(
             self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command)
 
@@ -155,7 +155,7 @@ class State():
         return DecodeModeMCH.from_bytes(value)
 
     async def set_decode_mode_mch(self, mode: DecodeModeMCH):
-        command = self.get_code_from_dict(RC5CODE_DECODE_MODE_MCH, mode)
+        command = self.get_rc5code(RC5CODE_DECODE_MODE_MCH, mode)
         await self._client.request(
             self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command)
 
@@ -204,22 +204,26 @@ class State():
             return None
         return int.from_bytes(value, 'big') == 0x01
 
-    async def set_power(self, power: bool, use_rc5: bool = True) -> None:
-        correct_command_code = CommandCodes.SIMULATE_RC5_IR_COMMAND if use_rc5 else CommandCodes.POWER
-        correct_dict = RC5CODE_POWER if use_rc5 else NONRC5_CODE_POWER
-        command = self.get_code_from_dict(correct_dict, power)
-
-        if power:
+    async def set_power(self, power: bool) -> None:
+        if self._api_model in POWER_WRITE_SUPPORTED:
+            bool_to_hex = 0x01 if power else 0x00
+            if not power:
+                self._state[CommandCodes.POWER] = bytes([0])
             await self._client.request(
-                self._zn, correct_command_code, command)
+                self._zn, CommandCodes.POWER, bytes([bool_to_hex]))
         else:
-            # seed with a response, since device might not
-            # respond in timely fashion, so let's just
-            # assume we succeded until response come
-            # back.
-            self._state[CommandCodes.POWER] = bytes([0])
-            await self._client.send(
-                self._zn, correct_command_code, command)
+            command = self.get_rc5code(RC5CODE_POWER, power)
+            if power:
+                await self._client.request(
+                    self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command)
+            else:
+                # seed with a response, since device might not
+                # respond in timely fashion, so let's just
+                # assume we succeded until response come
+                # back.
+                self._state[CommandCodes.POWER] = bytes([0])
+                await self._client.send(
+                    self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command)
 
     def get_menu(self) -> Optional[MenuCodes]:
         value = self._state.get(CommandCodes.MENU)
@@ -234,7 +238,7 @@ class State():
         return int.from_bytes(value, 'big') == 0
 
     async def set_mute(self, mute: bool) -> None:
-        command = self.get_code_from_dict(RC5CODE_MUTE, mute)
+        command = self.get_rc5code(RC5CODE_MUTE, mute)
         await self._client.request(
             self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command)
 
@@ -249,7 +253,7 @@ class State():
         return list(RC5CODE_SOURCE[(self._api_model, self._zn)].keys())
 
     async def set_source(self, src: SourceCodes) -> None:
-        command = self.get_code_from_dict(RC5CODE_SOURCE, src)
+        command = self.get_rc5code(RC5CODE_SOURCE, src)
         await self._client.request(
             self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command)
 
@@ -264,13 +268,13 @@ class State():
             self._zn, CommandCodes.VOLUME, bytes([volume]))
 
     async def inc_volume(self) -> None:
-        command = self.get_code_from_dict(RC5CODE_VOLUME, True)
+        command = self.get_rc5code(RC5CODE_VOLUME, True)
 
         await self._client.request(
             self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command)
 
     async def dec_volume(self) -> None:
-        command = self.get_code_from_dict(RC5CODE_VOLUME, False)
+        command = self.get_rc5code(RC5CODE_VOLUME, False)
 
         await self._client.request(
             self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2,13 +2,43 @@ import pytest
 from unittest.mock import MagicMock
 from arcam.fmj.client import Client
 from arcam.fmj.state import State
-from arcam.fmj import AnswerCodes, CommandCodes, ResponsePacket
+from arcam.fmj import AnswerCodes, ApiModel, CommandCodes, ResponsePacket
 
+TEST_PARAMS = [
+    (1, ApiModel.API450_SERIES, True),
+    (1, ApiModel.API450_SERIES, False),
+    (1, ApiModel.API860_SERIES, True),
+    (1, ApiModel.API860_SERIES, False),
+    (1, ApiModel.APISA_SERIES, True),
+    (1, ApiModel.APISA_SERIES, False),
+    (2, ApiModel.API450_SERIES, True),
+    (2, ApiModel.API450_SERIES, False),
+    (2, ApiModel.API860_SERIES, True),
+    (2, ApiModel.API860_SERIES, False),
+    (2, ApiModel.APISA_SERIES, True),
+    (2, ApiModel.APISA_SERIES, False)
+]
 
-@pytest.mark.parametrize("zn", [1, 2])
-async def test_power_on(zn):
+# zn, api_model, power
+PARAMS_TO_RC5COMMAND = {
+    (1, ApiModel.API450_SERIES, True): bytes([16, 123]),
+    (1, ApiModel.API450_SERIES, False): bytes([16, 124]),
+    (1, ApiModel.API860_SERIES, True): bytes([16, 123]),
+    (1, ApiModel.API860_SERIES, False): bytes([16, 124]),
+    (1, ApiModel.APISA_SERIES, True): bytes([16, 123]),
+    (1, ApiModel.APISA_SERIES, False): bytes([16, 124]),
+    (2, ApiModel.API450_SERIES, True): bytes([23, 123]),
+    (2, ApiModel.API450_SERIES, False): bytes([23, 124]),
+    (2, ApiModel.API860_SERIES, True): bytes([23, 123]),
+    (2, ApiModel.API860_SERIES, False): bytes([23, 124]),
+    (2, ApiModel.APISA_SERIES, True): bytes([16, 123]),
+    (2, ApiModel.APISA_SERIES, False): bytes([16, 124])
+}
+
+@pytest.mark.parametrize("zn, api_model, use_rc5", TEST_PARAMS)
+async def test_power_on(zn, api_model, use_rc5):
     client = MagicMock(spec=Client)
-    state = State(client, zn)
+    state = State(client, zn, api_model)
     response = ResponsePacket(
         zn,
         CommandCodes.SIMULATE_RC5_IR_COMMAND,
@@ -16,31 +46,45 @@ async def test_power_on(zn):
         bytes([0x01]),
     )
     client.request.return_value = response
-
-    await state.set_power(True)
-    if zn == 1:
-        code = bytes([16, 123])
+    if not use_rc5:
+        if api_model != ApiModel.APISA_SERIES:
+            with pytest.raises(ValueError):
+                await state.set_power(True, use_rc5)
+        else:
+            await state.set_power(True, use_rc5)
+            client.request.assert_called_with(
+                zn, CommandCodes.POWER, bytes([0x01])
+            )
     else:
-        code = bytes([23, 123])
+        await state.set_power(True, use_rc5)
+        # zn, api_model, power
+        code = PARAMS_TO_RC5COMMAND[zn, api_model, True]
+        client.request.assert_called_with(
+            zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code
+        )
 
-    client.request.assert_called_with(
-        zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code
-    )
 
-
-@pytest.mark.parametrize("zn", [1, 2])
-async def test_power_off(zn):
+@pytest.mark.parametrize("zn, api_model, use_rc5", TEST_PARAMS)
+async def test_power_off(zn, api_model, use_rc5):
     client = MagicMock(spec=Client)
-    state = State(client, zn)
+    state = State(client, zn, api_model)
 
     assert state.get_power() is None
-    await state.set_power(False)
-    if zn == 1:
-        code = bytes([16, 124])
+    if not use_rc5:
+        if api_model != ApiModel.APISA_SERIES:
+            with pytest.raises(ValueError):
+                await state.set_power(False, use_rc5)
+        else:
+            await state.set_power(False, use_rc5)
+            client.send.assert_called_with(
+                zn, CommandCodes.POWER, bytes([0x00])
+            )
+            assert state.get_power() == False
     else:
-        code = bytes([23, 124])
-
-    client.send.assert_called_with(
-        zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code
-    )
-    assert state.get_power() == False
+        await state.set_power(False, use_rc5)
+        # zn, api_model, power
+        code = PARAMS_TO_RC5COMMAND[zn, api_model, False]
+        client.send.assert_called_with(
+            zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code
+        )
+        assert state.get_power() == False


### PR DESCRIPTION
The SA series offers support for powering on/off via `CommandCodes.POWER`. I also updated the RC5 power codes for the SA models as the doc said they do not change by zone.

Tests can be ran with `pytest --cov` to ensure they're all passing:
![image](https://user-images.githubusercontent.com/36345325/131239403-e6f10d42-98c2-4e5b-8580-719ad0de6711.png)


### Reference
[SA 10/20 PDF](https://www.arcam.co.uk/ugc/tor/SA10/Custom%20Installation%20Notes/SH277E_RS232_SA10_SA20_B.pdf)
[SA 30 PDF](http://www.arcam.co.uk/ugc/tor/SA30/Custom%20Installation%20Notes/SH306E_RS232_SA30_4.pdf)

