### PR TITLE
Add non RC5 commands for current input source source

### DIFF
--- a/src/arcam/fmj/__init__.py
+++ b/src/arcam/fmj/__init__.py
@@ -306,23 +306,23 @@ class CommandCodes(IntOrTypeEnum):
 
 
 class SourceCodes(IntOrTypeEnum):
-    FOLLOW_ZONE_1 = 0x00
-    CD = 0x01
-    BD = 0x02
-    AV = 0x03
-    SAT = 0x04
-    PVR = 0x05
-    VCR = 0x06 # UHD on HDA Series
-    AUX = 0x08
-    DISPLAY = 0x09
-    FM = 0x0B
-    DAB = 0x0C, APIVERSION_DAB_SERIES
-    NET = 0x0E
-    USB = 0x0F
-    STB = 0x10
-    GAME = 0x11
-    PHONO = 0x12 # BT on HDA Series
-    ARC_ERC = 0x13
+    FOLLOW_ZONE_1 = enum.auto()
+    CD = enum.auto()
+    BD = enum.auto()
+    AV = enum.auto()
+    SAT = enum.auto()
+    PVR = enum.auto()
+    VCR = enum.auto()
+    AUX = enum.auto()
+    DISPLAY = enum.auto()
+    FM = enum.auto()
+    DAB = enum.auto()
+    NET = enum.auto()
+    USB = enum.auto()
+    STB = enum.auto()
+    GAME = enum.auto()
+    PHONO = enum.auto()
+    ARC_ERC = enum.auto()
 
 
 class MenuCodes(IntOrTypeEnum):
@@ -385,7 +385,33 @@ SOURCE_WRITE_SUPPORTED = {
     ApiModel.APISA_SERIES,
 }
 
-DIRECT_SOURCE_CODES = {
+DEFAULT_SOURCE_MAPPING = {
+    SourceCodes.FOLLOW_ZONE_1: bytes([0x00]),
+    SourceCodes.CD: bytes([0x01]),
+    SourceCodes.BD: bytes([0x02]),
+    SourceCodes.AV: bytes([0x03]),
+    SourceCodes.SAT: bytes([0x04]),
+    SourceCodes.PVR: bytes([0x05]),
+    SourceCodes.VCR: bytes([0x06]),
+    SourceCodes.AUX: bytes([0x08]),
+    SourceCodes.DISPLAY: bytes([0x09]),
+    SourceCodes.FM: bytes([0x0B]),
+    SourceCodes.DAB: bytes([0x0C]),
+    SourceCodes.NET: bytes([0x0E]),
+    SourceCodes.USB: bytes([0x0F]),
+    SourceCodes.STB: bytes([0x10]),
+    SourceCodes.GAME: bytes([0x11]),
+    SourceCodes.PHONO: bytes([0x12]),
+    SourceCodes.ARC_ERC: bytes([0x13]),
+}
+
+SOURCE_CODES = {
+    (ApiModel.API450_SERIES, 1): DEFAULT_SOURCE_MAPPING,
+    (ApiModel.API450_SERIES, 2): DEFAULT_SOURCE_MAPPING,
+    (ApiModel.API860_SERIES, 1): DEFAULT_SOURCE_MAPPING,
+    (ApiModel.API860_SERIES, 2): DEFAULT_SOURCE_MAPPING,
+    (ApiModel.APIHDA_SERIES, 1): DEFAULT_SOURCE_MAPPING,
+    (ApiModel.APIHDA_SERIES, 2): DEFAULT_SOURCE_MAPPING,
     (ApiModel.APISA_SERIES, 1): {
         SourceCodes.PHONO: bytes([0x01]),
         SourceCodes.AUX: bytes([0x02]),

--- a/src/arcam/fmj/__init__.py
+++ b/src/arcam/fmj/__init__.py
@@ -381,6 +381,40 @@ POWER_WRITE_SUPPORTED = {
     ApiModel.APIPA_SERIES,
 }
 MUTE_WRITE_SUPPORTED = POWER_WRITE_SUPPORTED
+SOURCE_WRITE_SUPPORTED = {
+    ApiModel.APISA_SERIES,
+}
+
+DIRECT_SOURCE_CODES = {
+    (ApiModel.APISA_SERIES, 1): {
+        SourceCodes.PHONO: bytes([0x01]),
+        SourceCodes.AUX: bytes([0x02]),
+        SourceCodes.PVR: bytes([0x03]),
+        SourceCodes.AV: bytes([0x04]),
+        SourceCodes.STB: bytes([0x05]),
+        SourceCodes.CD: bytes([0x06]),
+        SourceCodes.BD: bytes([0x07]),
+        SourceCodes.SAT: bytes([0x08]),
+        SourceCodes.GAME: bytes([0x09]),
+        SourceCodes.NET: bytes([0x0B]),
+        SourceCodes.USB: bytes([0x0B]),
+        SourceCodes.ARC_ERC: bytes([0x0D]),
+    },
+    (ApiModel.APISA_SERIES, 2): {
+        SourceCodes.PHONO: bytes([0x01]),
+        SourceCodes.AUX: bytes([0x02]),
+        SourceCodes.PVR: bytes([0x03]),
+        SourceCodes.AV: bytes([0x04]),
+        SourceCodes.STB: bytes([0x05]),
+        SourceCodes.CD: bytes([0x06]),
+        SourceCodes.BD: bytes([0x07]),
+        SourceCodes.SAT: bytes([0x08]),
+        SourceCodes.GAME: bytes([0x09]),
+        SourceCodes.NET: bytes([0x0B]),
+        SourceCodes.USB: bytes([0x0B]),
+        SourceCodes.ARC_ERC: bytes([0x0D]),
+    },
+}
 
 RC5CODE_DECODE_MODE_MCH: Dict[Tuple[ApiModel, int], Dict[DecodeModeMCH, bytes]] = {
     (ApiModel.API450_SERIES, 1): {

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -28,6 +28,8 @@ from . import (
     SourceCodes,
     POWER_WRITE_SUPPORTED,
     MUTE_WRITE_SUPPORTED,
+    SOURCE_WRITE_SUPPORTED,
+    DIRECT_SOURCE_CODES,
     RC5CODE_SOURCE,
     RC5CODE_POWER,
     RC5CODE_MUTE,
@@ -255,16 +257,27 @@ class State():
         value = self._state.get(CommandCodes.CURRENT_SOURCE)
         if value is None:
             return None
-        return SourceCodes.from_int(
+        correct_enum = SourceCodes
+        if self._api_model in SOURCE_WRITE_SUPPORTED:
+            correct_enum = DIRECT_SOURCE_CODES.get((self._api_model, self._zn))
+        return correct_enum.from_int(
             int.from_bytes(value, 'big'))
 
     def get_source_list(self) -> List[SourceCodes]:
         return list(RC5CODE_SOURCE[(self._api_model, self._zn)].keys())
 
     async def set_source(self, src: SourceCodes) -> None:
-        command = self.get_rc5code(RC5CODE_SOURCE, src)
-        await self._client.request(
-            self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command)
+        if self._api_model in SOURCE_WRITE_SUPPORTED:
+            source_codes = DIRECT_SOURCE_CODES.get((self._api_model, self._zn))
+            value = source_codes.get(src)
+            if not value:
+                raise ValueError("Unkown source code for model {} and zone {} and value {}".format(self._api_model, self._zn, value))
+            await self._client.request(
+                self._zn, CommandCodes.CURRENT_SOURCE, value)
+        else:
+            command = self.get_rc5code(RC5CODE_SOURCE, src)
+            await self._client.request(
+                self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command)
 
     def get_volume(self) -> Optional[int]:
         value = self._state.get(CommandCodes.VOLUME)

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -257,8 +257,11 @@ class State():
         value = self._state.get(CommandCodes.CURRENT_SOURCE)
         if value is None:
             return None
-        correct_enum = SOURCE_CODES.get((self._api_model, self._zn))
-        return int.from_bytes(correct_enum[value], 'big')
+        correct_enum = SOURCE_CODES.get((self._api_model, self._zn), {})
+        source = correct_enum.get(value)
+        if source is None:
+            return None
+        return int.from_bytes(source, 'big')
 
     def get_source_list(self) -> List[SourceCodes]:
         return list(RC5CODE_SOURCE[(self._api_model, self._zn)].keys())

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -29,7 +29,7 @@ from . import (
     POWER_WRITE_SUPPORTED,
     MUTE_WRITE_SUPPORTED,
     SOURCE_WRITE_SUPPORTED,
-    DIRECT_SOURCE_CODES,
+    SOURCE_CODES,
     RC5CODE_SOURCE,
     RC5CODE_POWER,
     RC5CODE_MUTE,
@@ -257,9 +257,7 @@ class State():
         value = self._state.get(CommandCodes.CURRENT_SOURCE)
         if value is None:
             return None
-        correct_enum = SourceCodes
-        if self._api_model in SOURCE_WRITE_SUPPORTED:
-            correct_enum = DIRECT_SOURCE_CODES.get((self._api_model, self._zn))
+        correct_enum = SOURCE_CODES.get((self._api_model, self._zn))
         return correct_enum.from_int(
             int.from_bytes(value, 'big'))
 
@@ -268,7 +266,7 @@ class State():
 
     async def set_source(self, src: SourceCodes) -> None:
         if self._api_model in SOURCE_WRITE_SUPPORTED:
-            source_codes = DIRECT_SOURCE_CODES.get((self._api_model, self._zn))
+            source_codes = SOURCE_CODES.get((self._api_model, self._zn))
             value = source_codes.get(src)
             if not value:
                 raise ValueError("Unkown source code for model {} and zone {} and value {}".format(self._api_model, self._zn, value))

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -258,8 +258,7 @@ class State():
         if value is None:
             return None
         correct_enum = SOURCE_CODES.get((self._api_model, self._zn))
-        return correct_enum.from_int(
-            int.from_bytes(value, 'big'))
+        return int.from_bytes(correct_enum[value], 'big')
 
     def get_source_list(self) -> List[SourceCodes]:
         return list(RC5CODE_SOURCE[(self._api_model, self._zn)].keys())

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,0 +1,84 @@
+import logging
+
+import pytest
+from unittest.mock import MagicMock
+
+from src.arcam.fmj.client import Client
+from src.arcam.fmj.state import State
+from src.arcam.fmj import (
+  SourceCodes,
+  ApiModel,
+  AnswerCodes,
+  CommandCodes,
+  ResponsePacket,
+  SOURCE_CODES,
+  SOURCE_WRITE_SUPPORTED,
+  RC5CODE_SOURCE,
+)
+
+NO_SOURCE = {ApiModel.APIPA_SERIES}
+
+TEST_PARAMS = [
+    (1, ApiModel.API450_SERIES),
+    (1, ApiModel.API860_SERIES),
+    (1, ApiModel.APIHDA_SERIES),
+    (1, ApiModel.APISA_SERIES),
+    (1, ApiModel.APIPA_SERIES),
+    (2, ApiModel.API450_SERIES),
+    (2, ApiModel.API860_SERIES),
+    (2, ApiModel.APIHDA_SERIES),
+    (2, ApiModel.APISA_SERIES),
+    (2, ApiModel.APIPA_SERIES),
+]
+
+@pytest.mark.parametrize("zn, api_model", TEST_PARAMS)
+async def test_get_source(zn, api_model):
+  client = MagicMock(spec=Client)
+  state = State(client, zn, api_model)
+  source = SourceCodes.AUX
+  state._state[CommandCodes.CURRENT_SOURCE] = source
+
+  raises_exception = api_model in NO_SOURCE
+  if raises_exception:
+    with pytest.raises(TypeError):
+      result = state.get_source()
+  else:
+    expected_source = SOURCE_CODES.get((api_model, zn))[source]
+    expected_source_as_int = int.from_bytes(expected_source, 'big')
+    result = state.get_source()
+    assert result == expected_source_as_int
+  
+
+@pytest.mark.parametrize("zn, api_model", TEST_PARAMS)
+async def test_set_source(zn, api_model):
+    client = MagicMock(spec=Client)
+    state = State(client, zn, api_model)
+    state._api_model = api_model
+    source = SourceCodes.AUX
+
+    command_code = CommandCodes.SIMULATE_RC5_IR_COMMAND
+
+    raises_exception = api_model in NO_SOURCE
+    if raises_exception:
+      with pytest.raises(ValueError):
+        code = state.get_rc5code(RC5CODE_SOURCE, source)
+        return
+    else:
+      if api_model in SOURCE_WRITE_SUPPORTED:
+        command_code = CommandCodes.CURRENT_SOURCE 
+        code = SOURCE_CODES.get((api_model, zn))[source]
+      else:
+        code = state.get_rc5code(RC5CODE_SOURCE, source)
+
+      response = ResponsePacket(
+          zn,
+          command_code,
+          AnswerCodes.STATUS_UPDATE,
+          bytes([0x01]),
+      )
+      client.request.return_value = response
+
+      await state.set_source(source)
+      client.request.assert_called_with(
+              zn, command_code, code
+          )

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -38,10 +38,10 @@ async def test_get_source(zn, api_model):
   source = SourceCodes.AUX
   state._state[CommandCodes.CURRENT_SOURCE] = source
 
-  raises_exception = api_model in NO_SOURCE
-  if raises_exception:
-    with pytest.raises(TypeError):
-      result = state.get_source()
+  source_not_supported = api_model in NO_SOURCE
+  if source_not_supported:
+    result = state.get_source()
+    assert result == None
   else:
     expected_source = SOURCE_CODES.get((api_model, zn))[source]
     expected_source_as_int = int.from_bytes(expected_source, 'big')


### PR DESCRIPTION
I intend to add tests for `get_source`, `set_source` and `get_source_list` and then mark this pr ready for review

part of the discussion in #5 and [home-assistant/core#84918](https://github.com/home-assistant/core/issues/84918)