### PR TITLE
feat: add fm_scan and dab_scan trigger methods

### DIFF
--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -666,6 +666,16 @@ class State:
             return None
         return value.decode("utf8", errors="replace").rstrip()
 
+    async def fm_scan(self, up: bool = True) -> None:
+        """Trigger an FM frequency scan (up by default, down if up=False)."""
+        await self._client.send(
+            self._zn, CommandCodes.FM_SCAN, bytes([0x01 if up else 0x02])
+        )
+
+    async def dab_scan(self) -> None:
+        """Trigger a DAB station scan."""
+        await self._client.send(self._zn, CommandCodes.DAB_SCAN, bytes([0xF0]))
+
     async def set_tuner_preset(self, preset: int) -> None:
         await self._request(self._zn, CommandCodes.TUNER_PRESET, bytes([preset]))
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1087,3 +1087,30 @@ async def test_set_video_selection():
     state = State(client, 1)
     await state.set_video_selection(VideoSelection.SAT)
     client.request.assert_called_with(1, CommandCodes.VIDEO_SELECTION, bytes([0x01]), 0)
+
+
+# --- FM Scan / DAB Scan (fire-and-forget) ---
+
+
+async def test_fm_scan_up():
+    """fm_scan() defaults to scan-up (0x01)."""
+    client = MagicMock(spec=Client)
+    state = State(client, 1)
+    await state.fm_scan()
+    client.send.assert_called_once_with(1, CommandCodes.FM_SCAN, bytes([0x01]))
+
+
+async def test_fm_scan_down():
+    """fm_scan(up=False) sends scan-down (0x02)."""
+    client = MagicMock(spec=Client)
+    state = State(client, 1)
+    await state.fm_scan(up=False)
+    client.send.assert_called_once_with(1, CommandCodes.FM_SCAN, bytes([0x02]))
+
+
+async def test_dab_scan():
+    """dab_scan should fire-and-forget with the start-scan byte (0xF0)."""
+    client = MagicMock(spec=Client)
+    state = State(client, 1)
+    await state.dab_scan()
+    client.send.assert_called_once_with(1, CommandCodes.DAB_SCAN, bytes([0xF0]))


### PR DESCRIPTION
## Summary
- Add fire-and-forget scan trigger methods:
  - `fm_scan()` — triggers FM frequency scan via `FM_SCAN` (0x23)
  - `dab_scan()` — triggers DAB station scan via `DAB_SCAN` (0x24)
- Uses `client.send` (no response expected) rather than `client.request`

## Test plan
- [x] Tests verify `client.send` is called with correct arguments
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)