### PR TITLE
feat: prioritize comms

### DIFF
--- a/src/arcam/fmj/__init__.py
+++ b/src/arcam/fmj/__init__.py
@@ -237,10 +237,16 @@ _T = TypeVar("_T", bound="IntOrTypeEnum")
 
 
 class EnumFlags(enum.IntFlag):
+    def __new__(cls, value, priority=0):
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        obj.priority = priority
+        return obj
+
     ZONE_SUPPORT = enum.auto()
     SEND_ONLY = enum.auto()
-    POLL_REQUIRED = enum.auto()
-    FULL_UPDATE = enum.auto()
+    POLL_REQUIRED = (enum.auto(), 20)
+    FULL_UPDATE = (enum.auto(), 10)
 
 
 class IntOrTypeEnum(enum.IntEnum):

--- a/src/arcam/fmj/client.py
+++ b/src/arcam/fmj/client.py
@@ -4,6 +4,7 @@ import asyncio
 from asyncio.streams import StreamReader, StreamWriter
 import logging
 from datetime import datetime, timedelta
+from arcam.fmj.priority_lock import PriorityLock
 from contextlib import AsyncExitStack, contextmanager, suppress
 from typing import Union, overload
 from collections.abc import Callable
@@ -40,7 +41,7 @@ class ClientBase:
         self._writer: StreamWriter | None = None
         self._task = None
         self._listen: set[Callable] = set()
-        self._request_lock = asyncio.Lock()
+        self._request_lock = PriorityLock()
         self._timestamp = datetime.now()
 
     @contextmanager
@@ -109,14 +110,14 @@ class ClientBase:
         return self._writer is not None
 
     @overload
-    async def request_raw(self, request: CommandPacket) -> ResponsePacket: ...
+    async def request_raw(self, request: CommandPacket, priority: int = 0) -> ResponsePacket: ...
 
     @overload
-    async def request_raw(self, request: AmxDuetRequest) -> AmxDuetResponse: ...
+    async def request_raw(self, request: AmxDuetRequest, priority: int = 0) -> AmxDuetResponse: ...
 
     @async_retry(2, asyncio.TimeoutError)
     async def request_raw(
-        self, request: CommandPacket | AmxDuetRequest
+        self, request: CommandPacket | AmxDuetRequest, priority: int = 0
     ) -> ResponsePacket | AmxDuetResponse:
         if not self._writer:
             raise NotConnectedException()
@@ -129,7 +130,7 @@ class ClientBase:
                     future.set_result(response)
 
         async with AsyncExitStack() as stack:
-            await stack.enter_async_context(self._request_lock)
+            await stack.enter_async_context(self._request_lock(priority))
             async with asyncio.timeout(_REQUEST_TIMEOUT.total_seconds()):
                 with self.listen(listen):
                     _LOGGER.debug("Requesting %s", request)
@@ -141,7 +142,7 @@ class ClientBase:
                     await stack.aclose()
                     return await future
                     
-    async def send(self, zn: int, cc: CommandCodes, data: bytes) -> None:
+    async def send(self, zn: int, cc: CommandCodes, data: bytes, priority: int = 0) -> None:
         if not self._writer:
             raise NotConnectedException()
 
@@ -150,11 +151,11 @@ class ClientBase:
 
         writer = self._writer
         request = CommandPacket(zn, cc, data)
-        async with self._request_lock:
+        async with self._request_lock(priority):
             await write_packet(writer, request)
             await asyncio.sleep(_REQUEST_THROTTLE)
 
-    async def request(self, zn: int, cc: CommandCodes, data: bytes):
+    async def request(self, zn: int, cc: CommandCodes, data: bytes, priority: int = 0):
         if not self._writer:
             raise NotConnectedException()
 
@@ -162,10 +163,10 @@ class ClientBase:
             raise UnsupportedZone()
 
         if cc.flags & EnumFlags.SEND_ONLY:
-            await self.send(zn, cc, data)
+            await self.send(zn, cc, data, priority)
             return
 
-        response = await self.request_raw(CommandPacket(zn, cc, data))
+        response = await self.request_raw(CommandPacket(zn, cc, data), priority)
 
         if response.ac == AnswerCodes.STATUS_UPDATE:
             return response.data

--- a/src/arcam/fmj/priority_lock.py
+++ b/src/arcam/fmj/priority_lock.py
@@ -1,0 +1,39 @@
+"""Async priority lock: when multiple coroutines are waiting, the highest-priority (lowest number) waiter wins."""
+
+import asyncio
+import heapq
+from contextlib import asynccontextmanager
+
+
+class PriorityLock:
+    def __init__(self):
+        self._locked = False
+        self._heap: list[tuple[int, int, asyncio.Future]] = []
+        self._counter = 0  # tiebreaker for equal priorities (FIFO)
+
+    @asynccontextmanager
+    async def __call__(self, priority: int = 0):
+        await self._acquire(priority)
+        try:
+            yield
+        finally:
+            self._release()
+
+    async def _acquire(self, priority: int) -> None:
+        if not self._locked and not self._heap:
+            self._locked = True
+            return
+
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        entry = (priority, self._counter, future)
+        self._counter += 1
+        heapq.heappush(self._heap, entry)
+        await future
+
+    def _release(self) -> None:
+        while self._heap:
+            _, _, future = heapq.heappop(self._heap)
+            if not future.cancelled():
+                future.set_result(None)
+                return
+        self._locked = False

--- a/src/arcam/fmj/priority_lock.py
+++ b/src/arcam/fmj/priority_lock.py
@@ -13,22 +13,24 @@ class PriorityLock:
 
     @asynccontextmanager
     async def __call__(self, priority: int = 0):
-        await self._acquire(priority)
+        future = self._acquire(priority)
         try:
+            if future:
+                await future
             yield
         finally:
             self._release()
 
-    async def _acquire(self, priority: int) -> None:
+    def _acquire(self, priority: int) -> asyncio.Future | None:
         if not self._locked and not self._heap:
             self._locked = True
-            return
+            return None
 
         future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         entry = (priority, self._counter, future)
         self._counter += 1
         heapq.heappush(self._heap, entry)
-        await future
+        return future
 
     def _release(self) -> None:
         while self._heap:

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -228,11 +228,11 @@ class State:
         if not self._is_command_supported(cc):
             raise UnsupportedCommand(cc=cc, model=self.model)
 
-    async def _request(self, zn: int, cc: CommandCodes, data: bytes) -> bytes:
+    async def _request(self, zn: int, cc: CommandCodes, data: bytes, priority: int = 0) -> bytes:
         """Check command support, then send a request."""
         self._require_command(cc)
         try:
-            return await self._client.request(zn, cc, data)
+            return await self._client.request(zn, cc, data, priority)
         except CommandNotRecognised:
             _LOGGER.debug("Command not recognised, marking %s as unsupported", cc)
             self._unsupported_commands.add(cc)
@@ -751,9 +751,11 @@ class State:
         return status, track
 
     async def update(self, flags: EnumFlags = EnumFlags.FULL_UPDATE) -> None:
+        priority = flags.priority
+
         async def _update(cc: CommandCodes):
             try:
-                data = await self._request(self._zn, cc, bytes([0xF0]))
+                data = await self._request(self._zn, cc, bytes([0xF0]), priority)
                 self._state[cc] = data
             except UnsupportedZone:
                 _LOGGER.debug("Unsupported zone %s for %s", self._zn, cc)
@@ -773,7 +775,7 @@ class State:
             for preset in range(1, 51):
                 try:
                     data = await self._request(
-                        self._zn, CommandCodes.PRESET_DETAIL, bytes([preset])
+                        self._zn, CommandCodes.PRESET_DETAIL, bytes([preset]), priority
                     )
                     if data != b"\x00":
                         presets[preset] = PresetDetail.from_bytes(data)
@@ -797,7 +799,7 @@ class State:
                     continue
                 try:
                     data = await self._request(
-                        self._zn, CommandCodes.NOW_PLAYING_INFO, bytes([field.metadata["request"]])
+                        self._zn, CommandCodes.NOW_PLAYING_INFO, bytes([field.metadata["request"]]), priority
                     )
                     kwargs[field.name] = field.metadata["converter"](data)
                 except CommandNotRecognised:
@@ -822,7 +824,7 @@ class State:
 
         async def _update_amxduet() -> None:
             try:
-                data = await self._client.request_raw(AmxDuetRequest())
+                data = await self._client.request_raw(AmxDuetRequest(), priority)
                 self._amxduet = data
 
                 if data.device_model in APIVERSION_450_SERIES:

--- a/tests/test_priority_lock.py
+++ b/tests/test_priority_lock.py
@@ -1,0 +1,246 @@
+import asyncio
+
+import pytest
+
+from arcam.fmj.priority_lock import PriorityLock
+
+
+async def test_basic_acquire_release():
+    lock = PriorityLock()
+    async with lock(0):
+        pass
+
+
+async def test_mutual_exclusion():
+    lock = PriorityLock()
+    counter = 0
+
+    async def bump():
+        nonlocal counter
+        async with lock(0):
+            tmp = counter
+            await asyncio.sleep(0)
+            counter = tmp + 1
+
+    await asyncio.gather(bump(), bump(), bump())
+    assert counter == 3
+
+
+async def test_higher_priority_wins():
+    """When multiple waiters queue up, lower numeric priority acquires first."""
+    lock = PriorityLock()
+    order = []
+
+    async def worker(name, priority, ready: asyncio.Event):
+        ready.set()
+        async with lock(priority):
+            order.append(name)
+
+    # Hold the lock so workers queue up.
+    async with lock(0):
+        events = []
+        for name, pri in [("low", 10), ("high", 1), ("mid", 5)]:
+            ev = asyncio.Event()
+            events.append(ev)
+            asyncio.create_task(worker(name, pri, ev))
+        # Wait until all workers are queued.
+        for ev in events:
+            await ev.wait()
+        # One more yield to ensure they're all blocked on acquire.
+        await asyncio.sleep(0)
+
+    # Let all queued tasks finish.
+    await asyncio.sleep(0.01)
+    assert order == ["high", "mid", "low"]
+
+
+async def test_fifo_within_same_priority():
+    """Equal-priority waiters are served in FIFO order."""
+    lock = PriorityLock()
+    order = []
+
+    async def worker(name, ready: asyncio.Event):
+        ready.set()
+        async with lock(5):
+            order.append(name)
+
+    async with lock(0):
+        events = []
+        for name in ["first", "second", "third"]:
+            ev = asyncio.Event()
+            events.append(ev)
+            asyncio.create_task(worker(name, ev))
+        for ev in events:
+            await ev.wait()
+        await asyncio.sleep(0)
+
+    await asyncio.sleep(0.01)
+    assert order == ["first", "second", "third"]
+
+
+async def test_default_priority():
+    """Priority defaults to 0."""
+    lock = PriorityLock()
+    async with lock():
+        pass
+
+
+async def test_reentrant_deadlock():
+    """Re-entering the lock from the same task should deadlock (not silently succeed)."""
+    lock = PriorityLock()
+
+    async def reenter():
+        async with lock(0):
+            async with lock(0):
+                pass  # pragma: no cover
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with asyncio.timeout(0.05):
+            await reenter()
+
+
+async def test_exception_in_body_releases_lock():
+    lock = PriorityLock()
+
+    with pytest.raises(RuntimeError):
+        async with lock(0):
+            raise RuntimeError("boom")
+
+    # Lock should be available again.
+    async with lock(0):
+        pass
+
+
+async def test_cancel_waiter():
+    """Cancelling a waiting task doesn't break the lock for others."""
+    lock = PriorityLock()
+    acquired = False
+
+    async def cancelled_worker():
+        async with lock(5):
+            pass  # pragma: no cover
+
+    async def good_worker():
+        nonlocal acquired
+        async with lock(5):
+            acquired = True
+
+    async with lock(0):
+        task_cancel = asyncio.create_task(cancelled_worker())
+        task_good = asyncio.create_task(good_worker())
+        await asyncio.sleep(0)
+        task_cancel.cancel()
+
+    # The good worker should still get through.
+    await asyncio.sleep(0.01)
+    assert acquired
+    assert task_good.done()
+
+
+async def test_many_priorities():
+    """Larger spread of priorities all sort correctly."""
+    lock = PriorityLock()
+    order = []
+    n = 20
+
+    async def worker(i, ready: asyncio.Event):
+        ready.set()
+        async with lock(i):
+            order.append(i)
+
+    # Queue up workers with priorities 19, 18, ..., 0 (reverse order).
+    async with lock(-1):
+        events = []
+        for i in reversed(range(n)):
+            ev = asyncio.Event()
+            events.append(ev)
+            asyncio.create_task(worker(i, ev))
+        for ev in events:
+            await ev.wait()
+        await asyncio.sleep(0)
+
+    await asyncio.sleep(0.05)
+    assert order == list(range(n))
+
+
+async def test_negative_priorities():
+    lock = PriorityLock()
+    order = []
+
+    async def worker(name, priority, ready: asyncio.Event):
+        ready.set()
+        async with lock(priority):
+            order.append(name)
+
+    async with lock(0):
+        events = []
+        for name, pri in [("normal", 0), ("urgent", -10), ("low", 10)]:
+            ev = asyncio.Event()
+            events.append(ev)
+            asyncio.create_task(worker(name, pri, ev))
+        for ev in events:
+            await ev.wait()
+        await asyncio.sleep(0)
+
+    await asyncio.sleep(0.01)
+    assert order == ["urgent", "normal", "low"]
+
+
+async def test_stress_concurrent():
+    """Many tasks contending on the lock; verify mutual exclusion holds."""
+    lock = PriorityLock()
+    n_tasks = 200
+    inside = 0
+    max_inside = 0
+    completed = 0
+
+    async def worker(priority):
+        nonlocal inside, max_inside, completed
+        async with lock(priority):
+            inside += 1
+            max_inside = max(max_inside, inside)
+            # Yield to give other tasks a chance to violate exclusion.
+            await asyncio.sleep(0)
+            inside -= 1
+            completed += 1
+
+    tasks = [
+        asyncio.create_task(worker(i % 10)) for i in range(n_tasks)
+    ]
+    await asyncio.gather(*tasks)
+    assert max_inside == 1
+    assert completed == n_tasks
+
+
+async def test_stress_priority_ordering():
+    """Under contention, verify priority ordering is respected across waves."""
+    lock = PriorityLock()
+    order = []
+    n_waves = 5
+    per_wave = 10
+
+    async def worker(wave, priority, ready: asyncio.Event):
+        ready.set()
+        async with lock(priority):
+            order.append((wave, priority))
+            # Simulate work so next wave queues up.
+            await asyncio.sleep(0.001)
+
+    for wave in range(n_waves):
+        async with lock(-1):
+            events = []
+            for pri in reversed(range(per_wave)):
+                ev = asyncio.Event()
+                events.append(ev)
+                asyncio.create_task(worker(wave, pri, ev))
+            for ev in events:
+                await ev.wait()
+            await asyncio.sleep(0)
+
+        # Let wave drain.
+        await asyncio.sleep(0.05)
+
+        wave_order = [pri for w, pri in order if w == wave]
+        assert wave_order == list(range(per_wave)), f"Wave {wave}: {wave_order}"
+
+    assert len(order) == n_waves * per_wave

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -74,7 +74,7 @@ async def test_set_source(zn, api_model, source, ir, data):
 
     await state.set_source(source)
 
-    client.request.assert_called_with(zn, command_code, data)
+    client.request.assert_called_with(zn, command_code, data, 0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -82,13 +82,12 @@ async def test_power_on(zn, api_model):
     client.request.return_value = response
     await state.set_power(True)
     if api_model in POWER_WRITE_SUPPORTED:
-        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x01]))
+        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x01]), 0)
     else:
         # zn, api_model, power
         code = PARAMS_TO_RC5COMMAND[zn, api_model, True]
         client.request.assert_called_with(
-            zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code
-        )
+            zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code, 0)
 
 
 @pytest.mark.parametrize("zn, api_model", TEST_PARAMS)
@@ -99,7 +98,7 @@ async def test_power_off(zn, api_model):
     assert state.get_power() is None
     await state.set_power(False)
     if api_model in POWER_WRITE_SUPPORTED:
-        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x00]))
+        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x00]), 0)
     else:
         # zn, api_model, power
         code = PARAMS_TO_RC5COMMAND[zn, api_model, False]
@@ -192,7 +191,7 @@ async def test_set_mute_write_supported():
     client = MagicMock(spec=Client)
     state = State(client, 1, ApiModel.APISA_SERIES)
     await state.set_mute(True)
-    client.request.assert_called_with(1, CommandCodes.MUTE, bytes([0x00]))
+    client.request.assert_called_with(1, CommandCodes.MUTE, bytes([0x00]), 0)
 
 
 async def test_set_mute_rc5():
@@ -201,8 +200,7 @@ async def test_set_mute_rc5():
     state = State(client, 1, ApiModel.API450_SERIES)
     await state.set_mute(True)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([16, 119])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([16, 119]), 0)
 
 
 # --- Decode mode ---
@@ -272,8 +270,7 @@ async def test_save_settings_default_pin():
     await state.save_settings()
     client.request.assert_called_with(
         1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
-        bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]),
-    )
+        bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]), 0)
 
 
 async def test_restore_settings_default_pin():
@@ -282,8 +279,7 @@ async def test_restore_settings_default_pin():
     await state.restore_settings()
     client.request.assert_called_with(
         1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
-        bytes([SaveRestoreSubCommand.RESTORE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]),
-    )
+        bytes([SaveRestoreSubCommand.RESTORE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]), 0)
 
 
 async def test_save_settings_custom_pin():
@@ -292,8 +288,7 @@ async def test_save_settings_custom_pin():
     await state.save_settings(pin=(9, 8, 7, 6))
     client.request.assert_called_with(
         1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
-        bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x09, 0x08, 0x07, 0x06]),
-    )
+        bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x09, 0x08, 0x07, 0x06]), 0)
 
 
 # --- Headphones (0x02) ---
@@ -337,8 +332,7 @@ async def test_set_display_info_type():
     state = State(client, 1)
     await state.set_display_info_type(0x03)
     client.request.assert_called_with(
-        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0x03])
-    )
+        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0x03]), 0)
 
 
 async def test_set_display_info_type_cycle():
@@ -346,8 +340,7 @@ async def test_set_display_info_type_cycle():
     state = State(client, 1)
     await state.set_display_info_type(0xE0)
     client.request.assert_called_with(
-        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0xE0])
-    )
+        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0xE0]), 0)
 
 
 # --- Lipsync Delay (0x40) ---
@@ -380,7 +373,7 @@ async def test_set_lipsync_delay(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_lipsync_delay(value)
-    client.request.assert_called_with(1, CommandCodes.LIPSYNC_DELAY, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.LIPSYNC_DELAY, bytes([expected_byte]), 0)
 
 
 # --- Subwoofer Trim (0x3F) ---
@@ -418,7 +411,7 @@ async def test_set_subwoofer_trim(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_subwoofer_trim(value)
-    client.request.assert_called_with(1, CommandCodes.SUBWOOFER_TRIM, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.SUBWOOFER_TRIM, bytes([expected_byte]), 0)
 
 
 # --- Sub Stereo Trim (0x45) ---
@@ -453,7 +446,7 @@ async def test_set_sub_stereo_trim(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_sub_stereo_trim(value)
-    client.request.assert_called_with(1, CommandCodes.SUB_STEREO_TRIM, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.SUB_STEREO_TRIM, bytes([expected_byte]), 0)
 
 
 # --- Treble Equalization (0x35) ---
@@ -488,7 +481,7 @@ async def test_set_treble_equalization(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_treble_equalization(value)
-    client.request.assert_called_with(1, CommandCodes.TREBLE_EQUALIZATION, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.TREBLE_EQUALIZATION, bytes([expected_byte]), 0)
 
 
 # --- Bass Equalization (0x36) ---
@@ -525,7 +518,7 @@ async def test_set_bass_equalization(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_bass_equalization(value)
-    client.request.assert_called_with(1, CommandCodes.BASS_EQUALIZATION, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.BASS_EQUALIZATION, bytes([expected_byte]), 0)
 
 
 # --- Room EQ (0x37) ---
@@ -560,7 +553,7 @@ async def test_set_room_equalization(mode, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_room_equalization(mode)
-    client.request.assert_called_with(1, CommandCodes.ROOM_EQUALIZATION, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.ROOM_EQUALIZATION, bytes([expected_byte]), 0)
 
 
 # --- Room EQ Names (0x34) ---
@@ -608,7 +601,7 @@ async def test_set_dolby_audio():
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_dolby_audio(DolbyAudioMode.NIGHT)
-    client.request.assert_called_with(1, CommandCodes.DOLBY_AUDIO, bytes([0x03]))
+    client.request.assert_called_with(1, CommandCodes.DOLBY_AUDIO, bytes([0x03]), 0)
 
 
 # --- Balance (0x3B) ---
@@ -646,7 +639,7 @@ async def test_set_balance(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_balance(value)
-    client.request.assert_called_with(1, CommandCodes.BALANCE, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.BALANCE, bytes([expected_byte]), 0)
 
 
 # --- Compression (0x41) ---
@@ -674,7 +667,7 @@ async def test_set_compression():
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_compression(CompressionMode.HIGH)
-    client.request.assert_called_with(1, CommandCodes.COMPRESSION, bytes([0x02]))
+    client.request.assert_called_with(1, CommandCodes.COMPRESSION, bytes([0x02]), 0)
 
 
 # --- IMAX Enhanced (0x0C) ---
@@ -709,8 +702,7 @@ async def test_set_imax_enhanced(mode, expected_byte):
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.set_imax_enhanced(mode)
     client.request.assert_called_with(
-        1, CommandCodes.IMAX_ENHANCED, bytes([expected_byte])
-    )
+        1, CommandCodes.IMAX_ENHANCED, bytes([expected_byte]), 0)
 
 
 # --- Network Playback Status (0x1C) ---
@@ -799,8 +791,7 @@ async def test_send_playback():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_playback(RC5CodePlayback.PLAY)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x35])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x35]), 0)
 
 
 async def test_send_navigation():
@@ -808,8 +799,7 @@ async def test_send_navigation():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_navigation(RC5CodeNavigation.UP)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x56])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x56]), 0)
 
 
 async def test_send_toggle():
@@ -817,8 +807,7 @@ async def test_send_toggle():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_toggle(RC5CodeToggle.RADIO)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x5B])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x5B]), 0)
 
 
 async def test_send_playback_unsupported_model():
@@ -871,8 +860,7 @@ async def test_inc_bass_equalization():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.inc_bass_equalization()
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x2C])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x2C]), 0)
 
 
 async def test_dec_bass_equalization():
@@ -880,8 +868,7 @@ async def test_dec_bass_equalization():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.dec_bass_equalization()
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x38])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x38]), 0)
 
 
 async def test_inc_bass_equalization_unsupported():
@@ -907,8 +894,7 @@ async def test_set_display_brightness():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.set_display_brightness(DisplayBrightness.L2)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x23])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x23]), 0)
 
 
 async def test_set_hdmi_output():
@@ -916,8 +902,7 @@ async def test_set_hdmi_output():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.set_hdmi_output(HdmiOutput.OUT_1_2)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4B])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4B]), 0)
 
 
 async def test_set_hdmi_output_unsupported():
@@ -947,12 +932,10 @@ async def test_set_direct_mode():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.set_direct_mode(True)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4E])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4E]), 0)
     await state.set_direct_mode(False)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4F])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4F]), 0)
 
 
 # --- Command support checking ---


### PR DESCRIPTION
This is more work that comes out of my polling proposal, and like the last one, is also good ground work regardless of how or where polling is actually implemented.

This takes the serialized comms we already have, and adds **priority queuing** for messages: when we're ready to send a message, we choose the _highest-priority_ message that's waiting. This means, for example, that we could have dozens of update/polling messages queued, and if the user issues a command, that command will wait at most for the currently-active message to complete, and will then be sent before any of the pre-existing queued update messages. In my testing, the command handler seems to run at 12.5Hz so that means that latency for user commands should be no more than 80ms even during an active update.

I've added priorities to the update flags, and update() automatically pulls and uses that priority. Default/normal priority is 0, and user commands get that. A full start-up update gets 10 (so user commands beat it) and polling updates get 20 (so they don't interfere with either user commands or the start-up update - the latter useful in the case that the start-up update is still running when polling starts.)