### PR TITLE
Polling

### DIFF
--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -875,3 +875,11 @@ class State:
                 tasks.append(_update(cc))
         if tasks:
             await asyncio.gather(*tasks)
+
+    async def poll_step(self) -> None:
+        await self.update(EnumFlags.POLL_REQUIRED)
+
+    async def poll_loop(self, rest_delay_s: float = 0) -> None:
+        while True:
+            await self.poll_step()
+            await asyncio.sleep(rest_delay_s)


### PR DESCRIPTION
Putting this up as a draft because it's just a rough idea, and it this point it's more material for discussion rather than a proposal to merge.

The problem is that with both bluetooth and net play info, you get updated info when you actively poll, but the device doesn't proactively push updates to these things. You've said (as I understand it) that HA does a polling loop that would cover this, but I don't see it, so maybe I'm just missing it, or maybe we're talking about different things?

Anyway, it _seems_ to me that we need _some_ sort of mechanism that periodically polls the device to get updates to these things, then when _we_ see the value(s) change, we can then push to HA (or whoever the client is) so they get timely updates (e.g., they see the change in playback state or get an updated playing track title - hello HA media player!)

This code would be a really simple way to do that. Make a think _like_ `update()` but with only the subset of things that need to be polled. Still call `update()` on startup, then call `poll()` from there, and periodically.

Some obvious improvements:
- Make the polling period user-adjustable
- Don't have a period at _all_. Instead just _always_ poll. That is, we have some "send loop", and if we have a _real_ command to send (e.g. the user issues a command) then the send loop does that. If not, then the send loop is always busy polling for state updates on things that need it
- The stuff in `update` vs `poll` is hard-coded; it would be better to have metadata on the commands that indicate what needs polling, and have the code just read that dynamically

Probably lots of other things too. Again, mostly putting this up in this state to start the conversation