### PR TITLE
fix: use CommandCodes.VIDEO_SELECTION in set_video_selection

### DIFF
--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -591,7 +591,7 @@ class State:
     async def set_video_selection(self, mode: VideoSelection) -> None:
         """Set the video input selection (pre-HDA AVR series)."""
         await self._request(
-            self._zn, VideoSelection.VIDEO_SELECTION, bytes([mode])
+            self._zn, CommandCodes.VIDEO_SELECTION, bytes([mode])
         )
 
     async def set_hdmi_output(self, output: HdmiOutput) -> None:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -29,6 +29,7 @@ from arcam.fmj import (
     ResponsePacket,
     RoomEqMode,
     UnsupportedCommand,
+    VideoSelection,
     POWER_WRITE_SUPPORTED,
     SAVE_RESTORE_CONFIRMATION,
     SaveRestoreSubCommand,
@@ -1076,3 +1077,13 @@ async def test_update_records_command_not_recognised():
     assert CommandCodes.MENU not in state._unsupported_commands
     await state.update()
     assert CommandCodes.MENU in state._unsupported_commands
+
+
+# --- Video Selection (0x0A) ---
+
+
+async def test_set_video_selection():
+    client = MagicMock(spec=Client)
+    state = State(client, 1)
+    await state.set_video_selection(VideoSelection.SAT)
+    client.request.assert_called_with(1, CommandCodes.VIDEO_SELECTION, bytes([0x01]), 0)


### PR DESCRIPTION
## Summary
- `set_video_selection()` used `VideoSelection.VIDEO_SELECTION` as the command code, but `VideoSelection` is a value enum (BD/SAT/AV/etc.) — this raised `AttributeError` on every call
- Fixed to use `CommandCodes.VIDEO_SELECTION`
- Added test verifying the correct command code is sent

## Test plan
- [x] New test `test_set_video_selection` added
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)