### PR TITLE
feat: prioritize comms, but with a writer task

### DIFF
--- a/src/arcam/fmj/__init__.py
+++ b/src/arcam/fmj/__init__.py
@@ -272,10 +272,16 @@ _T = TypeVar("_T", bound="IntOrTypeEnum")
 
 
 class EnumFlags(enum.IntFlag):
+    def __new__(cls, value, priority=0):
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        obj.priority = priority
+        return obj
+
     ZONE_SUPPORT = enum.auto()
     SEND_ONLY = enum.auto()
-    POLL_REQUIRED = enum.auto()
-    FULL_UPDATE = enum.auto()
+    POLL_REQUIRED = (enum.auto(), 20)
+    FULL_UPDATE = (enum.auto(), 10)
 
 
 class IntOrTypeEnum(enum.IntEnum):

--- a/src/arcam/fmj/client.py
+++ b/src/arcam/fmj/client.py
@@ -1,11 +1,11 @@
 """Client code"""
 
 import asyncio
-from asyncio.streams import StreamReader, StreamWriter
+from asyncio.streams import StreamReader
 import logging
 from datetime import datetime, timedelta
-from contextlib import AsyncExitStack, contextmanager, suppress
-from typing import Union, overload
+from contextlib import contextmanager
+from typing import overload
 from collections.abc import Callable
 
 from . import (
@@ -37,11 +37,14 @@ _HEARTBEAT_TIMEOUT = _HEARTBEAT_INTERVAL + _HEARTBEAT_INTERVAL
 class ClientBase:
     def __init__(self) -> None:
         self._reader: StreamReader | None = None
-        self._writer: StreamWriter | None = None
         self._task = None
+        self._write_task: asyncio.Task | None = None
         self._listen: set[Callable] = set()
-        self._request_lock = asyncio.Lock()
         self._timestamp = datetime.now()
+        self._write_queue: asyncio.PriorityQueue[
+            tuple[int, int, CommandPacket | AmxDuetRequest, asyncio.Future | None]
+        ] = asyncio.PriorityQueue()
+        self._write_seq = 0
 
     @contextmanager
     def listen(self, listener: Callable):
@@ -50,6 +53,39 @@ class ClientBase:
             yield self
         finally:
             self._listen.remove(listener)
+
+    async def _process_write_queue(self, writer):
+        try:
+            while True:
+                _priority, _seq, request, result = await self._write_queue.get()
+
+                if result is None:
+                    _LOGGER.debug("Sending %s", request)
+                    await write_packet(writer, request)
+                    self._timestamp = datetime.now()
+                    await asyncio.sleep(_REQUEST_THROTTLE)
+                    continue
+
+                if result.cancelled():
+                    continue
+
+                def listen(packet: ResponsePacket | AmxDuetResponse):
+                    if packet.respons_to(request):
+                        if not (result.cancelled() or result.done()):
+                            result.set_result(packet)
+
+                try:
+                    async with asyncio.timeout(_REQUEST_TIMEOUT.total_seconds()):
+                        with self.listen(listen):
+                            _LOGGER.debug("Requesting %s", request)
+                            await write_packet(writer, request)
+                            self._timestamp = datetime.now()
+                            await asyncio.shield(result)
+                except Exception as exc:
+                    if not result.done():
+                        result.set_exception(exc)
+        finally:
+            writer.close()
 
     async def _process_heartbeat(self):
         while True:
@@ -86,7 +122,6 @@ class ClientBase:
             self._reader = None
 
     async def process(self) -> None:
-        assert self._writer, "Writer missing"
         assert self._reader, "Reader missing"
 
         _process_heartbeat = asyncio.create_task(self._process_heartbeat())
@@ -98,7 +133,6 @@ class ClientBase:
                 await _process_heartbeat
             except asyncio.CancelledError:
                 pass
-            self._writer.close()
 
     @property
     def connected(self) -> bool:
@@ -106,66 +140,42 @@ class ClientBase:
 
     @property
     def started(self) -> bool:
-        return self._writer is not None
+        return self._write_task is not None
 
     @overload
-    async def request_raw(self, request: CommandPacket) -> ResponsePacket: ...
+    async def request_raw(self, request: CommandPacket, priority: int = 0) -> ResponsePacket: ...
 
     @overload
-    async def request_raw(self, request: AmxDuetRequest) -> AmxDuetResponse: ...
+    async def request_raw(self, request: AmxDuetRequest, priority: int = 0) -> AmxDuetResponse: ...
 
     @async_retry(2, asyncio.TimeoutError)
     async def request_raw(
-        self, request: CommandPacket | AmxDuetRequest
+        self, request: CommandPacket | AmxDuetRequest, priority: int = 0
     ) -> ResponsePacket | AmxDuetResponse:
-        if not self._writer:
-            raise NotConnectedException()
-        writer = self._writer  # keep copy around if stopped by another task
         future: asyncio.Future[ResponsePacket | AmxDuetResponse] = asyncio.Future()
+        self._write_seq += 1
+        self._write_queue.put_nowait((priority, self._write_seq, request, future))
+        return await future
 
-        def listen(response: ResponsePacket | AmxDuetResponse):
-            if response.respons_to(request):
-                if not (future.cancelled() or future.done()):
-                    future.set_result(response)
-
-        async with AsyncExitStack() as stack:
-            await stack.enter_async_context(self._request_lock)
-            async with asyncio.timeout(_REQUEST_TIMEOUT.total_seconds()):
-                with self.listen(listen):
-                    _LOGGER.debug("Requesting %s", request)
-                    await write_packet(writer, request)
-                    self._timestamp = datetime.now()
-                    with suppress(TimeoutError):
-                        async with asyncio.timeout(_REQUEST_THROTTLE):
-                            return await asyncio.shield(future)
-                    await stack.aclose()
-                    return await future
-                    
-    async def send(self, zn: int, cc: CommandCodes, data: bytes) -> None:
-        if not self._writer:
-            raise NotConnectedException()
-
+    async def send(self, zn: int, cc: CommandCodes, data: bytes, priority: int = 0) -> None:
         if not (cc.flags & EnumFlags.ZONE_SUPPORT) and zn != 1:
             raise UnsupportedZone()
 
-        writer = self._writer
-        request = CommandPacket(zn, cc, data)
-        async with self._request_lock:
-            await write_packet(writer, request)
-            await asyncio.sleep(_REQUEST_THROTTLE)
+        self._write_seq += 1
+        self._write_queue.put_nowait((priority, self._write_seq, CommandPacket(zn, cc, data), None))
 
-    async def request(self, zn: int, cc: CommandCodes, data: bytes):
-        if not self._writer:
+    async def request(self, zn: int, cc: CommandCodes, data: bytes, priority: int = 0):
+        if not self._write_task:
             raise NotConnectedException()
 
         if not (cc.flags & EnumFlags.ZONE_SUPPORT) and zn != 1:
             raise UnsupportedZone()
 
         if cc.flags & EnumFlags.SEND_ONLY:
-            await self.send(zn, cc, data)
+            await self.send(zn, cc, data, priority)
             return
 
-        response = await self.request_raw(CommandPacket(zn, cc, data))
+        response = await self.request_raw(CommandPacket(zn, cc, data), priority)
 
         if response.ac == AnswerCodes.STATUS_UPDATE:
             return response.data
@@ -188,12 +198,12 @@ class Client(ClientBase):
         return self._port
 
     async def start(self) -> None:
-        if self._writer:
+        if self._write_task:
             raise ArcamException("Already started")
 
         _LOGGER.debug("Connecting to %s:%d", self._host, self._port)
         try:
-            self._reader, self._writer = await asyncio.open_connection(
+            self._reader, writer = await asyncio.open_connection(
                 self._host, self._port
             )
         except ConnectionError as exception:
@@ -201,18 +211,17 @@ class Client(ClientBase):
         except OSError as exception:
             raise ConnectionFailed() from exception
         _LOGGER.info("Connected to %s:%d", self._host, self._port)
+        self._write_task = asyncio.create_task(self._process_write_queue(writer))
 
     async def stop(self) -> None:
-        if self._writer:
+        if self._write_task:
+            self._write_task.cancel()
             try:
-                _LOGGER.info("Disconnecting from %s:%d", self._host, self._port)
-                self._writer.close()
-                await self._writer.wait_closed()
-            except (ConnectionError, OSError):
+                await self._write_task
+            except asyncio.CancelledError:
                 pass
-            finally:
-                self._writer = None
-                self._reader = None
+            self._write_task = None
+        self._reader = None
 
 
 class ClientContext:

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -228,11 +228,11 @@ class State:
         if not self._is_command_supported(cc):
             raise UnsupportedCommand(cc=cc, model=self.model)
 
-    async def _request(self, zn: int, cc: CommandCodes, data: bytes) -> bytes:
+    async def _request(self, zn: int, cc: CommandCodes, data: bytes, priority: int = 0) -> bytes:
         """Check command support, then send a request."""
         self._require_command(cc)
         try:
-            return await self._client.request(zn, cc, data)
+            return await self._client.request(zn, cc, data, priority)
         except CommandNotRecognised:
             _LOGGER.debug("Command not recognised, marking %s as unsupported", cc)
             self._unsupported_commands.add(cc)
@@ -751,9 +751,11 @@ class State:
         return status, track
 
     async def update(self, flags: EnumFlags = EnumFlags.FULL_UPDATE) -> None:
+        priority = flags.priority
+
         async def _update(cc: CommandCodes):
             try:
-                data = await self._request(self._zn, cc, bytes([0xF0]))
+                data = await self._request(self._zn, cc, bytes([0xF0]), priority)
                 self._state[cc] = data
             except UnsupportedZone:
                 _LOGGER.debug("Unsupported zone %s for %s", self._zn, cc)
@@ -773,7 +775,7 @@ class State:
             for preset in range(1, 51):
                 try:
                     data = await self._request(
-                        self._zn, CommandCodes.PRESET_DETAIL, bytes([preset])
+                        self._zn, CommandCodes.PRESET_DETAIL, bytes([preset]), priority
                     )
                     if data != b"\x00":
                         presets[preset] = PresetDetail.from_bytes(data)
@@ -797,7 +799,7 @@ class State:
                     continue
                 try:
                     data = await self._request(
-                        self._zn, CommandCodes.NOW_PLAYING_INFO, bytes([field.metadata["request"]])
+                        self._zn, CommandCodes.NOW_PLAYING_INFO, bytes([field.metadata["request"]]), priority
                     )
                     kwargs[field.name] = field.metadata["converter"](data)
                 except CommandNotRecognised:
@@ -822,7 +824,7 @@ class State:
 
         async def _update_amxduet() -> None:
             try:
-                data = await self._client.request_raw(AmxDuetRequest())
+                data = await self._client.request_raw(AmxDuetRequest(), priority)
                 self._amxduet = data
 
                 if data.device_model in APIVERSION_450_SERIES:

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -74,7 +74,7 @@ async def test_set_source(zn, api_model, source, ir, data):
 
     await state.set_source(source)
 
-    client.request.assert_called_with(zn, command_code, data)
+    client.request.assert_called_with(zn, command_code, data, 0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -82,13 +82,12 @@ async def test_power_on(zn, api_model):
     client.request.return_value = response
     await state.set_power(True)
     if api_model in POWER_WRITE_SUPPORTED:
-        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x01]))
+        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x01]), 0)
     else:
         # zn, api_model, power
         code = PARAMS_TO_RC5COMMAND[zn, api_model, True]
         client.request.assert_called_with(
-            zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code
-        )
+            zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code, 0)
 
 
 @pytest.mark.parametrize("zn, api_model", TEST_PARAMS)
@@ -99,7 +98,7 @@ async def test_power_off(zn, api_model):
     assert state.get_power() is None
     await state.set_power(False)
     if api_model in POWER_WRITE_SUPPORTED:
-        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x00]))
+        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x00]), 0)
     else:
         # zn, api_model, power
         code = PARAMS_TO_RC5COMMAND[zn, api_model, False]
@@ -192,7 +191,7 @@ async def test_set_mute_write_supported():
     client = MagicMock(spec=Client)
     state = State(client, 1, ApiModel.APISA_SERIES)
     await state.set_mute(True)
-    client.request.assert_called_with(1, CommandCodes.MUTE, bytes([0x00]))
+    client.request.assert_called_with(1, CommandCodes.MUTE, bytes([0x00]), 0)
 
 
 async def test_set_mute_rc5():
@@ -201,8 +200,7 @@ async def test_set_mute_rc5():
     state = State(client, 1, ApiModel.API450_SERIES)
     await state.set_mute(True)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([16, 119])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([16, 119]), 0)
 
 
 # --- Decode mode ---
@@ -272,8 +270,7 @@ async def test_save_settings_default_pin():
     await state.save_settings()
     client.request.assert_called_with(
         1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
-        bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]),
-    )
+        bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]), 0)
 
 
 async def test_restore_settings_default_pin():
@@ -282,8 +279,7 @@ async def test_restore_settings_default_pin():
     await state.restore_settings()
     client.request.assert_called_with(
         1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
-        bytes([SaveRestoreSubCommand.RESTORE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]),
-    )
+        bytes([SaveRestoreSubCommand.RESTORE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]), 0)
 
 
 async def test_save_settings_custom_pin():
@@ -292,8 +288,7 @@ async def test_save_settings_custom_pin():
     await state.save_settings(pin=(9, 8, 7, 6))
     client.request.assert_called_with(
         1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
-        bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x09, 0x08, 0x07, 0x06]),
-    )
+        bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x09, 0x08, 0x07, 0x06]), 0)
 
 
 # --- Headphones (0x02) ---
@@ -337,8 +332,7 @@ async def test_set_display_info_type():
     state = State(client, 1)
     await state.set_display_info_type(0x03)
     client.request.assert_called_with(
-        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0x03])
-    )
+        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0x03]), 0)
 
 
 async def test_set_display_info_type_cycle():
@@ -346,8 +340,7 @@ async def test_set_display_info_type_cycle():
     state = State(client, 1)
     await state.set_display_info_type(0xE0)
     client.request.assert_called_with(
-        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0xE0])
-    )
+        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0xE0]), 0)
 
 
 # --- Lipsync Delay (0x40) ---
@@ -380,7 +373,7 @@ async def test_set_lipsync_delay(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_lipsync_delay(value)
-    client.request.assert_called_with(1, CommandCodes.LIPSYNC_DELAY, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.LIPSYNC_DELAY, bytes([expected_byte]), 0)
 
 
 # --- Subwoofer Trim (0x3F) ---
@@ -418,7 +411,7 @@ async def test_set_subwoofer_trim(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_subwoofer_trim(value)
-    client.request.assert_called_with(1, CommandCodes.SUBWOOFER_TRIM, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.SUBWOOFER_TRIM, bytes([expected_byte]), 0)
 
 
 # --- Sub Stereo Trim (0x45) ---
@@ -453,7 +446,7 @@ async def test_set_sub_stereo_trim(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_sub_stereo_trim(value)
-    client.request.assert_called_with(1, CommandCodes.SUB_STEREO_TRIM, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.SUB_STEREO_TRIM, bytes([expected_byte]), 0)
 
 
 # --- Treble Equalization (0x35) ---
@@ -488,7 +481,7 @@ async def test_set_treble_equalization(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_treble_equalization(value)
-    client.request.assert_called_with(1, CommandCodes.TREBLE_EQUALIZATION, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.TREBLE_EQUALIZATION, bytes([expected_byte]), 0)
 
 
 # --- Bass Equalization (0x36) ---
@@ -525,7 +518,7 @@ async def test_set_bass_equalization(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_bass_equalization(value)
-    client.request.assert_called_with(1, CommandCodes.BASS_EQUALIZATION, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.BASS_EQUALIZATION, bytes([expected_byte]), 0)
 
 
 # --- Room EQ (0x37) ---
@@ -560,7 +553,7 @@ async def test_set_room_equalization(mode, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_room_equalization(mode)
-    client.request.assert_called_with(1, CommandCodes.ROOM_EQUALIZATION, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.ROOM_EQUALIZATION, bytes([expected_byte]), 0)
 
 
 # --- Room EQ Names (0x34) ---
@@ -608,7 +601,7 @@ async def test_set_dolby_audio():
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_dolby_audio(DolbyAudioMode.NIGHT)
-    client.request.assert_called_with(1, CommandCodes.DOLBY_AUDIO, bytes([0x03]))
+    client.request.assert_called_with(1, CommandCodes.DOLBY_AUDIO, bytes([0x03]), 0)
 
 
 # --- Balance (0x3B) ---
@@ -646,7 +639,7 @@ async def test_set_balance(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_balance(value)
-    client.request.assert_called_with(1, CommandCodes.BALANCE, bytes([expected_byte]))
+    client.request.assert_called_with(1, CommandCodes.BALANCE, bytes([expected_byte]), 0)
 
 
 # --- Compression (0x41) ---
@@ -674,7 +667,7 @@ async def test_set_compression():
     client = MagicMock(spec=Client)
     state = State(client, 1)
     await state.set_compression(CompressionMode.HIGH)
-    client.request.assert_called_with(1, CommandCodes.COMPRESSION, bytes([0x02]))
+    client.request.assert_called_with(1, CommandCodes.COMPRESSION, bytes([0x02]), 0)
 
 
 # --- IMAX Enhanced (0x0C) ---
@@ -709,8 +702,7 @@ async def test_set_imax_enhanced(mode, expected_byte):
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.set_imax_enhanced(mode)
     client.request.assert_called_with(
-        1, CommandCodes.IMAX_ENHANCED, bytes([expected_byte])
-    )
+        1, CommandCodes.IMAX_ENHANCED, bytes([expected_byte]), 0)
 
 
 # --- Network Playback Status (0x1C) ---
@@ -799,8 +791,7 @@ async def test_send_playback():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_playback(RC5CodePlayback.PLAY)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x35])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x35]), 0)
 
 
 async def test_send_navigation():
@@ -808,8 +799,7 @@ async def test_send_navigation():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_navigation(RC5CodeNavigation.UP)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x56])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x56]), 0)
 
 
 async def test_send_toggle():
@@ -817,8 +807,7 @@ async def test_send_toggle():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_toggle(RC5CodeToggle.RADIO)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x5B])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x5B]), 0)
 
 
 async def test_send_playback_unsupported_model():
@@ -871,8 +860,7 @@ async def test_inc_bass_equalization():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.inc_bass_equalization()
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x2C])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x2C]), 0)
 
 
 async def test_dec_bass_equalization():
@@ -880,8 +868,7 @@ async def test_dec_bass_equalization():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.dec_bass_equalization()
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x38])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x38]), 0)
 
 
 async def test_inc_bass_equalization_unsupported():
@@ -907,8 +894,7 @@ async def test_set_display_brightness():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.set_display_brightness(DisplayBrightness.L2)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x23])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x23]), 0)
 
 
 async def test_set_hdmi_output():
@@ -916,8 +902,7 @@ async def test_set_hdmi_output():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.set_hdmi_output(HdmiOutput.OUT_1_2)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4B])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4B]), 0)
 
 
 async def test_set_hdmi_output_unsupported():
@@ -947,12 +932,10 @@ async def test_set_direct_mode():
     state = State(client, 1, ApiModel.APIHDA_SERIES)
     await state.set_direct_mode(True)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4E])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4E]), 0)
     await state.set_direct_mode(False)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4F])
-    )
+        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4F]), 0)
 
 
 # --- Command support checking ---


### PR DESCRIPTION
Per my other comment, here's the task-based approach for comparison, but again I _don't_ recommend it, because:
- I haven't tested it beyond the unit tests
- The full 3s timeout blocks everything if the device doesn't respond