### PR TITLE
Correct source mapping

### DIFF
--- a/src/arcam/fmj/__init__.py
+++ b/src/arcam/fmj/__init__.py
@@ -305,7 +305,7 @@ class CommandCodes(IntOrTypeEnum):
     MAXIMUM_STREAMING_VOLUME = 0x67, APIVERSION_APP_SAFETY_SERIES
 
 
-class SourceCodes(IntOrTypeEnum):
+class SourceCodes(enum.Enum):
     FOLLOW_ZONE_1 = enum.auto()
     CD = enum.auto()
     BD = enum.auto()
@@ -324,6 +324,25 @@ class SourceCodes(IntOrTypeEnum):
     PHONO = enum.auto()
     ARC_ERC = enum.auto()
 
+    @classmethod
+    def from_bytes(cls, data: bytes, model: ApiModel, zn: int) -> 'SourceCodes':
+        try:
+            table = SOURCE_CODES[(model, zn)]
+        except KeyError:
+            raise ValueError("Unknown source map for model {} and zone {}".format(model, zn))
+        for key, value in table.items():
+            if value == data:
+                return key
+        raise ValueError("Unknown source code for model {} and zone {} and value {!r}".format(model, zn, data))
+
+    def to_bytes(self, model: ApiModel, zn: int):
+        try:
+            table = SOURCE_CODES[(model, zn)]
+        except KeyError:
+            raise ValueError("Unknown source map for model {} and zone {}".format(model, zn))
+        if data := table.get(self):
+            return data
+        raise ValueError("Unknown byte code for model {} and zone {} and value {}".format(model, zn, self))
 
 class MenuCodes(IntOrTypeEnum):
     NONE = 0x00

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -257,21 +257,17 @@ class State():
         value = self._state.get(CommandCodes.CURRENT_SOURCE)
         if value is None:
             return None
-        correct_enum = SOURCE_CODES.get((self._api_model, self._zn), {})
-        source = correct_enum.get(value)
-        if source is None:
+        try:
+            return SourceCodes.from_bytes(value, self._api_model, self._zn)
+        except ValueError:
             return None
-        return int.from_bytes(source, 'big')
 
     def get_source_list(self) -> List[SourceCodes]:
         return list(RC5CODE_SOURCE[(self._api_model, self._zn)].keys())
 
     async def set_source(self, src: SourceCodes) -> None:
         if self._api_model in SOURCE_WRITE_SUPPORTED:
-            source_codes = SOURCE_CODES.get((self._api_model, self._zn))
-            value = source_codes.get(src)
-            if not value:
-                raise ValueError("Unkown source code for model {} and zone {} and value {}".format(self._api_model, self._zn, value))
+            value = src.to_bytes(self._api_model, self._zn)
             await self._client.request(
                 self._zn, CommandCodes.CURRENT_SOURCE, value)
         else:

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -3,9 +3,9 @@ import logging
 import pytest
 from unittest.mock import MagicMock
 
-from src.arcam.fmj.client import Client
-from src.arcam.fmj.state import State
-from src.arcam.fmj import (
+from arcam.fmj.client import Client
+from arcam.fmj.state import State
+from arcam.fmj import (
   SourceCodes,
   ApiModel,
   AnswerCodes,
@@ -16,69 +16,66 @@ from src.arcam.fmj import (
   RC5CODE_SOURCE,
 )
 
-NO_SOURCE = {ApiModel.APIPA_SERIES}
-
-TEST_PARAMS = [
-    (1, ApiModel.API450_SERIES),
-    (1, ApiModel.API860_SERIES),
-    (1, ApiModel.APIHDA_SERIES),
-    (1, ApiModel.APISA_SERIES),
-    (1, ApiModel.APIPA_SERIES),
-    (2, ApiModel.API450_SERIES),
-    (2, ApiModel.API860_SERIES),
-    (2, ApiModel.APIHDA_SERIES),
-    (2, ApiModel.APISA_SERIES),
-    (2, ApiModel.APIPA_SERIES),
-]
-
-@pytest.mark.parametrize("zn, api_model", TEST_PARAMS)
-async def test_get_source(zn, api_model):
+@pytest.mark.parametrize("zn, api_model, source, data", [
+    (1, ApiModel.API450_SERIES, SourceCodes.AUX, bytes([0x08])),
+    (1, ApiModel.API860_SERIES, SourceCodes.AUX, bytes([0x08])),
+    (1, ApiModel.APIHDA_SERIES, SourceCodes.AUX, bytes([0x08])),
+    (1, ApiModel.APISA_SERIES, SourceCodes.AUX, bytes([0x02])),
+    (1, ApiModel.APIPA_SERIES, None, bytes([0x02])),
+    (2, ApiModel.API450_SERIES, SourceCodes.AUX, bytes([0x08])),
+    (2, ApiModel.API860_SERIES, SourceCodes.AUX, bytes([0x08])),
+    (2, ApiModel.APIHDA_SERIES, SourceCodes.AUX, bytes([0x08])),
+    (2, ApiModel.APISA_SERIES, SourceCodes.AUX, bytes([0x02])),
+    (2, ApiModel.APIPA_SERIES, None, bytes([0x02])),
+])
+async def test_get_source(zn, api_model, source, data):
   client = MagicMock(spec=Client)
   state = State(client, zn, api_model)
-  source = SourceCodes.AUX
-  state._state[CommandCodes.CURRENT_SOURCE] = source
+  state._state[CommandCodes.CURRENT_SOURCE] = data
 
-  source_not_supported = api_model in NO_SOURCE
-  if source_not_supported:
-    result = state.get_source()
-    assert result == None
-  else:
-    expected_source = SOURCE_CODES.get((api_model, zn))[source]
-    expected_source_as_int = int.from_bytes(expected_source, 'big')
-    result = state.get_source()
-    assert result == expected_source_as_int
+  assert state.get_source() == source
   
 
-@pytest.mark.parametrize("zn, api_model", TEST_PARAMS)
-async def test_set_source(zn, api_model):
+@pytest.mark.parametrize("zn, api_model, source, ir, data", [
+    (1, ApiModel.API450_SERIES, SourceCodes.AUX, True, bytes([16, 8])),
+    (1, ApiModel.API860_SERIES, SourceCodes.AUX, True, bytes([16, 99])),
+    (1, ApiModel.APIHDA_SERIES, SourceCodes.AUX, True, bytes([16, 99])),
+    (1, ApiModel.APISA_SERIES, SourceCodes.AUX, False, bytes([0x02])),
+    (2, ApiModel.API450_SERIES, SourceCodes.AUX, True, bytes([23, 13])),
+    (2, ApiModel.API860_SERIES, SourceCodes.AUX, True, bytes([23, 13])),
+    (2, ApiModel.APIHDA_SERIES, SourceCodes.AUX, True, bytes([23, 13])),
+    (2, ApiModel.APISA_SERIES, SourceCodes.AUX, False, bytes([0x02])),
+])
+async def test_set_source(zn, api_model, source, ir, data):
     client = MagicMock(spec=Client)
     state = State(client, zn, api_model)
-    state._api_model = api_model
-    source = SourceCodes.AUX
 
-    command_code = CommandCodes.SIMULATE_RC5_IR_COMMAND
-
-    raises_exception = api_model in NO_SOURCE
-    if raises_exception:
-      with pytest.raises(ValueError):
-        code = state.get_rc5code(RC5CODE_SOURCE, source)
-        return
+    if ir:
+      command_code = CommandCodes.SIMULATE_RC5_IR_COMMAND
     else:
-      if api_model in SOURCE_WRITE_SUPPORTED:
-        command_code = CommandCodes.CURRENT_SOURCE 
-        code = SOURCE_CODES.get((api_model, zn))[source]
-      else:
-        code = state.get_rc5code(RC5CODE_SOURCE, source)
+      command_code = CommandCodes.CURRENT_SOURCE
 
-      response = ResponsePacket(
-          zn,
-          command_code,
-          AnswerCodes.STATUS_UPDATE,
-          bytes([0x01]),
-      )
-      client.request.return_value = response
+    client.request.return_value = ResponsePacket(
+        zn,
+        command_code,
+        AnswerCodes.STATUS_UPDATE,
+        bytes([0x01]),
+    )
 
+    await state.set_source(source)
+
+    client.request.assert_called_with(
+            zn, command_code, data
+        )
+
+
+@pytest.mark.parametrize("zn, api_model, source", [
+    (1, ApiModel.APIPA_SERIES, SourceCodes.AUX),
+    (2, ApiModel.APIPA_SERIES, SourceCodes.AUX),
+])
+async def test_set_source_invalid(zn, api_model, source):
+    client = MagicMock(spec=Client)
+    state = State(client, zn, api_model)
+
+    with pytest.raises(ValueError):
       await state.set_source(source)
-      client.request.assert_called_with(
-              zn, command_code, code
-          )


### PR DESCRIPTION
Correct errors with source lookup mapping introduced in: #18. There was a mixup between int values and source codes in returns. 
