### PR TITLE
feat: Dev tools & docs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ dist
 .coverage
 .mypy_cache
 venv
+.direnv
+.venv
+result
+.firmware

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# arcam_fmj
+
+Python library for controlling Arcam AV receivers.
+
+## Upstream
+
+The upstream repository is [elupus/arcam_fmj](https://github.com/elupus/arcam_fmj). We are very respectful of the upstream maintainer's (elupus) feedback and preferences. When preparing changes for upstream, follow the existing code style and conventions closely.
+
+## Fork-only files
+
+The following files exist only in this fork and **must not** be included in PRs to upstream:
+
+- `flake.nix`, `flake.lock`
+- `.envrc`
+- `CLAUDE.md`, `.claude/`
+
+Remove or exclude these before submitting anything to elupus. This includes references in e.g. .gitignore
+
+## Development environment
+
+This project runs on NixOS without much on the global PATH. The nix devshell (activated automatically via direnv) provides `uv` and `python3`.
+
+- **Package management & virtualenv**: Use `uv` (e.g. `uv sync`, `uv run`).
+- **Testing**: `uv run pytest` (install test deps with `uv sync --extra tests`).
+- **Running the CLI**: `uv run arcam-fmj`.
+
+## Commits
+
+Let the user review changes before committing. When committing, use [Conventional Commits](https://www.conventionalcommits.org/) style (e.g. `fix:`, `feat:`, `chore:`, `docs:`).
+
+## Specs and Reference Implementation
+
+The protocol specs live as committed Markdown in `docs/specs/` (see `docs/specs/README.md` for the model → document mapping and links to the original PDFs). They are generated from Arcam's official PDFs by `nix run '.#fetch-specs'`; re-run that when the upstream documents change.
+
+NOTE: The PDFs _mostly_ translate well into markdown, _except_ table ordering - often tables are offset from the text they belong to, especially with regard to command reference: in the PDF, a command description will be in the left column and a table with the data layout in the right; in the markdown you'll see a whole group of descriptions followed by a whole group of tables.
+
+## Firmware dump
+
+See `docs/Firmware Dump.md` for full details. Highlights:
+
+Run `nix run '.#fetch-firmware'` to download the official AVRx1 firmware bundle and unpack it into `.firmware/`.
+
+Arcam's own embedded "setup" web app lives at `.firmware/net/rootfs/www/pages/setup/`. It is their implementation of the protocol, and examining its code can be as useful as reading the specifications. (Though, keep in mind their implementation has its shortcomings too.)

--- a/README.rst
+++ b/README.rst
@@ -62,11 +62,6 @@ Code to set volume and source using console over serial.
 Protocol Specifications
 =======================
 
-- `AVR5/AVR10/AVR20/AVR30/AV40/AVR11/AVR21/AVR31/AV41 <https://www.arcam.co.uk/ugc/tor/AVR11/Custom%20Installation%20Notes/RS232_5_10_20_30_40_11_21_31_41__SH289E_F_07Oct21.pdf>`_
-- `SA30 <https://www.arcam.co.uk/ugc/tor/SA30/Custom%20Installation%20Notes/SH306E_RS232_SA30_4.pdf>`_
-- `SA750 <https://www.jbl.com/on/demandware.static/-/Sites-masterCatalog_Harman/default/dwabc088c9/pdfs/SH320E_RS232_SA750_iss1.pdf>`_
-- `PA720/PA240/PA410 <https://www.arcam.co.uk/ugc/tor/PA240/Custom%20Installation%20Notes/RS232_PA720_PA240_PA410_SH305E_3.pdf>`_
-- `ST60 <https://www.arcam.co.uk/ugc/tor/ST60/Custom%20Installation%20Notes/SH309_RS232_ST60_C.pdf>`_
-- `AV860/AVR850/AVR550/AVR390/SR250 <https://www.arcam.co.uk/ugc/tor/avr390/RS232/RS232_860_850_550_390_250_SH274E_D_181018.pdf>`_
-- `SA10/SA20 <https://www.arcam.co.uk/ugc/tor/SA20/Custom%20Installation%20Notes/SH277E_RS232_SA10_SA20_B.pdf>`_
-- `AVR750/AVR450/AVR380 <https://www.arcam.co.uk/ugc/tor/avr380/RS232/RS232_AVR750450380_SH256E_3.pdf>`_
+See `docs/specs/README.md <docs/specs/README.md>`_ for the list of supported
+models and the corresponding protocol documents (Markdown conversions of
+Arcam's official PDFs, with links to the originals).

--- a/docs/Firmware Dump.md
+++ b/docs/Firmware Dump.md
@@ -1,0 +1,426 @@
+# Firmware dump
+
+## 1. Introduction
+
+This document describes the Arcam AVRx1-series (AVR11/AVR21/AVR31/AV41) firmware bundle: how to obtain and unpack it, what's inside, and a step-by-step walkthrough of the code path that handles control-protocol traffic — from a TCP byte arriving on port 50000, through the on-device software stack, down to the host MCU, and back. The walkthrough is followed by a correlation section that maps the observed black-box behaviour of the live device onto the internal code path, identifies a structural issue in the design, and discusses workarounds available to clients.
+
+All references in this document are to artifacts produced by `nix run '.#fetch-firmware'`. Disassemblies named below are in the build derivation, not the repo — fetch first to read them.
+
+## 2. Extraction methodology
+
+`nix run '.#fetch-firmware'` performs the entire pipeline:
+
+1. **Download** the official update bundle `AVRx1_1v62_2148.zip` from `arcam.co.uk` using `pkgs.fetchurl` with a pinned SHA-256.
+2. **Unzip** to obtain `AVRx0_System*.fw` (the composite host-side firmware blob), `image.swu` (the network-side SWUpdate payload), and `AVR11_AVR21_AVR31_AV41_Software_Release_Notes_*.pdf`.
+3. **Unpack `image.swu`** with `cpio -idv` (it's a cpio archive) to obtain the SoC payload's individual components.
+4. **Decompress the UBIFS rootfs** with `xz -dc` (the `yocto-…-arcam.ubifs` blob is XZ-compressed; this matches `compressed = true` in the bundled `sw-description` manifest).
+5. **Extract the UBIFS contents** with `ubireader_extract_files` to produce a complete Linux rootfs tree.
+6. **Extract the FIT images** with `dumpimage` (from `u-boot-tools`) — splits the signed FIT into kernel/dtb/ramdisk subimages; the kernel and ramdisk are gzip-compressed inside the FIT and are decompressed after extraction. The SWU updater's ramdisk is then further extracted as a cpio archive into `ramdisk.cpio.d/`.
+7. **Untar `u-boot.tar.gz`** to obtain the bootloader binaries.
+8. **Extract STM32 code regions** from the host `.fw` blob and **disassemble** them with `arm-none-eabi-objdump` (Thumb-2, `armv7e-m`). Two regions are extracted, identified by the vector-table pattern (initial-SP + reset-handler-Thumb-address pair) at the start of each contiguous run of non-`0xFF` bytes; see [flake.nix](../flake.nix) `firmwareHostAnalysis` for the offsets.
+9. **Disassemble** every `libnsdk_*.so` and binary on the Linux side plausibly involved in protocol handling, using `llvm-objdump --demangle`. The target list is in [flake.nix](../flake.nix) `firmwareNetAnalysis`.
+
+The full pipeline is defined in [flake.nix](../flake.nix). The bundle URL, SHA-256, and exact extraction recipes are all there.
+
+## 3. Layout of extracted contents
+
+```
+.firmware/
+├── AVR11_AVR21_AVR31_AV41_Software_Release_Notes_1v62_2148.pdf
+├── host/
+│   ├── AVRx0_System(HDMI2p1Plus)0v1p62.fw          ← original 90 MB composite bundle
+│   └── analysis/
+│       ├── extracted/
+│       │   ├── stm32_bootloader.bin                ← file offset 0x000000–0x010000
+│       │   └── stm32_app.bin                       ← file offset 0x010000–0x0ea020
+│       └── disasm/
+│           ├── stm32_bootloader.S                  ← arm-none-eabi-objdump, VMA 0x08000000
+│           └── stm32_app.S                         ← arm-none-eabi-objdump, VMA 0x08010000
+└── net/
+    ├── fitImage-a113d-arcam-signed                 ← raw FIT (kernel + dtb)
+    ├── fitImage-swu-a113d-arcam-signed             ← raw FIT (SWU updater)
+    ├── u-boot.tar.gz                               ← raw u-boot bundle
+    ├── yocto-nsdk-ip-image-swu-a113d-arcam.ubifs   ← raw UBIFS (XZ-compressed)
+    ├── sw-description, sw-description.sig          ← SWUpdate manifest
+    ├── swupdate_preinstall.sh, swupdate_postinstall.sh
+    ├── rootfs/                                     ← unpacked Yocto rootfs
+    ├── fit/                                        ← extracted kernel + fdt.dtb
+    ├── fit-swu/                                    ← extracted SWU kernel + dtb + ramdisk(.d)
+    ├── u-boot/                                     ← extracted u-boot tarball
+    └── analysis/
+        └── disasm/                                 ← llvm-objdump --demangle of selected libs
+            ├── nSDK.S
+            ├── hostlink_cli.S, nsdk_cli.S
+            ├── libnsdk_hostLink.so.S
+            ├── libnsdk_hostLinkLib.so.S
+            ├── libnsdk_serialComm.so.S
+            ├── libnsdk_thrift_api.so.S
+            ├── libnsdk_api.so.S
+            ├── libnsdk_webserver.so.S
+            ├── libnsdk_machine.so.S
+            ├── libnsdk_systemManager.so.S
+            ├── libnsdk_networking.so.S
+            ├── libnsdk_services.so.S
+            ├── libnsdk_simple_ipc.so.S
+            ├── libnsdk_processhandler.so.S
+            ├── libnsdk_powerHandler.so.S
+            ├── libnsdk_powerManager.so.S
+            ├── libnsdk_constpartition.so.S
+            ├── libnsdk_sysfs.so.S
+            ├── libnsdk_mLib.so.S
+            ├── libnsdk_miscUtils.so.S
+            ├── libnsdk_mdnsHelpers.so.S
+            └── libnsdk_mdnsSystemMembers.so.S
+```
+
+Absolute symlinks inside the extracted Linux filesystems (e.g. busybox shims like `flashcp -> /usr/sbin/flashcp.mtd-utils`) are preserved as symlinks and appear broken on the host. They resolve correctly on the target device.
+
+## 4. Hardware architecture (from the firmware image)
+
+Evidence for each claim is the artifact path + a brief description of the indicator.
+
+| Claim | Evidence |
+|---|---|
+| Host control MCU is an STM32 Cortex-M (Thumb-2, ARMv7E-M). | Vector-table-shaped bytes at file offsets 0x000000 and 0x010000 of `host/AVRx0_System*.fw`: initial-SP word followed by a `0x080000?? \| 1` (Thumb) reset-handler address. The image contains references to STM32 HAL routines (`HAL_I2C_SlaveRxCpltCallback`, `HAL_I2C_AddrCallback`, `HardwareI2C_ID1Enable`, `HardwareI2C_SendData`, `HardwareI2C_ReadData`) as string constants — see [host/analysis/disasm/stm32_app.S](../.firmware/host/analysis/disasm/stm32_app.S) (search for the strings near rodata). |
+| Network/streaming SoC is an Amlogic A113D running Linux. | [net/sw-description](../.firmware/net/sw-description) declares `hardware-compatibility: ["a113d-arcam", "a113d-arcam-V1", "a113dArcam", "a113dArcam-V1", "Generic", "Generic-V1"]`. The FIT image (`net/fit/`) targets `a113d-arcam`. |
+| Audio decoding/processing is on a Texas Instruments DSP (separate from STM32). | Path strings inside the composite `.fw` blob (use `strings -t x` on the .fw): `/home/anam.dev/ti/ANAM_KOR_18_004_PA_processor_sdk_audio_1_03_00_00/…/simulate_dma/simulate_dma.c`, `src/I2C_drv.c`, `src/v0/I2C_v0.c`. DTS/Dolby decoder file paths also present (e.g. `dlb_jocdeclib/src/parser.c`, `dtshd-c-decoder/src/…`). |
+| A separate sub-component, codename "Bach", talks to the rest over SPI. | Strings inside the composite `.fw`: `bach_set_channel_db2`, `bach_handle_service_info`, `Bach Boot Done...`, `Bach command i/f: SPI`. |
+| The STM32 ↔ SoC link is I²C, not UART (despite the "hostlink"/"serial" naming in the Linux-side library). | [net/rootfs/usr/lib64/libnsdk_hostLink.so](../.firmware/net/rootfs/usr/lib64/libnsdk_hostLink.so): `CMHostLinkWorker::CMHostLinkWorker` (flash addr `0x27950` in [net/analysis/disasm/libnsdk_hostLink.so.S](../.firmware/net/analysis/disasm/libnsdk_hostLink.so.S)) loads the literal `"i2c"` (rodata at flash `0xb0248`) and passes it as `name` to `HostLinkPhysicalLayer::create`. The factory at [net/analysis/disasm/libnsdk_hostLinkLib.so.S](../.firmware/net/analysis/disasm/libnsdk_hostLinkLib.so.S) `0x1c228` instantiates `I2cPhysicalLayer` when name == `"i2c"`. |
+| The MCU asserts a GPIO IRQ to signal the SoC that response data is ready. | SoC-side `SyncSerialLayer::gpioIrqLoop` at `0x24168` in [net/analysis/disasm/libnsdk_hostLinkLib.so.S](../.firmware/net/analysis/disasm/libnsdk_hostLinkLib.so.S) polls `/sys/class/gpio/gpioN/value` via the sysfs interface and enqueues a wake-up to `readLoop`. Strings `/sys/class/gpio/export`, `/sys/class/gpio/gpio`, `IRQ GPIO falling edge` appear in the same library. |
+
+## 5. Software architecture overview
+
+### Network-streaming SoC (Amlogic A113D, Linux)
+
+- Yocto-built Linux rootfs at [net/rootfs/](../.firmware/net/rootfs/).
+- Boot sequence: [net/u-boot/uboot/u-boot-signed.bin](../.firmware/net/u-boot/uboot/u-boot-signed.bin) → signed FIT kernel ([net/fit/kernel](../.firmware/net/fit/kernel)) → SWUpdate verifies signed payload → installs rootfs.
+- The main userspace control daemon is `nSDK` at [net/rootfs/usr/share/nsdk/nSDK](../.firmware/net/rootfs/usr/share/nsdk/nSDK), launched under `nsdk_watchdog` by [net/rootfs/etc/init.d/nsdk](../.firmware/net/rootfs/etc/init.d/nsdk).
+- `nSDK` `dlopen`s `libnsdk_hostLink.so` at runtime (the lib name appears only as a string literal in the `nSDK` rodata, not as a `DT_NEEDED` entry — verified with `readelf -d`).
+- Inside `libnsdk_hostLink.so`, the class `CMHostLinkWorker` owns three `HostLinkMessageHandler` subclasses: `UInputHandler`, `TcpTunneling`, `LedApi`. They are stored polymorphically in a `QList<HostLinkMessageHandler*>` at `this+0x68`. The shared transport-layer pointer is at `this+0x48`.
+- `TcpTunneling` is the part that exposes port 50000.
+
+### Host MCU (STM32)
+
+- Two code regions in the host `.fw` blob: a small **update bootloader** at flash `0x08000000` and the **main app** at flash `0x08010000`.
+- The bootloader's role is firmware update (string evidence in [host/analysis/disasm/stm32_bootloader.S](../.firmware/host/analysis/disasm/stm32_bootloader.S): `[Boot] Open File: %s`, `AVRx0 Update Result.txt`, `BOOTLOADER Ver. %s`, `AVRx0_System*.fw`, `AVRx0_LCD*.bin`).
+- The main app handles normal runtime, including I²C slave for the SoC-side host-link protocol.
+- The remainder of the .fw bundle (file offsets beyond `0x0ea020`, mostly past `0x200000` after a long 0xFF padding) contains TI Performance Audio DSP firmware and the "Bach" sub-component. These are different processor architectures and are not relevant to the protocol path analysed here, so are not disassembled.
+
+### Protocol layering, top to bottom
+
+```
+TCP client (port 50000)
+  │
+  ▼
+TcpTunneling                       libnsdk_hostLink.so       (TCP server + per-client slot id; bin16 wrapper)
+  │
+  ▼
+HostLinkTransportLayer             libnsdk_hostLinkLib.so    (HostLink message framing, packetisation)
+  │
+  ▼
+SyncSerialLayer / I2cPhysicalLayer libnsdk_hostLinkLib.so    (per-packet I²C transaction, GPIO IRQ wait)
+  │
+  ▼
+I2c                                libnsdk_serialComm.so     (ioctl(I2C_RDWR) wrapper, stateless)
+  │
+  ▼  /dev/i2c-N (Linux)  ⇆  I²C2 peripheral  (STM32)
+  │
+  ▼
+I²C-RX dispatcher                  stm32_app.S               (HostLink fragment reassembly)
+  │
+  ▼
+HostLink message parser            stm32_app.S               (value-entry loop)
+  │
+  ▼
+0xC5 (bin16) sub-handler           stm32_app.S               (Arcam frame handling + reply build)
+  │
+  ▼
+I²C TX kick → GPIO IRQ → SoC reads response
+```
+
+## 6. Methodology for software analysis
+
+| Layer | Tool | Notes |
+|---|---|---|
+| AArch64 ELF shared objects on the Linux side | `llvm-objdump --disassemble --demangle` | C++ symbols are demangled inline. Function bodies are recognisable; cross-references are grep-able by mangled name. |
+| ARMv7E-M raw binary on the STM32 side | `arm-none-eabi-objdump -D -b binary -m armv7e-m -M force-thumb --adjust-vma=…` | No ELF metadata; functions must be found by patterns and cross-references. The image contains some symbol-name strings (e.g. `HAL_I2C_SlaveRxCpltCallback`) referenced for hard-fault diagnostics — useful as anchors. |
+| Both | `nm -D --demangle` | Linux side has dynamic symbol tables; STM32 side does not. |
+| Both | `strings -t x` | Anchor functions via referenced string literals (log messages, file paths, function-name diagnostics). |
+
+For both sides, the disassembled `.S` files at `.firmware/{host,net}/analysis/disasm/` are the canonical reference. Line numbers in this document refer to those files unless otherwise stated.
+
+Two facts about the disassembly format are useful to know when following along:
+
+- `arm-none-eabi-objdump` output line format: `   <hex_addr>:	<bytes>	<mnemonic> <operands>`. PC-relative loads are annotated with `@ <effective addr>`.
+- `llvm-objdump --demangle` output begins each function body with `<hex_addr> <DemangledSignature>:` then per-instruction lines. Mangled-name grep (`_ZN…`) finds function entry points; demangled grep finds call sites with operands.
+
+## 7. Walkthrough: port 50000 to MCU and back
+
+This is a step-by-step trace of a single Arcam protocol command and its reply. Every step cites the precise file, function, and offset where the behaviour is implemented. Statements marked **observed** are directly read from disassembly; those marked **inferred** are structural deductions explicitly built on cited observations.
+
+### 7.1. TCP server setup
+
+**Step 1.** At nSDK startup, `CMHostLinkWorker::CMHostLinkWorker` (`libnsdk_hostLink.so` flash addr `0x27950`, [net/analysis/disasm/libnsdk_hostLink.so.S](../.firmware/net/analysis/disasm/libnsdk_hostLink.so.S)) constructs three `HostLinkMessageHandler` subclasses and stores them in a `QList` at `this+0x68`. One of these is the `TcpTunneling` instance.
+
+**Step 2.** `TcpTunneling::TcpTunneling` (`libnsdk_hostLink.so` flash addr `0x30e48`) reads its `port` and `maxOpenConnections` parameters from a `NsdkValue::tcpTunnelingConf` configured at [net/rootfs/settings-default/hostlink/tcpTunnelingConf](../.firmware/net/rootfs/settings-default/hostlink/tcpTunnelingConf) (JSON: `port=50000, maxOpenConnections=10`). It constructs a `QTcpServer` at `this+0x28` and calls `QTcpServer::listen()` with those values. Per-client state is held in a `QHash<QTcpSocket*, signed_char>` at `this+0x30`. **Observed.**
+
+### 7.2. Client connect → slot assignment
+
+**What a slot is, and what it's for.** The SoC-side bridge multiplexes up to `maxOpenConnections` (default 10) concurrent TCP clients over a **single** I²C link to the MCU. To let the MCU and the bridge identify which client a given byte stream belongs to, the bridge assigns each new TCP connection a 1-byte **slot id** and uses it as a routing tag: every outbound byte stream sent to the MCU on this client's behalf will be prefixed with the slot id (step 5), and every reply byte stream from the MCU destined for this client will arrive at the SoC with the same slot id at offset 0 of the reply's payload (step 21, mirrored back by the MCU somewhere along the unresolved code path in step 14). The slot is a per-TCP-connection routing tag, **not** a per-thread identifier — all TCP-client servicing runs on the single Qt event-loop thread (step 4), and all outbound I²C transactions serialise through one `pthread_mutex_t` on the physical-layer object (step 8), so concurrency-wise the slot id makes no difference.
+
+**Step 3.** When a client connects, Qt invokes `TcpTunneling::on_tcpServer_newConnection` (flash `0x33018`). The handler walks the existing slot values in the hash, picks the lowest integer `s` in `[0, maxOpenConnections)` not already in use, and stores it as the new socket's value at the hash node's `+0x18` offset (`strb w21, [x1]` at flash `0x33230`, where `x1 = node+0x18` and `w21` holds the slot id). If all slot ids are taken the connection is rejected by calling the socket's `close` vtable slot and `QObject::deleteLater()`. **Observed.**
+
+**Step 4.** `nsdkConnect` ([net/analysis/disasm/libnsdk_api.so.S](../.firmware/net/analysis/disasm/libnsdk_api.so.S) flash `0x64dc8`) wires three Qt signals on the new socket — `readyRead`, `disconnected`, `error(QAbstractSocket::SocketError)` — to `TcpTunneling`'s slots, with `Qt::ConnectionType=0` (`AutoConnection`). Since `TcpTunneling` and the socket share a thread, this resolves to `DirectConnection`. **Observed.**
+
+### 7.3. Client send → bin16 wrap
+
+**Step 5.** Bytes arrive on the kernel TCP receive buffer. Qt emits `readyRead` once for each new batch (Qt does not re-emit until all bytes have been read or new bytes arrive). The slot is `TcpTunneling::on_socket_readyRead` (flash `0x328c0`). The handler does:
+
+1. `QObject::sender()` → the originating socket. **Observed.**
+2. `QHash<QTcpSocket*, signed_char>::findNode` → locates the slot byte; if not found, the handler logs `"Unknown connection ready to read"` and calls the socket's vtable+0x70 (close). **Observed.**
+3. Loads the slot byte with `ldrsb` (sign-extended). If equal to `-1` (`0xff`), the handler also takes the "Unknown connection" path. **Observed.** (Note: no code path in this binary writes `-1` to a hash node value — verified by exhaustive search for `strb` of an immediate `0xff` against any QHash node offset. The check is defensive.) **Observed (negative result).**
+4. **`QIODevice::read(socket, 8192)`** — reads **up to** 8192 bytes (immediate `#0x2000` in `mov x1, …` at `0x329fc`). No loop; one call per `readyRead`. **Observed.**
+5. Builds a 1-byte `QByteArray` containing the slot id assigned at step 3, prepends it to the just-read data → final payload is `[slot_id, ...bytes_read]`. The leading byte is the routing tag the MCU side uses to identify which client owns this byte stream (relied on indirectly through step 14 and recovered from the reply at step 21).
+6. Constructs `HostLinkValueMessage` with `messageId = 8` and calls `HostLinkValueMessage::addValueBin16` **exactly once** with the prepended payload (single bin16 entry).
+7. Calls `HostLinkTransportLayer::writeMessage` via the transport-layer vtable. The return value is discarded.
+
+**Key observation**: there is **no Arcam-protocol-aware parsing** in this handler. Whatever bytes `QIODevice::read` returns are passed as a single opaque blob.
+
+### 7.4. Transport-layer packetisation
+
+**Step 6.** `HostLinkTransportLayer::writeMessage` ([net/analysis/disasm/libnsdk_hostLinkLib.so.S](../.firmware/net/analysis/disasm/libnsdk_hostLinkLib.so.S) flash `0x1a7e8`):
+
+1. Calls `physicalLayer->nextFrameId()` (vtable+0x20) to obtain a monotonic frame id. **Observed.**
+2. Constructs a `HostLinkMsgFrame` with `(message_bytes, frame_id, max_packet_size)`.
+3. Iterates over the resulting packets (`HostLinkMsgFrame::packetCount`).
+4. For each packet, calls `physicalLayer->writeData(packet)` (vtable+0x28). Status codes:
+   - `0` → success, continue to next packet
+   - `1` → transient busy; sleeps 10 ms (`usleep(10000)` at `0x1a95c`), retries up to 3 attempts; if still `1` after 3, logs `"Unable to write data to the physical layer: rejected after 3 retries"` and returns 0.
+   - `2`, `3` → error; logs `"Unable to write data to the physical layer: <code>"` and returns 0.
+
+**Observed.** There is no per-message-id, per-slot, or per-frame state on the transport layer object beyond the frame-id counter (and a `std::map<int, HostLinkFrame*>` used only by the reassembly path on the read side — see step 12).
+
+### 7.5. Physical layer is I²C
+
+**Step 7.** `HostLinkPhysicalLayer::create("i2c", props)` returns an `I2cPhysicalLayer` instance ([net/analysis/disasm/libnsdk_hostLinkLib.so.S](../.firmware/net/analysis/disasm/libnsdk_hostLinkLib.so.S) ctor at `0x1e3a8`). The `I2cPhysicalLayer` vtable (`_ZTV16I2cPhysicalLayer` at `0x3eaa8` in the same library) overrides only the destructor; every other slot points to a `SyncSerialLayer` method. So in practice, all writes go through `SyncSerialLayer::writeData` at `0x22bf8`. **Observed.**
+
+**Step 8.** `SyncSerialLayer::writeData`:
+
+1. Unconditionally `pthread_mutex_lock(this + 0xf0)` at `0x22c9c` ("writeMutex"). Concurrent callers block. **Observed.**
+2. Calls `SyncSerialLayer::writeReadPacket(buf, 2 * minFrameSize)` at `0x22478` — this both sends the packet and waits for the I²C-level response sentinel:
+   - `usleep(5000)` (5 ms minimum dwell), then calls the device's `read` (vtable+0x18) and polls for a 16-bit response sentinel `0xFEFF`. Backoff: 5 ms → 10 → 20 → 40 → 80 ms, max 5 attempts.
+   - Returns the response bytes (or empty on timeout).
+3. Parses the response; returns one of `{0=OK, 1=busy/retry, 2=error, 3=unexpected}` to the transport layer.
+4. Unconditionally `pthread_mutex_unlock` at `0x22e74` on every return path.
+
+**Observed.** **Inferred**: because the mutex is unconditionally taken on every entry and there is no `trylock`/`wait_for`/single-slot-replace pattern, second writers cannot drop — they block until they acquire the mutex.
+
+**Step 9.** `SyncSerialLayer` underlying byte transfer goes through `I2c::write` / `I2c::writeRead` in [net/rootfs/usr/lib64/libnsdk_serialComm.so](../.firmware/net/rootfs/usr/lib64/libnsdk_serialComm.so). These classes are stateless syscall wrappers: `I2c::writeRead` issues a single `ioctl(I2C_RDWR)` (cmd `0x707`, 2 messages); `I2c::write` uses the raw `write(2)` syscall on the open `/dev/i2c-N` fd. No threading primitives, no buffers, no statics. **Observed.**
+
+### 7.6. MCU I²C-RX
+
+**Step 10.** Bytes arrive on the STM32's I²C2 peripheral. The HAL invokes `HAL_I2C_SlaveRxCpltCallback` (function-name string present at file offset `0x97cc0` in `stm32_app.bin`, flash `0x080a7cc0`). Standard STM32 HAL: this callback is `__weak` in the library and overridden by the application.
+
+**Step 11.** The application's I²C-RX dispatcher (flash `0x080a74d0` in [host/analysis/disasm/stm32_app.S](../.firmware/host/analysis/disasm/stm32_app.S)) reads the HostLink message header from the I²C buffer and branches on a tag byte at `[r6,#4]` (the dispatcher masks the byte to its low nibble for the `0x02`/`0x03` comparisons and tests the full byte for `0x23`/`0x63`):
+
+- `tag == 0x02` (TX-ready signalling): stores 4-byte payload at `[r5+0x754]` and toggles the GPIO IRQ via `0x0807608e` (the only direct caller of this GPIO toggle inside the dispatcher). **Observed.**
+- `tag == 0x03` (non-final HostLink fragment): `memcpy` payload from `r6+8` into one of three **HostLink fragment-reassembly buffers** at `r5+0x44d8`, `r5+0x54d6`, `r5+0x64cc`, then increment a **fragment counter** at `[r5+0x72f]` (saturating at 3). `r5 = 0x20000000` (literal at `0x080a7c90`). So the fragment counter lives at RAM `0x2000072f` and the buffers at `0x200044d8`, `0x200054d6`, `0x200064cc`. **Observed.** (These reassembly buffers are an internal MCU mechanism for stitching together a multi-packet HostLink message; they are distinct from the TcpTunneling slot id of step 3 — the TcpTunneling slot id is embedded as the first byte of the bin16 payload **inside** the reassembled HostLink message.)
+- `tag == 0x23` (final HostLink fragment): append payload into fragment-buffer[counter] at offsets `0xffe`/`0x1ff4`/`0x2fea` relative to `+0x44d8`, **zero the fragment counter** (`strb.w r0(=0), [r5, #1839]` at `0x080a75a2`), then call the parser at `0x080a46f0` **exactly once**. If the fragment counter was already 0 (no pending fragments), the dispatcher skips the memcpy and calls the parser directly on the just-arrived I²C buffer `r6`. **Observed.**
+- `tag == 0x63`: 532-byte `memset` starting at `[r5,#16]` (buffer reset).
+
+**Key observation**: the parser is invoked **once per I²C-RX dispatch**, regardless of the size of the reassembled buffer. There is no loop here, no second parser pass, no scan over the buffer. **Observed.**
+
+### 7.7. MCU HostLink message parser
+
+**Step 12.** Parser entry: `0x080a46f0`. The function:
+
+1. Prologue: `push {r4..fp, lr}`, 36 bytes of locals; `r4 = buffer pointer (caller arg)`.
+2. Validates a 16-bit header at `[r4+0..1]` against `0xff 0xfe`. **Observed.**
+3. Reads a field count at `[r4+10]`. **Observed.**
+4. Runs a fixed `for (i=0; i < count; ++i)` loop (iterator at `[sp+1]`, loop body roughly `0x080a4788..0x080a7462`, with the back-branch at `0x080a7462` and exit at `0x080a7466`). Per iteration:
+   - Reads a one-byte type tag from the current cursor in `r4`.
+   - Dispatches by tag: known tags include `0xCC`, `0xC5` (bin16), `0xCE`, `0xD3`.
+   - Advances the cursor `r7` by the field size for that tag.
+5. Loop exit at `0x080a7466`; epilogue at `0x080a747c` (`pop {r4..fp, pc}`).
+
+**Observed.** The dispatch tags `0xCC`/`0xC5`/`0xCE`/`0xD3` are HostLink value-entry type tags, **not Arcam `<St>=0x21`/`<Et>=0x0d` framing bytes**. The loop iterates over HostLink fields, not over Arcam frames.
+
+### 7.8. Bin16 sub-handler
+
+**Step 13.** When the type tag is `0xC5` (bin16), the dispatch lands at flash `0x080a5790`. The handler:
+
+1. Confirms tag (`cmp r0, #197` at `0x080a5792`). **Observed.**
+2. Computes a destination pointer in RAM at `r8 + 0x4480` (32-byte staging area immediately preceding the slot-0 RX buffer at `+0x44d8`). **Observed.**
+3. Loads a 16-bit length from the local stack at `[sp+2]`.
+4. Calls **`bl 0x080a0b18`** with `(r0=staging_dst, r1=src=bin16 payload, r2=tag-related, r3=u16_len)`. **Observed; the call is unconditional and made exactly once.** The buffer at `r1` is the full bin16 payload from the bridge — its first byte is the TcpTunneling slot id from step 5, and the remainder is the Arcam frame.
+5. `memcmp` the result at the staging area against a 32-byte reference buffer at `r8+0x44a0` (`bl 0x801a268`); if equal, take the "no change" exit path. **Observed.**
+6. If different, copy 32 bytes from staging into the reference buffer (via `ldmia/stmia` at `0x080a57c2`–`0x080a57ca`). **Observed.**
+7. Call `bl 0x080895fe` — a 3-instruction accessor that returns the byte at `[r0+#0x44a]` (a TX-state flag) — then `cmp r0, #1` / `bne 0x80a5810` at `0x080a57d4`–`0x080a57d6`. The two branches diverge from here:
+   - If the state byte was 1 (TX path taken): clear flags at `[r8, #0x706]` and `[r8, #0x708]` (`0x080a57da`–`0x080a57de`), then run a per-slot housekeeping loop (sdiv/mls modular arithmetic over slot index, slot-state writes via `[r1, #0x238]`) and exit into the outer parser loop at `0x080a7450`.
+   - Otherwise (`0x080a5810`+): perform a second 32-byte memcmp against a reference buffer at `r8+0x8560`, then either clear the same `+0x706`/`+0x708` flags and continue, or read another state byte at `[r8, #0x726]` and branch further. Not fully traced.
+8. The actual I²C-TX write and GPIO-IRQ assertion — the **reply emission** — must lie further along one of these branches, not at `0x080895fe` itself (which is a getter with ~72 callers across the image and does not touch the I²C peripheral or GPIO). Precise location of the kick and its relation to the five `0x0807608e` (GPIO toggle) call sites is not identified in this pass. **Observed (negative result for the cited address); downstream path not traced.**
+
+The flash trampoline at `0x080a0b18`:
+
+```
+080a0b18:  df f8 00 f0    LDR.W  PC, [PC]
+080a0b1c:  f5 c0 00 20    .word  0x2000c0f5
+```
+
+`PC ← 0x2000c0f5` (Thumb-mode, code at RAM `0x2000c0f4`). **Observed.**
+
+**Static limit**: the actual code at RAM `0x2000c0f4` is not initialised by anything in the STM32 firmware images we have. Exhaustive search of both `stm32_bootloader.S` and `stm32_app.S` finds no init-time `memcpy` writing to that RAM region, no literal-pool entry containing `0x2000c0c8`/`0x2000c0f4`/`0x2000c0c9`/`0x2000c0f5` except the trampoline itself, and no `MOVW`/`MOVT` pair computing those addresses. The bootloader's startup is BSS-clear-only — no flash-to-RAM `.data` copy loop. **Observed (exhaustive negative search).** **Deduction**: the destination is populated by a mechanism outside the firmware images extractable from this `.fw` (candidates not investigated: a separate firmware partition, runtime upload from the SoC, DMA descriptor loading).
+
+**Structural observations** about the trampoline's calling convention:
+
+- ~20 call sites use `bl 0x080a0b18` with identical 4-arg register signature `(dst, src, tag, u16_len)`. **Observed.**
+- The companion trampoline at `0x080a0b20` (target `0x2000c0c9` → RAM `0x2000c0c8`) is paired and adjacent. **Observed.**
+
+**Step 14.** The Arcam-protocol-level parsing of the bin16 payload bytes — that is, recognising the `<St>=0x21 <Zn> <Cc> <Dl> <data> <Et>=0x0d` framing — must happen either inside the call at step 13.4 (the RAM trampoline target) or downstream of the state-machine branches in step 13.7. The `0xC5` sub-handler itself does not iterate over the bin16 payload bytes; it makes the single trampoline call, then transitions through the state-flag check and exits via one of those branches. **Observed.**
+
+**Image-wide negative search**: across the entire STM32 main app and bootloader disassembly, no function contains a loop with `cmp #0x21` (the Arcam `<St>` byte) on successive memory bytes. The only function that compares a buffer byte to `#0x21` and then computes `Dl + N` (the Arcam-frame-length pattern) is at flash `0x08076c68`. That function reads exactly `Dl + 5` bytes, makes a single dispatch via an indirect call, and returns — it contains no loop or second `<St>` scan. Its only inbound call site is a `b.w` tail-branch from `0x080a2876` inside what appears to be a periodic test/injector routine (the only caller computes `r0 = table_base + 101*(global_tick % 30) + 223` before the tail-branch). It is **not** reachable from the I²C-RX path. **Observed (exhaustive grep over both `stm32_bootloader.S` and `stm32_app.S`).**
+
+### 7.9. MCU reply transmission
+
+**Step 15.** The reply is emitted by writing bytes to the I²C2 TX peripheral and asserting a GPIO IRQ line, signalling the SoC that response data is ready. The GPIO toggle helper at `0x0807608e` has exactly **five call sites** in `stm32_app.S`: one inside the I²C-RX dispatcher's tag-`0x02` path (step 11) and four others elsewhere. Which of those four lies on the bin16-reply path (downstream of step 13.7) is not identified in this pass. **Observed (call-site enumeration); reply-path identification not completed.**
+
+**Slot id in the reply.** The reply payload's bin16 entry contains, at offset 0, the same TcpTunneling slot id the request carried at step 5 — confirmed indirectly because the SoC-side `TcpTunneling::handleDataMessage` at step 21 reads that byte from the inbound bin16 and reverse-looks-up the matching socket. The MCU code that writes the slot byte into the outgoing reply bin16 sits inside the unresolved code at step 14 (RAM trampoline target at `0x2000c0f4` or downstream from it); not statically visible. **Deduced** from step 21's reverse lookup being the only way the bridge could route the reply correctly.
+
+### 7.10. SoC reads reply over I²C
+
+**Step 16.** On the Linux side, `SyncSerialLayer::gpioIrqLoop` (`libnsdk_hostLinkLib.so` flash `0x24168`) is one of two threads spawned by `SyncSerialLayer::init` (flash `0x250d0`). It blocks in `poll(POLLPRI)` on a `/sys/class/gpio/gpioN/value` file descriptor. When the MCU asserts the GPIO IRQ, the loop reads 4 bytes to discharge the event, allocates a 0x18-byte work-queue node (with flag byte `1` at node+0x10), hooks it into the work queue at `this+0xd8`, and `cv.notify_all`s. **Observed.**
+
+**Step 17.** The other thread, `SyncSerialLayer::readLoop` (`libnsdk_hostLinkLib.so` flash `0x23d48`), waits on the same condition variable, pops the work node, and calls `SyncSerialLayer::readFromSlave` (flash `0x23440`). `readFromSlave` reads the response packet via the I²C device and dispatches it via observer pattern. **Observed.**
+
+**Step 18.** `HostLinkTransportLayer::on_data_received` (`libnsdk_hostLinkLib.so` flash `0x1b460`) reassembles inbound packets keyed by frame id into a `std::map<int, HostLinkFrame*>` at `this+0x10` (guarded by `pthread_mutex_t` at `this+0x58`). When a complete `HostLinkFrame` arrives, the transport invokes the registered observer callbacks (stored in a `std::list<std::function<…>>` at `this+0x40`). **Observed.**
+
+### 7.11. Cross-thread marshal back to the Qt thread
+
+**Step 19.** `CMHostLinkWorker::CMHostLinkWorker` (`libnsdk_hostLink.so` flash `0x27950`, around `0x27fa0`) registers an observer with the transport layer whose `std::function` body is `QMetaObject::invokeMethod(worker, "on_message_received", Qt::QueuedConnection=2, …)`. This marshals the received-frame bytes from `readLoop`'s thread (non-Qt) onto the Qt event loop. **Observed.**
+
+**Step 20.** The Qt event loop processes the queued invocation. The receiver dispatches by `messageId`; for `messageId == 8`, control reaches `TcpTunneling::handleMessage` (`libnsdk_hostLink.so` flash inside the `0x32` range — exact address present as the virtual method). `handleMessage` constructs a response `HostLinkValueMessage(0x8009)` and iterates the input message's value entries:
+
+- For each entry: if `tag == 1 && enc == 0xc5`, call `handleDataMessage`; if `tag == 2 && enc == 0xcd`, call `handleCommandMessage`; else log `"Unsupported tcp tunneling message"`.
+
+After the loop, `writeMessage` is called on the transport layer to emit the response. **Observed.**
+
+**Step 21.** `TcpTunneling::handleDataMessage` (flash `0x31240`) is the relevant path for command replies:
+
+1. `HostLinkValueMessage::getBin16` to extract the response payload `QByteArray`. **Observed.**
+2. The **first byte** of the payload is the **slot id** the MCU response is addressed to (`local_99 = local_98[offset_of_bin16_data]`). **Observed.**
+3. `QHash::key(slot_id, &found_socket)` — **reverse lookup**: scans the per-socket slot-id hash for a socket whose value matches `slot_id`. **Observed.**
+4. If a socket is found: `QByteArray::remove(0)` strips the slot id, then `QIODevice::write(socket, data)` ships the rest to the client over TCP. Reply marker `addValueUint8(response, 1)` (success). **Observed.**
+5. If no socket is found: `addValueUint8(response, 1)` and log `"Tcp connection N doesn't exist"`. **Observed.**
+
+The `QIODevice::write` is a direct call, not marshalled via `QMetaObject::invokeMethod`. Since `handleDataMessage` is itself reached via `Qt::QueuedConnection` (step 19), it executes on the same thread as the socket; the call is thread-safe. **Observed.**
+
+**Step 22.** The TCP-layer kernel pushes the bytes back to the client. The client receives a complete Arcam reply frame `<St> <Zn> <Cc> <Ac> <Dl> <data> <Et>`.
+
+### 7.12. Cross-connection state-update broadcast (incidental, but observable)
+
+**Step 23.** When the MCU reports certain state changes (e.g. POWER), the SoC-side delivery loop emits the resulting response frame to **all** connected `TcpTunneling` clients, not only the one that sent the originating request. This is implemented via the same observer-list dispatch (step 18); the response message arriving with `messageId == 8` and certain sub-tags causes `handleMessage` to write to multiple sockets in turn. Direct evidence of which sub-tags trigger broadcasts: not traced. Observed black-box: a POWER query on one connection results in one reply packet on every currently-open TCP connection (tested with N=2 and N=3).
+
+## 8. Correlation with observed behaviour
+
+The following black-box behaviours of the live device have been independently measured against an AV41 running firmware v1.62 build 2148 (single-connection probes use `/tmp/arcam_probe*.py`; multi-connection probes verify symmetric behaviour):
+
+### 8.1. Pair-send coalescing window
+
+Two POWER queries sent on one TCP connection with inter-send gap `g`, count of trials (out of 10) where only one reply was received:
+
+| g | 0 ms | 100 µs | 500 µs | 1 ms | 2 ms | 5 ms+ |
+|---|---|---|---|---|---|---|
+| drops/10 | 9 | 9 | 5 | 1 | 0 | 0 |
+
+### 8.2. Trailing-zero tolerance, single frame
+
+One POWER query plus N trailing zero bytes in a single `send()`:
+
+| N trailing zeros | reply latency |
+|---|---|
+| 10 | 75 ms |
+| 100 | 79 ms |
+| 1 000 | 168 ms |
+| 2 000 | 253 ms |
+| 3 000 | 349 ms |
+| 4 000 | 440 ms (one run); no reply within 20 s (another run) |
+| 6 000–16 000 | no reply within 20 s, every run |
+
+### 8.3. Leading-zero tolerance
+
+Any number of leading zeros (`N ∈ {10, 100, 8192}`) before `<St>` causes the entire packet to be silently dropped — no reply within 20 s.
+
+### 8.4. Pipelined multi-frame
+
+A single `send()` of 10 POWER queries each followed by N trailing zeros (N ∈ {1000, 1500, 2000, 2500, 3000, 3500, 8186, 8192}): in every test, zero replies were received within 20 s.
+
+### 8.5. Sustained rate
+
+N back-to-back POWER queries on one connection at gap `g`, count of replies received within 3 s after the last send:
+
+| g | N=2 | N=3 | N=5 | N=8 | N=10 | N=15 | N=20 | N=30 | N=50 |
+|---|---|---|---|---|---|---|---|---|---|
+| 2 ms | 2/2 | 2/3 | 2/5 | 3/8 | 3/10 | 4/15 | 5/20 | 7/30 | 0/50 |
+| 5 ms | 2/2 | 2/3 | 4/5 | 5/8 | 0/10 | 8/15 | 0/20 | 0/30 | 2/50 |
+| 10 ms | 2/2 | 3/3 | 0/5 | 8/8 | 0/10 | 15/15 | 0/20 | 0/30 | 3/50 |
+| 50 ms | 2/2 | 3/3 | 4/5 | 8/8 | 10/10 | 11/15 | 16/20 | 24/30 | 37/50 |
+| 100 ms | 2/2 | 3/3 | 5/5 | 8/8 | 10/10 | 15/15 | 20/20 | 30/30 | 50/50 |
+| 200 ms | 2/2 | 3/3 | 5/5 | 8/8 | 10/10 | 15/15 | 20/20 | 30/30 | 50/50 |
+
+### 8.6. Cross-connection broadcast
+
+When N TCP connections are open simultaneously and one of them sends a POWER query, all N connections receive an identical reply packet (tested with N=2 and N=3). When two connections each send one POWER query within ~50 µs of each other, each connection receives 2 reply packets (its own reply plus the other connection's broadcast).
+
+### 8.7. Mapping observation to walkthrough
+
+| Observation | Walkthrough step | Mechanism |
+|---|---|---|
+| Two consecutive sends with ≥2 ms gap both reply (§8.1). | Steps 5 (TCP-buffer drain), 6 (I²C-bus serialisation) | At ≥2 ms gap the two segments are reliably separate kernel TCP segments AND the first segment has reliably been drained from the kernel buffer by `QIODevice::read` before the second arrives. Two `readyRead` signals, two HostLink messages, two MCU dispatches, two replies. |
+| Two consecutive sends with 0 ms gap (same `send()` call): only first reply (§8.1). | Step 5 (`read(8192)` reads the entire kernel-buffered chunk in one shot; `addValueBin16` called once with the merged bytes) → step 12 (HostLink parser loops by **value-entry count**, which is 1, not by Arcam-frame scanning) → step 13 (bin16 sub-handler runs once with the full merged payload) → step 14 (no `<St>`-scanning loop exists anywhere) | The Arcam frames after the first `<Et>` in the merged payload are inside a single bin16 value entry. The MCU parser sees one value entry, dispatches once to the bin16 sub-handler with the full payload pointer + length, and the bin16 sub-handler does not iterate within that payload. The trailing frames are unreached code-wise. |
+| Cross-connection sends do not drop (§8.6). | Step 8 (`writeMutex` is blocking, not dropping). | Both connections' bytes arrive as separate `readyRead` signals → separate HostLink messages → serialised at the SoC-side I²C `writeMutex` (no concurrency, no drops) → independent MCU dispatches → both reply. |
+| Postpad latency scales linearly with `N` until ~3 kB, then no reply (§8.2). | Steps 6, 7, 8 (transport layer chunks payload, I²C bus carries each chunk, MCU reassembles). | The latency curve fits an I²C-transport-rate-bounded model: at the observed slope (~+1 ms per ~25 bytes), effective rate ≈ 25 kB/s, consistent with I²C fast-mode (400 kHz). The cliff above 3 kB is **observed** but its mechanism is not traced from disassembly — it could be MCU buffer size (the reassembly slot is at `0x200044d8` in a fixed-size memory region), HostLink protocol length limit, or transport-layer timeout. Not investigated further. |
+| Prepad zeros cause silent drop (§8.3). | Step 13 (bin16 sub-handler) | Inferred: the (unresolved) RAM-resident byte processor at `0x2000c0f4` validates the leading byte. Since prepended garbage breaks parsing for any N ≥ 10, the byte-0-must-be-`<St>` rule lives somewhere along the path from the bin16 sub-handler. The exact code is not statically visible because it sits at the unresolved RAM trampoline target. |
+
+## 9. Identified structural issue
+
+The walkthrough shows that the **only** loop in the MCU's receive path that iterates over the received byte buffer is the HostLink **value-entry** loop in step 12 — and its iteration count is the HostLink field count read from the message header, **not** the number of Arcam `<St>...<Et>` frames in the payload.
+
+The SoC-side `TcpTunneling::on_socket_readyRead` (step 5) is the point where Arcam-protocol framing **would** need to be parsed in order to chunk a multi-frame TCP read into multiple HostLink value entries. It does not do this: it wraps the entire `read(8192)` result as a single `addValueBin16` value.
+
+The combination — the SoC sending one value per `readyRead`, and the MCU dispatching once per value entry without further `<St>`-scanning — is the design issue: **any Arcam protocol frame after the first `<St>...<Et>` in a single `readyRead`'s output is unreachable** by the receive path.
+
+This is consistent with all observed drop behaviour for the single-connection multi-frame case, with no remaining unexplained behaviour at the static-analysis level.
+
+## 10. Workarounds
+
+Workarounds available to a client that uses the Linux-side TCP interface.
+
+### 10.1. Wait for matching reply before sending again
+
+Conservative, completely reliable, no static-analysis risk. Per-request latency is the round-trip time (~75 ms baseline for a POWER query). Maximum sustained rate: ~13 commands/second. This is what the python library at [src/arcam/fmj/client.py](../src/arcam/fmj/client.py) already implements via `_request_lock` + the 200 ms `_REQUEST_THROTTLE`.
+
+### 10.2. Inter-send gap ≥ 2 ms for occasional back-to-back sends
+
+For two commands sent close together, a measured 2 ms gap between `send()` calls (with `TCP_NODELAY`) is sufficient to keep them in separate kernel TCP segments AND to give the SoC's `on_socket_readyRead` time to drain the buffer between them. Drop rate 0/10 in the pair-send measurement (§8.1).
+
+### 10.3. Pair pattern with truly-silent fill command
+
+For mixing a fire-and-forget command (today gated by the library's 200 ms `_REQUEST_THROTTLE`) with a reply-gated command: send the fire-and-forget first, wait ~2 ms, then send a reply-generating command and wait for its matching reply. Measured against an AV41 over 500 iterations with `21 01 00 00 0D` (POWER frame with `Dl=0` — the MCU parses and silently drops with no echo) as the fill: 489/500 matched (97.8% success), 0 unsolicited packets, p50 latency 98 ms, p95 104 ms.
+
+The fill command must be **legitimately silent** (no echo reply); the only commands documented in the spec [.specs/markdown/RS232_5_10_20_30_40_11_21_31_41__SH289E_F_07Oct21.md](../.specs/markdown/RS232_5_10_20_30_40_11_21_31_41__SH289E_F_07Oct21.md) generate replies, but several inputs the MCU silently discards have been measured:
+
+- Any non-`<St>` leading-byte stream
+- `<St> <Zn> <Cc> <Dl=0> <Et>` (e.g. `21 01 00 00 0D`)
+- `<St> <Zn> <Cc=0xFE> <Dl> <data> <Et>` (unknown command code 0xFE — note that 0xFF and 0x7F do generate `AC=0x83 CMD_NOT_RECOGNISED` replies, so not all unknown CCs are silent)
+
+### 10.4. Sustained pipelining at ≥100 ms gap
+
+For sustained throughput without per-reply gating, the table in §8.5 shows 100 ms inter-send gap is the first reliably-safe sustained rate for batches of up to N=50 commands (50/50 success). 50 ms suffices for N ≤ 10 but degrades beyond that. Below 50 ms, behaviour is unstable across N.
+
+### 10.5. Not workarounds
+
+The following do **not** help:
+
+- **Prepad** with any number of bytes (≥10 tested) → drops the entire packet.
+- **Postpad** to make a single padded unit exceed 8 kB → MCU stops replying (size cliff at ~3–4 kB).
+- **Pipelined postpad** (multiple padded units in one `send()`) → drops all replies; the bridge's `read(8192)` still merges multiple units into one bin16.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,16 @@
+# Protocol specifications
+
+Arcam's official RS-232 / IP control protocol PDFs, converted to Markdown by `nix run '.#fetch-specs'`. The spec PDFs are the first source of ground truth for the library implemention (modulo errors discovered in the specs.) These markdown versions are easier for LLM agents to consume than the original PDFs. Please regenerate them whenever the upstream PDFs change.
+
+Caveat: `pymupdf4llm` does not always preserve table ordering — command-reference tables may appear separated from the prose that describes them. When in doubt, consult the original PDF.
+
+## Documents
+
+- AVR5/AVR10/AVR20/AVR30/AV40/AVR11/AVR21/AVR31/AV41 — [RS232_5_10_20_30_40_11_21_31_41__SH289E_F_07Oct21.md](RS232_5_10_20_30_40_11_21_31_41__SH289E_F_07Oct21.md) ([original PDF](https://www.arcam.co.uk/ugc/tor/AVR11/Custom%20Installation%20Notes/RS232_5_10_20_30_40_11_21_31_41__SH289E_F_07Oct21.pdf))
+- SA30 — [SH306E_RS232_SA30_4.md](SH306E_RS232_SA30_4.md) ([original PDF](https://www.arcam.co.uk/ugc/tor/SA30/Custom%20Installation%20Notes/SH306E_RS232_SA30_4.pdf))
+- SA750 — [SH320E_RS232_SA750_iss1.md](SH320E_RS232_SA750_iss1.md) ([original PDF](https://www.jbl.com/on/demandware.static/-/Sites-masterCatalog_Harman/default/dwabc088c9/pdfs/SH320E_RS232_SA750_iss1.pdf))
+- PA720/PA240/PA410 — [RS232_PA720_PA240_PA410_SH305E_3.md](RS232_PA720_PA240_PA410_SH305E_3.md) ([original PDF](https://www.arcam.co.uk/ugc/tor/PA240/Custom%20Installation%20Notes/RS232_PA720_PA240_PA410_SH305E_3.pdf))
+- ST60 — [SH309_RS232_ST60_C.md](SH309_RS232_ST60_C.md) ([original PDF](https://www.arcam.co.uk/ugc/tor/ST60/Custom%20Installation%20Notes/SH309_RS232_ST60_C.pdf))
+- AV860/AVR850/AVR550/AVR390/SR250 — [RS232_860_850_550_390_250_SH274E_D_181018.md](RS232_860_850_550_390_250_SH274E_D_181018.md) ([original PDF](https://www.arcam.co.uk/ugc/tor/avr390/RS232/RS232_860_850_550_390_250_SH274E_D_181018.pdf))
+- SA10/SA20 — [SH277E_RS232_SA10_SA20_B.md](SH277E_RS232_SA10_SA20_B.md) ([original PDF](https://www.arcam.co.uk/ugc/tor/SA20/Custom%20Installation%20Notes/SH277E_RS232_SA10_SA20_B.pdf))
+- AVR750/AVR450/AVR380 — [RS232_AVR750450380_SH256E_3.md](RS232_AVR750450380_SH256E_3.md) ([original PDF](https://www.arcam.co.uk/ugc/tor/avr380/RS232/RS232_AVR750450380_SH256E_3.pdf))

--- a/docs/specs/RS232_5_10_20_30_40_11_21_31_41__SH289E_F_07Oct21.md
+++ b/docs/specs/RS232_5_10_20_30_40_11_21_31_41__SH289E_F_07Oct21.md
@@ -1,0 +1,2697 @@
+# Custom Installation Notes:
+## Serial programming interface and IR remote commands for Arcam AVR5/AVR10/AVR20/AVR30/AV40 AVR11/AVR21/ARV31/AVR41
+
+
+
+
+
+
+
+
+
+
+**Contents**
+
+**Introduction................................................................3**
+**Set-up...........................................................................3**
+**Conventions................................................................3**
+**Command and response formats...........................3**
+**Serial Cable Specification.........................................3**
+Data transfer format **.** ....................................................................3
+AMX Duet™ Support.....................................................................4
+Control 4 SDDP Support **.** ............................................................4
+Crestron Connected Support **.** ..................................................4
+Zone numbers **.** ...............................................................................4
+Answer codes **.** .................................................................................4
+State changes as a result of other inputs.............................4
+Reserved Commands...................................................................4
+**Example command and response sequence........4**
+**System Command Specifications............................5**
+Power (0x00) **.** ...................................................................................5
+Display Brightness (0x01) **.** ..........................................................5
+Headphones (0x02).......................................................................5
+FM genre (0x03) .............................................................................6
+Software version (0x04) **.** .............................................................6
+Restore factory default settings (0x05).................................6
+Save/Restore secure copy of settings (0x06) .....................7
+Simulate RC5 IR Command (0x08)..........................................7
+Display Information Type (0x09)..............................................8
+Request current source (0x1D).................................................9
+Headphone Over-ride (0x1F) **.** ..................................................9
+**Input Command Specifications ........................... 10**
+Select analogue/digital (0x0B) **.** .............................................10
+**Output Command Specifications......................... 11**
+Set/Request Volume (0x0D) **.** ..................................................11
+Request Mute status (0x0E) **.** ...................................................11
+Request direct mode status (0x0F)......................................11
+Request decode mode status — 2ch (0x10) **.** ..................12
+Request Decode mode status — MCH (0x11) **.** ...............12
+Request RDS information (0x12) **.** .........................................13
+Request Video Output Resolution (0x13) **.** ........................13
+
+
+
+**Menu Command Specifications........................... 14**
+Request menu status (0x14)...................................................14
+Request tuner preset (0x15)...................................................14
+Tune (0x16)....................................................................................14
+Request DAB station (0x18)....................................................15
+Prog. Type/Category (0x19) **.** ..................................................15
+DLS/PDT info. (0x1A)..................................................................15
+Request preset details (0x1B) **.** ...............................................16
+Network playback status (0x1C) ..........................................16
+IMAX Enhanced (0x0C).............................................................16
+**Setup Adjustment Command Specifications.... 17**
+Treble Equalisation (0x35).......................................................17
+Bass Equalisation (0x36)...........................................................17
+Room Equalisation (0x37) **.** ......................................................17
+Dolby Audio (0x38) **.** ...................................................................18
+Balance (0x3B)..............................................................................19
+Subwoofer Trim (0x3F)..............................................................19
+Lipsync Delay (0x40)..................................................................19
+Compression (0x41)...................................................................20
+Request incoming video parameters (0x42) **.** ..................20
+Request incoming audio format (0x43).............................21
+Request incoming audio sample rate (0x44) **.** .................22
+Set/Request Sub Stereo Trim (0x45) **.** ..................................22
+Set/Request Zone 1 OSD on/off (0x4E) **.** ............................23
+Set/Request Video Output Switching (0x4F) **.** .................23
+Set/request input name (0x20) **.** ............................................23
+FM Scan up/down (0x23).........................................................24
+DAB Scan (0x24) **.** .........................................................................24
+Heartbeat (0x25) **.** ........................................................................24
+Reboot (0x26)...............................................................................25
+Bluetooth status (0x50) **.** ...........................................................25
+Setup (0x27)..................................................................................26
+Room EQ name(s) (0x34) **.** ........................................................26
+Now Playing Information (0x64)...........................................27
+Input config (0x28).....................................................................28
+General Setup (0x29).................................................................29
+Speaker Types (0x2A) **.** ...............................................................31
+Speaker Distances (0x2B) **.** .......................................................32
+Speaker Levels (0x2C) **.** ..............................................................33
+Video Inputs (0x2D) **.** ..................................................................34
+HDMI settings (0x2E).................................................................34
+Zone settings (0x2F) **.** .................................................................35
+Network (0x30) **.** ...........................................................................36
+Bluetooth (0x32) **.** ........................................................................37
+Engineering menu (0x33)........................................................38
+**AV RC5 command codes........................................ 39**
+Basic Functions **.** ...........................................................................39
+Advanced Functions..................................................................40
+
+#### **Applicability**
+
+
+**Changelog**
+Issue A.0: First draft
+
+Issue B.0: Added C4 & DANTE to engineering menu control & correct 0x13
+
+Issue C.0: Removed commands 0x39/0x3A as not longer used, Auro
+commands 0x10, 0x11 & 0x28 updated. Dolby Centre spread
+removed from 0x29, Leveller & Calibration Offset removed from
+0x28. Added Auro Native & Auro 2D IR commands.
+
+Issue D.0: Added Auro channel responses to 0x43 / 0x29. Correct Bass -1 IR
+comamnd.
+
+Issue E.0: Added AVR5
+
+Issue F.o: Added AVR11, AVR21, AVR31, AV41
+
+
+
+2
+
+
+### **Controlling via RS232/NET**
+
+**Introduction**
+
+This document describes the remote control protocol for controlling via the RS232/NET interface. The AV implements virtual IR commands in order
+to simplify the protocol. Any operation that can be invoked using the IR remote control can be achieved over a control link using the Simulate RC5 IR
+command (0x08). See page 7 for details of this command. The RC5 IR code set is listed from page 39.
+
+**Set-up**
+
+The AV must be correctly configured for Control; by default, Control is disabled for minimum standby power consumption. RS232 control can be
+enabled using the front panel: press and hold the front panel **DIRECT** button for 4 seconds until “RS232 CONTROL ON” is displayed on the VFD.
+Alternatively, Control for RS232 or IP can be enabled using the OSD menu. Press A followed by U on the remote control in order to access the setup
+menu. Use the cursor keys < >, ' and O to enter the General Setup menu and locate the option _**Control**_ . Press O,, then O to change
+this parameter to ‘On’. IP control is via port 50000 of the IP address of the unit (in the Network Settings menu).
+
+**Conventions**
+
+   - All hexadecimal numbers begin 0x.
+
+   - Any character in single quotes gives the ASCII equivalent of a hex value.
+
+   - <n> represents an unknown or variable number.
+
+
+**Serial Cable Specification**
+
+
+The cable is wired as a null modem:
+
+|Connector 1 pin|Connector 2 pin|Function|
+|---|---|---|
+|2|3|Rx  Tx|
+|3|2|<br>Tx  Rx|
+|5|5|<br>RS232 Ground|
+
+
+
+**Data transfer format**
+
+   - Transfer rate: 38,400bps.
+
+   - 1 start bit, 8 data bits, 1 stop bit, no parity, no flow control.
+
+
+**Command and response formats**
+
+Communication between the remote controller (RC) and the AV takes the form of sequences of bytes, with all commands and responses having the
+same basic format. The AV shall always respond to a received command, but may also send messages at other times.
+
+
+Each transmission by the RC is the following format:
+
+<St> <Zn> <Cc> <Dl> <Data> <Et>
+
+   - St (Start transmission): 0x21 ‘!’
+
+   - Zn (Zone number): see below.
+
+   - Cc (Command code): the code for the command
+
+   - Dl (Data length): the number of data items following this item,excluding the ETR
+
+   - Data: the parameters for the command
+
+   - Et (End transmission): 0x0D
+
+
+Each response by the AVR is the following format::
+
+<St> <Zn> <Cc> <Ac> <Dl> <Data> <Et>
+
+   - St (Start transmission): 0x21 ‘!’
+
+   - Zn (Zone number): see below.
+
+   - Cc (Command code): the code for the command
+
+   - Ac (Answer code): see below.
+
+   - Dl (Data Length): the number of data items following this item, excluding the ETR
+
+   - Data: the parameters for the response of length n. n is limited to 255.
+
+   - Et (End transmission): 0x0D
+
+The AV responds to each command from the RC within three seconds. The RC may send further commands before a previous command response has
+been received.
+
+
+
+3
+
+
+**Zone numbers**
+The following zone numbers are defined:
+
+   - 0x01 – Zone number 1. (Zone 1 is the master zone. Commands that appear zone-less refer to the master zone)
+
+   - 0x02 – Zone number 2.
+
+**Answer codes**
+The following answer codes are defined:
+
+   - 0x00 – Status update.
+
+   - 0x82 – Zone Invalid.
+
+   - 0x83 – Command not recognised.
+
+   - 0x84 – Parameter not recognised.
+
+   - 0x85 – Command invalid at this time.¹
+
+   - 0x86 – Invalid data length.
+¹Certain commands cannot be processed when the Setup Menu is being displayed. An answer code of 0x85 will be returned in these circumstances. Also,
+commands for tuner control cannot be processed when the tuner input is not selected, etc.
+
+**State changes as a result of other inputs**
+It is possible that the state of the AV may be changed as a result of user input via the front panel buttons or via the IR remote control. Any change
+resulting from these inputs is relayed to the RC using the appropriate message type.
+
+For example, if the user changed the front panel display brightness using the DISPLAY button on the front panel, a display message (defined below)
+would be sent to the RC. A similar action would be taken for all other state changes (including decode mode changes).
+
+**Reserved Commands**
+
+
+Commands 0xF0 to 0xFF (inclusive) are reserved for test functions and should never be used.
+
+**Example command and response sequence**
+
+As an example, the command to simulate the RC5 command “16-16”, volume up:
+
+|STR|ZONE|CC|DL|Data 1|Data 2|ETR|
+|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x02|0x10|0x10|0x0D|
+
+
+
+Assuming that the command was accepted by the AV Receiver and is being processed, the AV responds to this command with the following sequence:
+
+|STR|ZONE|CC|AC|DL|Data 1|Data 2|ETR|
+|---|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x00|0x02|0x10|0x10|0x0D|
+
+
+
+**AMX Duet™ Support**
+The AV shall be fully compatible with AMX Duet™ Dynamic Device Discovery Protocol (DDDP) The following description of Dynamic Device
+Discovery comes from the AMX website (www.amx.com). Dynamic Device Discovery is part of AMX’s Duet™ platform, which combines the proven
+reliability and power of NetLinx with the extensive capabilities of the Java 2 Micro Edition (J2ME) platform. When integrating a serial or IP device
+from a manufacturer embedding the Dynamic Device Discovery Protocol (DDDP), Duet recognizes the device and loads the appropriate Duet
+module, which automatically installs the new device. AMX’s NetLinx Master can then find and install the Duet device module either from a library
+on the master, from AMX’s Web site, or from the manufacturer’s Web site. Duet also allows for device swapping so that programming changes are
+not required when devices with DDDP are removed or replaced – a huge benefit for end users. The Duet platform is an extension AMX’s InConcert®
+manufacturer partner program, which was developed to ensure seamless communication between partners’ devices and the AMX control system.
+
+Data is specified in the ASCII format. All ASCII characters between the quotes “” should be recognised/transmitted. “\r” is a carriage return (0x0D)
+
+Command: “AMX\r”
+
+Response:
+“AMXB<Device-SDKClass=Receiver><Device-Make=ARCAM><Device-Model=modelname><Device-Revision=x.y.z>\r”
+
+Where
+
+x.y.z = RS232 protocol version number.
+
+
+**Control 4 SDDP Support**
+The AV shall be fully compatible with the Control 4 SDDP discovery protocol.
+
+
+**Crestron Connected Support**
+The AV shall be fully compatible with the Crestron Connected discovery protocol.
+
+
+
+4
+
+
+**System Command Specifications**
+
+
+**Power (0x00)**
+Request the stand-by state of a zone.
+
+
+**Example**
+Command/response sequence to request the power state of zone 1 where
+zone 1 has power on:
+Command: 0x21 0x01 0x00 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x00 0x00 0x01 0x01 0x0D
+
+
+**Display Brightness (0x01)**
+Request the brightness of the front panel display.
+
+
+**Example**
+Command/response sequence for requesting the brightness of the display
+where the display is off:
+Command: 0x21 0x01 0x01 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x01 0x00 0x01 0x00 0x0D
+
+
+**Headphones (0x02)**
+Determine whether headphones are connected.
+
+
+**Example**
+Command/response sequence to request the headphone status where the
+headphones are not connected:
+Command: 0x21 0x01 0x02 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x02 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Dl|0x01|
+|Data|0xF0 – Request power state|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Zone is in stand-by<br>0x01 – Zone is powered on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x01|
+|Dl|0x01|
+|Data|0xF0 – Request brightness|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x01|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Front panel is off<br>0x01 – Front panel L1<br>0x02 – Front panel L2|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x02|
+|Dl|0x01|
+|Data|0xF0 – Request current headphone connection status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x02|
+|Ac|Answer code|
+|Dl|0x01 (Data length)|
+|Data|0x00 – Headphones are not connected.<br>0x01 – Headphones are connected|
+|Et|0x0D|
+
+
+
+5
+
+
+**FM genre (0x03)**
+Request information on the current station programme type from FM source
+in a given zone. If FM is not selected on the given zone an error 0x85 is
+returned.
+
+
+**Example**
+Command/response sequence to request the programme type on zone 1 where
+the programme type is “POP MUSIC”:
+Command: 0x21 0x01 0x03 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x03 0x00 0x09 0x50 0x4F 0x50 0x20 0x4D
+0x55 0x53 0x49 0x43 0x0D
+
+
+**Software version (0x04)**
+Request the version number of the various pieces of software on the AVR.
+
+
+**Example**
+Command/response sequence to request the RS232 protocol version (1.4):
+
+Command: 0x21 0x01 0x04 0x01 0xF0 0x0D
+
+Response: 0x21 0x01 0x04 0x00 0x03 0xF0 0x01 0x04 0x0D
+
+
+**Restore factory default settings (0x05)**
+Force a restore of the factory default settings.
+
+
+**Example**
+Command/response sequence to restore factory defaults:
+Command: 0x21 0x01 0x05 0x02 0xAA 0xAA 0x0D
+Response: 0x21 0x01 0x05 0x00 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x03|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – FM program type|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x03|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1 –<br>Data<n>|The radio programme type in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x04|
+|Dl|0x01|
+|Data|0xF0 – Request RS232 version<br>0xF1 – Request Host version<br>0xF2 – Request OSD version<br>0xF3 – Request DSP version<br>0xF4 – Request NET version<br>0xF5 – Request IAP version|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x04|
+|Ac|Answer code|
+|Dl|0x03|
+|Data1|Echo data from command|
+|Data2|Major version number|
+|Data3|Minor version number|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x05|
+|Dl|0x02|
+|Data1|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Data2|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x05|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+
+6
+
+
+**Save/Restore secure copy of settings (0x06)**
+Force a restore of the secure copy of the settings. Note: If no secure copy has
+been made, this command will return an answer code of 0x85.
+
+If the system is currently doing a save and another save is requested. The
+second save will fail silently. If a command 0x1E is being processed this
+command will fail with a answer code 0x85
+
+
+**Example**
+Command/response sequence to restore secure backup:
+Command: 0x21 0x01 0x06 0x07 0x01 0x55 0x55 0x01 0x02 0x03 0x040x0D
+Response: 0x21 0x01 0x06 0x00 0x00 0x0D
+
+
+**Simulate RC5 IR Command (0x08)**
+Simulate an RC5 command via the RS232 port. An additional status message
+will be sent in most cases as a result of the IR command.
+
+
+**Example**
+Command/response sequence to RC5 16-17 (AVR volume down in zone 1):
+Command: 0x21 0x01 0x08 0x02 0x10 0x11 0x0D
+Response: 0x21 0x01 0x08 0x00 0x02 0x10 0x11 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0X06|
+|Dl|0x07|
+|Data1|0x00 – Save secure backup<br>0x01 – Restore secure backup|
+|Data2|0x55 (Confirmation data pattern to avoid accidental save/restore)|
+|Data3|0x55 (Confirmation data pattern to avoid accidental save/restore)|
+|Data4|Pin digit 1|
+|Data5|Pin Digit 2|
+|Data5|Pin Digit 3|
+|Data7|Pin Digit 4|
+|Et|0x0D|
+|_RESPONSE:_|_RESPONSE:_|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x06|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+
+
+
+7
+
+
+**Display Information Type (0x09)**
+Set the VFD display information type (where applicable).
+
+The return data echoes the data sent.
+
+
+**Example**
+Command/response sequence to set the display text to show the current FM
+radio text with FM playing in zone 2:
+
+Command: 0x21 0x02 0x09 0x01 0x01 0x0D
+Response: 0x21 0x02 0x09 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x09|
+|Dl|0x01|
+|Data|**For all sources:**<br>0x00 – Set the display to Processing mode<br>0xE0 – Cycle though all displayable information.<br>0xF0 – Request the current display type<br>**If the current source is FM:**<br>0x01 – Set the display to Radio text<br>0x02 – Set the display to Programme type<br>0x03 – Set the display to Signal strength<br>**If the current source is DAB:**<br>0x01 – Set the display to Radio text<br>0x02 – Set the display to Genre<br>0x03 – Set the display to Signal quality<br>0x04 – Set the display to Bit rate<br>**If the current source is NET**<br>0x01 – Set the display to Track<br>0x02 – Set the display to Artist<br>0x03 - Set the display to Album<br>0x04 – Set the display to audio type<br>0x05 – Set the display to rate|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x09|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|The current display is returned, as for the command.|
+|Et|0x0D|
+
+
+
+8
+
+
+**Request current source (0x1D)**
+Request the source currently selected for a given zone.
+
+
+**Example**
+Command/response sequence to request the current source for Zone 1 where
+the source is set to ‘SAT’:
+
+
+Command: 0x21 0x01 0x1D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x1D 0x00 0x01 0x04 0x0D
+
+
+**Headphone Over-ride (0x1F)**
+Activate/deactivate the mute relays (does not zero the volume).
+
+
+**Example**
+Command/response sequence to activate the mute relays:
+Command: 0x21 0x01 0x1F 0x01 0x01 0x0D
+Response: 0x21 0x01 0x1F 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Dl|0x01|
+|Data|0xF0|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|The current source in the indicated zone:<br>0x00 – Follow Zone 1<br>0x01 – CD<br>0x02 – BD<br>0x03 – AV<br>0x04 – SAT<br>0x05 – PVR<br>0x06 – UHD<br>0x08 – AUX<br>0x09 – DISPLAY<br>0x0B – TUNER (FM)<br>0x0C – TUNER (DAB)<br>0x0E – NET<br>0x10 - STB<br>0x11 - GAME<br>0x12 - BT|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Dl|0x01|
+|Data|0x00 – Headphone/Over-ride Clear (speakers muted if headphones present)<br>0x01 – Headphone/Over-ride Set (speakers unmuted if headphones present)|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|Relay state|
+|Et|0x0D|
+
+
+
+9
+
+
+**Input Command Specifications**
+
+
+**Select analogue/digital (0x0B)**
+Select an analogue/digital audio input for the current source. Returns invalid
+(0x85) if OSD is showing setup screen.
+
+
+**Example**
+Command/response sequence to change the audio input to ‘digital’ in zone 1:
+Command: 0x21 0x01 0x0B 0x01 0x01 0x0D
+Response: 0x21 0x01 0x0B 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0B|
+|Dl|0x01|
+|Data|0x00 – Use the analogue audio for the current source.<br>0x01 – Use the digital audio for the current source (if available).<br>0x02 – Use HDMI for the current source (if available).<br>0xF0 – Request the audio type in use for the current source.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Response:<br>0x00 – Analogue audio is in use for the current source.<br>0x01 – Digital audio is in use for the current source.<br>0x02 – HDMI audio is in use for the current source.|
+|Et|0x0D|
+
+
+
+10
+
+
+**Output Command Specifications**
+
+
+**Set/Request Volume (0x0D)**
+Set or request the volume of a zone.
+
+This command returns the volume even if the zone requested is in mute. The
+“Request Mute status” command can be used to discover if the zone is muted.
+
+Response data format:
+e.g. for volume 42dB: Data1=0x2A (42)
+**Example**
+
+Command/response sequence for setting the volume in Zone 1 to 45dB:
+Command: 0x21 0x01 0x0D 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x0D 0x00 0x01 0x2D 0x0D
+
+
+**Request Mute status (0x0E)**
+Request the mute status of the audio in a zone.
+
+
+**Example**
+Command/response sequence to request the mute status of zone 1 where zone
+1 is muted:
+Command: 0x21 0x01 0x0E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0E 0x00 0x01 0x00 0x0D
+
+
+**Request direct mode status (0x0F)**
+Request the direct mode status on Zone 1.
+
+
+**Example**
+Command/response sequence to request the Direct mode status in zone 1
+where the mode is direct:
+Command: 0x21 0x01 0x0F 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0F 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the volume<br>0xF0 – Request the current volume|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|Zone volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Dl|0x01|
+|Data|0xF0 – Request mute status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Ac|Answer code|
+|Dl|0x01|
+|P2|0x00 – Zone is muted<br>0x01 – Zone is not muted|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0F|
+|Dl|0x01|
+|Data|0xF0 – Request mode setting|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – ‘Direct mode’ is off<br>0x01 – ‘Direct mode’ is on|
+|Et|0x0D|
+
+
+
+11
+
+
+**Request decode mode status — 2ch (0x10)**
+Request the decode mode for two-channel material in zone 1.
+
+
+**Example**
+Command/response sequence to request the decode mode in zone 1 where the
+mode is Dolby Surround Mode:
+Command: 0x21 0x01 0x10 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x10 0x00 0x01 0x04 0x0D
+
+
+**Request Decode mode status — MCH (0x11)**
+Request the decode mode for multi-channel material in zone 1.
+
+
+**Example**
+Command/response sequence to request the decode mode in zone 1 where the
+mode is Dolby Surround Mode:
+Command: 0x21 0x01 0x11 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x11 0x00 0x01 0x06 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x10|
+|Dl|0x01|
+|Data|0xF0 – Request decode mode|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x10|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x01 – Stereo<br>0x04 – Dolby Surround<br>0x07 – Neo:6 Cinema<br>0x08 – Neo:6 Music<br>0x09 - 5/7 Ch Stereo<br>0x0A - DTS Neural:X<br>0x0B - Reserved<br>0x0C - DTS Virtual:X<br>0x0D - Dolby Virtual Height<br>0x0E - Auro Native (not AVR5)<br>0x0F - Auro-Matic 3D (not AVR5)<br>0x10 - Auro-2D (not AVR5)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x11|
+|Dl|0x01|
+|Data|0xF0 – Request decode mode|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x11|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x01 – Stereo down-mix<br>0x02 – Multi-channel<br>0x03 – DTS Neural:X<br>0x06 – Dolby Surround<br>0x0B - Reserved<br>0x0C - DTS Virtual:X<br>0x0D - Dolby Virtual Height<br>0x0E - Auro Native (not AVR5)<br>0x0F - Auro-Matic 3D (not AVR5)<br>0x10 - Auro-2D (not AVR5)|
+|Et|0x0D|
+
+
+
+12
+
+
+**Request RDS information (0x12)**
+Request RDS information from the current radio station in a given zone. If FM
+is not selected on the given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence to request the RDS information on FM in zone
+1, where the response is “Playing your favourite music”.
+Command: 0x21 0x01 0x12 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x12 0x00 0x1C 0x00 0x50 0x6C 0x61 0x79
+0x69 0x6E 0x67 0x20 0x79 0x6F 0x75 0x72 0x20 0x66
+0x61 0x76 0x6F 0x75 0x72 0x69 0x74 0x65 0x20 0x6D
+0x75 0x73 0x69 0x63 0x0D
+
+
+**Request Video Output Resolution (0x13)**
+Request the Video Output Resolution of zone 1.
+**Example**
+
+Command/response sequence to request the video output in zone 1 where
+the resolution is bypass - will always be bypass (command for legacy control
+support):
+Command: 0x21 0x01 0x13 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x13 0x00 0x01 0x07 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x12|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – FM|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x12|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1 –<br>Data<n>|The radio programme type in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x13|
+|Dl|0x01|
+|Data|0xF0 – Request the video output.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x13|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x07 - bypass|
+|Et|0x0D|
+
+
+
+13
+
+
+**Menu Command Specifications**
+
+
+**Request menu status (0x14)**
+Request which (if any) menu is open in the unit.
+
+
+**Example**
+Command/response sequence to request which menu is open where the ‘Trim’
+menu is open on the front panel:
+
+Command: 0x21 0x01 0x14 0x01 0xF0 0x0D
+
+Response: 0x21 0x01 0x14 0x00 0x01 0x03 0x0D
+
+
+**Request tuner preset (0x15)**
+Request the current tuner preset number. If the tuner is not selected on the
+given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence to request the preset number where the present
+number is 10 on zone 1:
+Command: 0x21 0x01 0x15 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x15 0x00 0x01 0x0A 0x0D
+
+
+**Tune (0x16)**
+Increment/Decrement the tuner frequency in 0.05MHz steps (FM).
+
+The returned frequency is calculated as follows:
+FM freq. (MHz) = reported freq. (MHz)
+FM freq. (kHz) = reported freq. (kHz)
+
+For these reasons, this command may return values that cannot be translated
+into ASCII characters.
+
+If the tuner is not selected on the given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence to increment the FM tuning from 85.0MHz to
+85.05MHz in zone 1:
+Command: 0x21 0x01 0x16 0x01 0x01 0x0D
+Response: 0x21 0x01 0x16 0x00 0x02 0x55 0x05 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x14|
+|Dl|0x01|
+|Data|0xF0 – Request the open menu state|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x14|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – No menu is open<br>0x02 – Set-up Menu Open<br>0x03 – Trim Menu Open<br>0x04 – Bass Menu Open<br>0x05 – Treble Menu Open<br>0x06 – Sync Menu Open<br>0x07 – Sub Menu Open<br>0x08 – Tuner Menu Open<br>0x09 – Network menu Open<br>0x0A – USB Menu Open|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x15|
+|Dl|0x01|
+|Data|0x01 – 0x32 (1-50) number of required preset.<br>0xF0 – Request the current preset number.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x15|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0xFF – Currently no preset selected<br>0x01- 0x32: (1-50) the current preset number.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x16|
+|Dl|0x01|
+|Data1|0x00 – Decrement tuner frequency by 1 step.<br>0x01 – Increment tuner frequency by 1 step.<br>0xF0 – Request the current tuner frequency.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x16|
+|Ac|Answer code|
+|Dl|0x02 (Data length)|
+|Data1|FM: New frequency (MHz)|
+|Data2|FM: New frequency (10’s kHz)|
+|Et|0x0D|
+
+
+
+14
+
+
+**Request DAB station (0x18)**
+Request the current DAB station selected. If DAB is not selected on the given
+zone, an error 0x85 is returned.
+**Example**
+
+Command/response sequence to request the DAB station selection where the
+station is called “DAB STATION 2” in zone 1:
+Command: 0x21 0x01 0x18 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x18 0x00 0x10 0x44 0x41 0x42 0x20 0x53 0x54 0x41
+
+0x54 0x49 0x4F 0x4E 0x20 0x32 0x20 0x20 0x20 0x0D
+
+
+**Prog. Type/Category (0x19)**
+Request information on the current station programme type from DAB source
+in a given zone. If DAB is not selected on the given zone an error 0x85 is
+returned.
+
+
+**Example**
+Command/response sequence to request the programme type on zone 1 where
+the programme type is “POP MUSIC”:
+Command: 0x21 0x01 0x19 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x19 0x00 0x10 0x50 0x4F 0x50 0x20 0x4D
+0x55 0x53 0x49 0x43 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x0D
+
+
+**DLS/PDT info. (0x1A)**
+Request DLS/PDT information (digital radio text) from the current radio
+station in a given zone. If DAB is not selected on the given zone an error 0x85
+is returned.
+
+
+**Example**
+Command/response sequence to request the DLS information on DAB in zone
+1, where the response is “Playing your favourite music”.
+Command: 0x21 0x01 0x1A 0xF0 0x0D
+Response: 0x21 0x01 0x1A 0x00 0x80 0x00 0x50 0x6C 0x61 0x79
+0x69 0x6E 0x67 0x20 0x79 0x6F 0x75 0x72 0x20 0x66
+0x61 0x76 0x6F 0x75 0x72 0x69 0x74 0x65 0x20 0x6D
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x18|
+|Dl|0x01|
+|Data|0xF0 – Request the current DAB station|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x18|
+|Ac|Answer code|
+|Dl|Data length, fixed to 16 bytes (ASCII characters)|
+|Data1 –<br>Data128|The service label of the DAB station in ASCII characters.<br>The data is padded to 16 bytes with the space character (0x20)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x19|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – DAB program type|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x19|
+|Ac|Answer code|
+|Dl|Data length, fixed to 16 bytes (ASCII characters)|
+|Data1 –<br>Data128|The radio programme type in ASCII characters.<br>The data is padded to 16 bytes with the space character (0x20)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1A|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – DAB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1A|
+|Ac|Answer code|
+|Dl|Data length, fixed to 128 bytes (ASCII characters)|
+|Data1 –<br>Data<n>|The radio programme type in ASCII characters.<br>The data is padded to 128 bytes with the space character (0x20)|
+|Et|0x0D|
+
+
+
+15
+
+
+**Request preset details (0x1B)**
+Request details of tuner presets.
+
+
+**Example**
+Command/response sequence to request preset 1 where the response is a preset
+on DAB called “DAB STATION 2”:
+Command: 0x21 0x01 0x1B 0x01 0x01 0x0D
+Response: 0x21 0x01 0x1B 0x00 0x0F 0x01 0x02 0x44 0x41 0x42
+0x20 0x53 0x54 0x41 0x54 0x49 0x4F 0x4E 0x20 0x32
+0x0D
+
+
+**Network playback status (0x1C)**
+Network message format.
+
+If the network is not selected on the given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence where the network module is playing.
+Command: 0x21 0x01 0x1C 0x01 0xF0 0x0D
+
+
+Response: 0x21 0x01 0x1C 0x00 0x01 0x01 0x0D
+
+
+**IMAX Enhanced (0x0C) (not AVR5)**
+Controls IMAX Enhanced.
+
+
+**Example**
+Command/response sequence to set IMAX Enhanced to Auto:
+Command: 0x21 0x01 0x0C 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x0C 0x00 0x01 0x02 0x0D
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1B|
+|Dl|0x01|
+|Data|0x01- 0x32: (1-50) The number of the required preset|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1B|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1|0x01- 0x32: (1-50) The number of the requested preset|
+|Data2|0x01 : FM frequency<br>0x02 : FM RDS name<br>0x03 : DAB (AVR450/750 only)|
+|Data3<br> <br>Data4<br>Data<n>|FM: New frequency (MHz)<br>FM: New frequency (10’skHz)<br>The name (DAB,  FM if RDS)<br>in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Dl|0x01|
+|Data|0xF0 – Request Network playback status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1|0x00 – Stopped<br>0x01 – Transitioning<br>0x02 – Playing<br>0x03 – Paused|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0C|
+|Dl|0x01|
+|Data|0xF0 – Request current IMAX Enhanced state<br>0xF1 – IMAX Enhaned Auto<br>0xF2 – IMAX Enhanced On<br>0xF3 - IMAX Enhanced Off|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – IMAX Enhanced Off<br>0x01 – IMAX Enhanced On<br>0x02 – IMAX Enhanced Auto|
+|Et|0x0D|
+
+
+
+16
+
+
+**Setup Adjustment Command Specifications**
+
+
+**Treble Equalisation (0x35)**
+Adjust the amount of treble equalisation.
+
+
+**Example**
+Command/response sequence to set the treble to -2dB:
+Command: 0x21 0x01 0x35 0x01 0x82 0x0D
+Response: 0x21 0x01 0x35 0x00 0x01 0x82 0x0D
+
+
+**Bass Equalisation (0x36)**
+Adjust the amount of bass equalisation.
+
+
+**Example**
+Command/response sequence to increase the bass EQ by 1dB when it was 0dB:
+Command: 0x21 0x01 0x36 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x36 0x00 0x01 0x01 0x0D
+
+
+**Room Equalisation (0x37)**
+Turn the room equalisation system on/off.
+
+
+**Example**
+Command/response sequence to turn the room equalisation system on (EQ1):
+Command: 0x21 0x01 0x37 0x01 0x01 0x0D
+Response: 0x21 0x01 0x37 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x35|
+|Dl|0x01|
+|Data|0x00 — 0x0C – Set treble to 0dB — +12dB<br>0x81 — 0x8C – Set treble to -1dB — -12dB<br>0xF0 – Request current treble value<br>0xF1 – Increment treble by 1dB<br>0xF2 – Decrement treble by 1dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x35|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x0C – Treble is 0dB — +12dB<br>0x81 — 0x8C – Treble is -1dB — -12dB|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x36|
+|Dl|0x01|
+|Data|0x00 — 0x0C – Set bass to 0dB — +12dB<br>0x81 — 0x8C – Set bass to -1dB — -12dB<br>0xF0 – Request current bass value<br>0xF1 – Increment bass by 1dB<br>0xF2 – Decrement bass by 1dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x36|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x0C – Bass is 0dB — +12dB<br>0x81 — 0x8C – Bass is -1dB — -12dB|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x37|
+|Dl|0x01|
+|Data|0xF0 – Request current Room EQ state<br>0x00 - Room EQ off<br>0x01 – Room EQ 1 on<br>0x02 – Room EQ 2 on<br>0x03 - Room EQ 3 on|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x37|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Room EQ is off<br>0x01 – Room EQ 1 is on<br>0x02 - Room EQ 2 is on<br>0x03 - Room EQ 3 is on<br>0x04 – Room EQ has not been calculated and is therefore off|
+|Et|0x0D|
+
+
+
+17
+
+
+**Dolby Audio (0x38)**
+Control the status of the Dolby Audio system.
+
+
+**Example**
+Command/response sequence to turn the Dolby Audio system is in movie
+mode:
+Command: 0x21 0x01 0x38 0x01 0x01 0x0D
+Response: 0x21 0x01 0x38 0x00 0x01 0x02 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x38|
+|Dl|0x01|
+|Data|0x00 – Dolby Audio off<br>0x01 – Dolby Audio movie mode<br>0x02 - Dolby Audio music mode<br>0x03 - Dolby Audio night mode<br>0xF0 – Request current Dolby Audio mode|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x38|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Dolby Audio is off<br>0x01 – Dolby Audio movie mode<br>0x02 - Dolby Audio Music mode<br>0x03 - Dolby Audio night mode|
+|Et|0x0D|
+
+
+
+18
+
+
+**Balance (0x3B)**
+Adjust the balance control.
+
+
+**Example**
+Command/response sequence to set the balance to -3:
+Command: 0x21 0x01 0x3B 0x01 0x83 0x0D
+Response: 0x21 0x01 0x3B 0x00 0x01 0x83 0x0D
+
+
+**Subwoofer Trim (0x3F)**
+Adjust the value of subwoofer trim.
+
+
+**Example**
+Command/response sequence to set the subwoofer trim to -1.5dB:
+Command: 0x21 0x01 0x3F 0x01 0x85 0x0D
+Response: 0x21 0x01 0x3F 0x00 0x01 0x85 0x0D
+
+
+**Lipsync Delay (0x40)**
+Adjust the lipsync delay value.
+
+
+**Example**
+Command/response sequence to set the lipsync delay to 50ms:
+Command: 0x21 0x01 0x40 0x01 0x0A 0x0D
+Response: 0x21 0x01 0x40 0x00 0x01 0x0A 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Dl|0x01|
+|Data|0x00 — 0x06 – Set the balance to 0 — 6<br>0x81 — 0x86 – Set the balance to -1 — -6<br>0xF0 – Request current balance<br>0xF1 – Increment the balance by 1dB<br>0xF2 – Decrement the balance by 1dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x06 – Balance is 0 — 6<br>0x81 — 0x86 – Balance is -1 — -6|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3F|
+|Dl|0x01|
+|Data|0x00 — 0x14 – Set positive subwoofer trim in 0.5dB steps (e.g. 0x02 = +1.0dB)<br>0x81 — 0x94 – Set negative sub. trim in 0.5dB steps (e.g. 0x82 = -1.0dB)<br>0xF0 – Request current subwoofer trim value<br>0xF1 – Increment the subwoofer trim by 0.5dB<br>0xF2 – Decrement the subwoofer trim by 0.5dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x14 – Positive subwoofer trim in 0.5dB steps (e.g. 0x02 = +1.0dB)<br>0x81 — 0x94 – Negative subwoofer trim in 0.5dB steps (e.g. 0x82 = -1.0dB)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x40|
+|Dl|0x01|
+|Data|0x00 — 0x32 – set the lipsync delay in 5ms steps (e.g. 0x08 = 40ms)<br>0xF0 – Request current lipsync delay value<br>0xF1 – Increment the lipsync delay by 5ms<br>0xF2 – Decrement the lipsync delay by 5ms|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x40|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x32 – the lipsync delay in 5ms steps (e.g. 0x10 = 80ms)|
+|Et|0x0D|
+
+
+
+19
+
+
+**Compression (0x41)**
+Adjust the dynamic range compression setting.
+
+
+**Example**
+Command/response sequence to set compression to medium:
+Command: 0x21 0x01 0x41 0x01 0x01 0x0D
+Response: 0x21 0x01 0x41 0x00 0x01 0x01 0x0D
+
+
+**Request incoming video parameters (0x42)**
+Request the incoming video resolution, refresh rate and aspect ratio.
+
+
+**Example**
+Command/response sequence to request video parameters, where the video is
+1280x720 (720p) 50Hz 16:9, normal colourspace:
+Command: 0x21 0x01 0x42 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x42 0x00 0x08 0x05 0x00 0x02 0xD0 0x32 0x00 0x02
+
+0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x41|
+|Dl|0x01|
+|Data|0x00 – Compression off<br>0x01 – Set compression to medium<br>0x02 – Set compression to high<br>0xF0 – Request current compression setting|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x41|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Compression off<br>0x01 – medium<br>0x02 – high|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x42|
+|Dl|0x01|
+|Data|0xF0 – Request incoming video parameters|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x42|
+|Ac|Answer code|
+|Dl|0x08|
+|Data1|Horizontal resolution MSB (e.g. for 720p: 0x05 since 1280 = 0x0500)|
+|Data2|Horizontal resolution LSB (e.g. for 720p: 0x00 since 1280 = 0x0500)|
+|Data3|Vertical resolution MSB (e.g. for 720p: 0x02 since 720 = 0x02D0)|
+|Data4|Vertical resolution LSB (e.g. for 720p: 0xD0 since 720 = 0x02D0)|
+|Data5|Refresh rate for full image update (half the field rate for interlaced signals)<br>(e.g. for 50Hz progressive: 0x32)|
+|Data6|Interlaced flag:<br>0x00 – Progressive<br>0x01 – Interlaced|
+|Data7|Aspect ratio:<br>0x00 – Undefined<br>0x01 – 4:3<br>0x02 – 16:9|
+|Data 8|Colour space<br>0x00 - normal<br>0x01 - HDR10<br>0x02 - Dolby Vision<br>0x03 - HLG<br>0x04 - HDR10+ (not HDMI2.0)|
+|Et|0x0D|
+
+
+
+20
+
+
+**Request incoming audio format (0x43)**
+Request the incoming audio format.
+
+
+**Example**
+Command/response sequence to request the incoming audio format, where the
+format is Dolby Digital 5.1:
+Command: 0x21 0x01 0x43 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x43 0x00 0x02 0x02 0x1A 0x0D
+
+
+
+
+
+21
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x43|
+|Dl|0x01|
+|Data|0xF0 – Request incoming audio format|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x43|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|Audio stream format:<br>0x00 – PCM<br>0x01 – Analogue Direct<br>0x02 – Dolby Digital<br>0x03 – Dolby Digital EX<br>0x04 – Dolby Digital Surround<br>0x05 – Dolby Digital Plus<br>0x06 – Dolby Digital True HD<br>0x07 – DTS<br>0x08 – DTS 96/24<br>0x09 – DTS ES Matrix<br>0x0A – DTS ES Discrete<br>0x0B – DTS ES Matrix 96/24<br>0x0C – DTS ES Discrete 96/24<br>0x0D – DTS HD Master Audio<br>0x0E – DTS HD High Res Audio<br>0x0F – DTS Low Bit Rate<br>0x10 – DTS Core<br>0x13 – PCM Zero<br>0x14 – Unsupported<br>0x15 – Undetected<br>0x16 - Dolby Atmos<br>0x17 - DTS:X<br>0x18 - IMAX ENHANCED (not AVR5)<br>0x19 - Auro 3D (not AVR5)|
+|Data2|Audio channel configuration:<br>0x00 –  Dual Mono<br>0x01 –  Centre only<br>0x02 –  Stereo only<br>0x03 –  Stereo + mono surround<br>0x04 –  Stereo + Surround L & R<br>0x05 –  Stereo + Surround L & R + mono Surround Back<br>0x06 –  Stereo + Surround L & R + Surround Back L & R<br>0x07 –  Stereo + Surround L & R containing matrix info for surr. back L&R<br>0x08 –  Stereo + Centre<br>0x09 –  Stereo + Centre + mono surround<br>0x0A –  Stereo + Centre + Surround L & R<br>0x0B –  Stereo + Centre + Surround L & R + mono Surround Back<br>0x0C –  Stereo + Centre + Surround L & R + Surround Back L & R<br>0x0D –  Stereo + Centre + Surr. L&R  plus matrix info for surr. back L&R<br>0x0E –  Stereo Downmix Lt Rt<br>0x0F –  Stereo Only (Lo Ro)<br>0x10 –  Dual Mono + LFE<br>0x11 –  Centre + LFE<br>0x12 –  Stereo + LFE<br>0x13 –  Stereo + single surround + LFE<br>0x14 –  Stereo + Surround L & R + LFE<br>0x15 –  Stereo + Surround L & R + mono Surround Back + LFE<br>0x16 –  Stereo + Surround L & R + Surround Back L & R + LFE<br>0x17 –  Stereo + Surround L & R + LFE<br>0x18 –  Stereo + Centre + LFE plus matrix information for surr. back L&R<br>0x19 –  Stereo + Centre + single surround + LFE<br>0x1A –  Stereo + Centre + Surround L & R + LFE (Standard 5.1)<br>0x1B –   Stereo + Centre + Surr. L & R + mono Surr. Back + LFE (6.1)<br>0x1C – Stereo + Centre + Surround L & R + Surround Back L & R + LFE (7.1)<br>0x1D – Stereo + Centre + Surround L & R + LFE, plus matrix for surr. back<br>0x1E –  Stereo Downmix (Lt Rt) + LFE<br>0x1F –  Stereo Only (Lo Ro) + LFE<br>0x20 –  Unknown<br>0x21 –  Undetected<br>0x30 - Auro Quad (not AVR5)<br>0x31 - Auro 5.0 (not AVR5)<br>0x32 - Auro 5.1 (not AVR5)<br>0x33 - Auro 2.2.2 (not AVR5)<br>0x34 - Auro 8.0 (not AVR5)<br>0x35 - Auro 9.1 (not AVR5)<br>0x36 - Auro 10.1 (not AVR5)<br>0x37 - Auro 11.1 (not AVR5)<br>0x38 - Auro 13.1 (not AVR5)|
+|Et|0x0D|
+
+
+**Request incoming audio sample rate (0x44)**
+Request the incoming audio sample rate.
+
+
+**Example**
+Command/response sequence to request the incoming audio sample rate,
+where the rate is 48kHz:
+Command: 0x21 0x01 0x44 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x44 0x00 0x01 0x02 0x0D
+
+
+**Set/Request Sub Stereo Trim (0x45)**
+Set/Request the subwoofer trim value for stereo mode.
+
+
+**Example**
+Command/response sequence to set the sub stereo trim to -1.5dB:
+Command: 0x21 0x01 0x45 0x01 0x83 0x0D
+Response: 0x21 0x01 0x45 0x00 0x01 0x83 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x44|
+|Dl|0x01|
+|Data|0xF0 – Request incoming audio sample rate|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|Incoming audio sample rate:<br>0x00 – 32 KHz<br>0x01 – 44.1 KHz<br>0x02 – 48 KHz<br>0x03 – 88.2 KHz<br>0x04 – 96 KHz<br>0x05 – 176.4 KHz<br>0x06 – 192 KHz<br>0x07 – Unknown<br>0x08 – Undetected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x45|
+|Dl|0x01|
+|Data|0x00 – set the Sub Stereo Trim value to 0dB<br>0x81 — 0x94 – set the Sub Stereo Trim value to -0.5dB — -10.00dB<br>0xF0 – Request Sub Stereo Trim value<br>0xF1 – Increment Sub Stereo Trim value by 0.5dB<br>0xF2 – Decrement Sub Stereo Trim value by 0.5dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x45|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00, 0x81 — 0x94 – Sub Stereo Trim value in -0.5dB steps|
+|Et|0x0D|
+
+
+
+22
+
+
+**Set/Request Zone 1 OSD on/off (0x4E)**
+Set/Request whether the Zone 1 OSD is shown.
+
+
+**Example**
+Command/response sequence to set the Zone 1 OSD to ‘Off’:
+Command: 0x21 0x01 0x4A 0x01 0xF2 0x0D
+Response: 0x21 0x01 0x4A 0x00 0x00 0x01 0x0D
+
+
+**Set/Request Video Output Switching (0x4F)**
+Set/Request the HDMI video output selection.
+
+
+**Example**
+Command/response sequence to set the video output to HDMI output 1:
+Command: 0x21 0x01 0x4F 0x01 0x02 0x0D
+Response: 0x21 0x01 0x4F 0x00 0x01 0x02 0x0D
+
+
+**Set/request input name (0x20)**
+This command returns the name of an input if renamed by the user. It can also
+be used to set the input name.
+
+
+**Example**
+Command/response sequence for setting the current input to “BDP300”:
+Command: 0x21 0x01 0x20 0x06 0x42 0x44 0x50 0x33 0x30 0x30
+0x0D
+Response: 0x20 0x01 0x20 0x00 0x06 0x42 0x44 0x50 0x33 0x30
+0x30 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4E|
+|Dl|0x01|
+|Data|0xF0 – Request current Zone 1 OSD on/off state.<br>0xF1 – Set Zone 1 OSD to On.<br>0xF2 – Set Zone 1 OSD to Off.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4E|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Zone 1 OSD is On.<br>0x01 – Zone 1 OSD is Off.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4F|
+|Dl|0x01|
+|Data|0x02 – Set HDMI Output 1.<br>0x03 – Set HDMI Output 2.<br>0x04 – Set HDMI Output 1 & 2.<br>0xF0 – Request current video output switching setting.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x02 – HDMI Output 1.<br>0x03 – HDMI Output 2.<br>0x04 – HDMI Output 1 & 2.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x20|
+|Dl|0x01 (query) or <n> (limited to 10 characters) for setting name|
+|Data|F0 - query<br>1-<n>|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x20|
+|Ac|Answer code|
+|Dl|Data length - <n> if setting,  0x0A if requesting the name|
+|Data1 -<br>Data <n>|Input name in ASCII characters|
+|Et|0x0D|
+
+
+
+23
+
+
+**FM Scan up/down (0x23)**
+Initiates a FM scan up or down. Note: only valid if on FM input
+
+
+**Example**
+Command/response to starting a FM scan up:
+Command: 0x21 0x01 0x23 0x01 0x01 0x0D
+Response: 0x21 0x01 0x23 0x00 0x01 0xFF 0x0D
+
+
+**DAB Scan (0x24)**
+Initiates a DAB scan. Note: only valid if on DAB input
+
+
+**Example**
+Command/response to starting a DAB scan:
+Command: 0x21 0x01 0x24 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x24 0x00 0x01 0xFF 0x0D
+
+
+**Heartbeat (0x25)**
+Heartbeat command to check unit is still connected and communication - also
+resets the EuP standby timer.
+
+
+**Example**
+Command/response to sending a heartbeat command:
+Command: 0x21 0x01 0x25 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x25 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x23|
+|Dl|0x01|
+|Data|0x01 - Scan up<br>0x02 - Scan down|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x23|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0xFF - scanning|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x24|
+|Dl|0x01|
+|Data|0xF0 - Start DAB scan|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x24|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0xFF - scanning<br>0x00 - Scan finished|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x25|
+|Dl|0x01|
+|Data|0xF0 - Heartbeat|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x25|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 - response|
+|Et|0x0D|
+
+
+
+24
+
+
+**Reboot (0x26)**
+Forces a reboot of the unit.
+
+
+**Example**
+Command/response to sending a reboot command:
+Command: 0x21 0x01 0x26 0x06 0x52 0x45 0x42 0x4F 0x4F 0x54
+0x0D
+Response: 0x21 0x01 0x26 0x01 0x00 0x0D
+
+
+**Bluetooth status (0x50)**
+Bluetooth status. Note: only valid if on BT input
+
+
+**Example**
+Command/response to starting a BT status request, where the response is
+paired, audio paused:
+Command: 0x21 0x01 0x50 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x50 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x26|
+|Dl|0x06|
+|Data1|0x52|
+|Data2|0x45|
+|Data3|0x42|
+|Data4|0x4F|
+|Data5|0x4F|
+|Data6|0x54|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x26|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 - response|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x50|
+|Dl|0x01|
+|Data|0xF0 - BT status request|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x50|
+|Ac|Answer code|
+|Dl|Dat a length <n>|
+|Data1|0x00 - No connection<br>0x01 - Connected, audio paused<br>0x02 - Connected, audio playing SBC<br>0x03 - Connected, audio playing AAC<br>0x04 - Connected, audio playing aptX<br>0x05 - Connected, audio playing aptX-HD|
+|Data2 –<br>Data<n>|name of track in ASCII if playing or paused|
+|Et|0x0D|
+
+
+
+25
+
+
+**Setup (0x27)**
+Starts remote setup of the unit.
+
+
+**Room EQ name(s) (0x34)**
+Request Room EQ name(s).
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x27|
+|Dl|0x01|
+|Data1|0xF0|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x27|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0xnn - setup mode active, nn = version of menu<br>0xFF - setup mode from front panel, remote setup not possible|
+|Et|0x0D|
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x34|
+|Dl|0x01|
+|Data1|0xF0 - request EQ names|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x34|
+|Ac|Answer code|
+|Dl|0xn - dependant on number of EQ slots filled, 20, 40, 60|
+|Data1-20<br>Data21-40<br>Data41-60|EQ1 name (read only / 20 characters)<br>name in ASCII characters<br>EQ2 name (read only / 20 characters)<br>name in ASCII characters<br>EQ3 name (read only / 20 characters)<br>name in ASCII characters|
+|Et|0x0D|
+
+
+
+26
+
+
+**Now Playing Information (0x64)**
+
+
+Request the various now playing track details
+
+**Example**
+
+
+Command/response sequence to request the currently playing artist where
+the response is A
+Command: 0x21 0x01 0x64 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x64 0x00 0x02 0x41 0x0D
+
+**Note**
+
+
+Response length is limited to 100 characters
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x64|
+|Dl|0x01|
+|Data|0xF0 – Request the currently playing track title<br>0xF1 - Request the currently playing artist<br>0xF2 - Request the currently playing album<br>0xF3 - Request the currently playing application (GoogleCast only)<br>0xF4 - Request the currently playing sample rate<br>0xF5 - Request the currently playing track encoder|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x64|
+|Ac|Answer code|
+|Dl|<n>|
+|Data|Track:<br>Track title in ASCII characters<br>Album:<br>Album name in ASCII characters<br>Artist:<br>Artist name in ASCII characters<br>Application:<br>GoogleCast source application in ASCII characters<br>Sample rate:<br>0x00 – 32 kHz<br>0x01 – 44.1 kHz<br>0x02 – 48 kHz<br>0x03 – 88.2 kHz<br>0x04 – 96 kHz<br>0x05 – 176.4 kHz<br>0x06 – 192 kHz<br>0x07 – Unknown<br>0x08 – Undetected<br>Audio encoder:<br>0x00 – MP3<br>0x01 – WAV<br>0x02 – WMA<br>0x03 – FLAC<br>0x04 - ALAC<br>0x05 – MQA<br>0x0A – Unknown|
+|Et|0x0D|
+
+
+
+27
+
+
+**Input config (0x28)**
+Sends input config menu info.
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x28|
+|Dl|0x01 / 0x19|
+|Data1<br>Data 1-25|0xF0 - request Input config<br>set input config as below|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x28|
+|Ac|Answer code|
+|Dl|0x19|
+|Data1-10<br>Data11<br>Data12<br>Data13<br>Data14<br>Data15<br>Data16<br>Data17<br>Data18<br>Data19<br>Data20<br>Data21<br>Data22<br>Data23<br>Data24<br>Data25|Input name<br>0xnn - Input name in ASCII characters<br>Lip Sync<br>0x00 - 0x32 Lip sync in 5mS steps<br>Mode<br>0x00 - Last mode<br>0x01 - Stereo<br>0x02 - Stereo Direct<br>0x03 - Dolby Surround<br>0x04 - DTS Neural:X<br>0x05 - Virtual Height<br>0x06 - 16 Ch Stereo Mode<br>0x07 - Auro 2D Surround (not AVR5)<br>0x08 - Reserved<br>0x09 - Auro 3D (not AVR5)<br>0x0A - Auro Native (not AVR5)<br>MCH mode<br>0x00 - Last mode<br>0x01 - Native<br>0x02 - Stereo Downmix<br>0x03 - Virtual Height<br>0x04 - Native Upmixer (Dolby Surround, DTS Virtual:X)<br>0x05 - Reserved<br>0x06 - Auro 2D Surround (not AVR5)<br>0x07 - Auro 3D (not AVR5)<br>0x08 - Auro Native (not AVR5)<br>Bass<br>0x00 - 0x0C – Bass is 0dB — +12dB<br>0x81 - 0x8C – Bass is -1dB — -12dB<br>Treble<br>0x00 - 0x0C – Treble is 0dB — +12dB<br>0x81 - 0x8C – Treble is -1dB — -12dB<br>Room EQ<br>0x00 - Room EQ off<br>0x01 - Room EQ1, 0x02 - Room EQ2, 0x03 - Room EQ3<br>0x04 - Not calculated<br>Input Trim<br>0x00 - 1V<br>0x01 - 2V<br>0x02 - 4V<br>Dolby Audio<br>0x00 - Dolby Audio off<br>0x01 - Dolby Audio movie, 0x02 - music, 0x03 - night<br>Stereo mode<br>0x00 - Left/Right<br>0x01 -  Left/Right+Sub<br>0x02 - Sub+Sat<br>0x03 - As speaker types<br>Sub Stereo<br>0x00 - 0dB<br>0x81 — 0x94 – Sub Stereo is -0.5 — -10dB<br>IMAX Enhanced mode (not AVR5)<br>0x00 - Auto<br>0x01 - On<br>0x02 - Off<br>Auro-Matic 3D (not AVR5)<br>0x00 - Small, 0x01 - Medium, 0x02 - Large, 0x03 - Movie, 0x04 - Speech<br>Auro-Matic Strength (not AVR5)<br>0x00 - 0x10 - 0-16<br>Audio Source<br>0x00 – Analogue audio is in use for the current source.<br>0x01 – Digital audio is in use for the current source.<br>0x02 – HDMI audio is in use for the current source.<br>CD Direct<br>0x00 - CD Direct off, 0x01 - CD Direct on|
+|Et|0x0D|
+
+
+
+28
+
+
+**General Setup (0x29)**
+Sends general setup menu info.
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x29|
+|Dl|0x01 / 0x20|
+|Data1<br>Data 1-32|0xF0 - request Input config<br>set input config as below|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x29|
+|Ac|Answer code|
+|Dl|0x20|
+|Data1-10<br>Data11<br>Data12|0xnn - Input name in ASCII characters<br>Audio stream format:<br>0x00 – PCM<br>0x01 – Analogue Direct<br>0x02 – Dolby Digital<br>0x03 – Dolby Digital EX<br>0x04 – Dolby Digital Surround<br>0x05 – Dolby Digital Plus<br>0x06 – Dolby Digital True HD<br>0x07 – DTS<br>0x08 – DTS 96/24<br>0x09 – DTS ES Matrix<br>0x0A – DTS ES Discrete<br>0x0B – DTS ES Matrix 96/24<br>0x0C – DTS ES Discrete 96/24<br>0x0D – DTS HD Master Audio<br>0x0E – DTS HD High Res Audio<br>0x0F – DTS Low Bit Rate<br>0x10 – DTS Core<br>0x13 – PCM Zero<br>0x14 – Unsupported<br>0x15 – Undetected<br>0x16 - Dolby Atmos<br>0x17 - DTS:X<br>0x18 - IMAX ENHANCED (not AVR5)<br>0x19 - Auro 3D (not AVR5)<br>Audio channel configuration:<br>0x00 –  Dual Mono<br>0x01 –  Centre only<br>0x02 –  Stereo only<br>0x03 –  Stereo + mono surround<br>0x04 –  Stereo + Surround L & R<br>0x05 –  Stereo + Surround L & R + mono Surround Back<br>0x06 –  Stereo + Surround L & R + Surround Back L & R<br>0x07 –  Stereo + Surround L & R containing matrix information for surround<br> <br>back L&R<br>0x08 –  Stereo + Centre<br>0x09 –  Stereo + Centre + mono surround<br>0x0A –  Stereo + Centre + Surround L & R<br>0x0B –  Stereo + Centre + Surround L & R + mono Surround Back<br>0x0C –  Stereo + Centre + Surround L & R + Surround Back L & R<br>0x0D –  Stereo + Centre + Surround L & R  containing matrix information for<br> <br>surround back L&R<br>0x0E –  Stereo Downmix Lt Rt<br>0x0F –  Stereo Only (Lo Ro)<br>0x10 –  Dual Mono + LFE<br>0x11 –  Centre + LFE<br>0x12 –  Stereo + LFE<br>0x13 –  Stereo + single surround + LFE<br>0x14 –  Stereo + Surround L & R + LFE<br>0x15 –  Stereo + Surround L & R + mono Surround Back + LFE<br>0x16 –  Stereo + Surround L & R + Surround Back L & R + LFE<br>0x17 –  Stereo + Surround L & R + LFE<br>0x18 –  Stereo + Centre + LFE containing matrix information for<br> <br> <br>surround back L&R<br>0x19 –  Stereo + Centre + single surround + LFE<br>0x1A –  Stereo + Centre + Surround L & R + LFE (Standard 5.1)<br>0x1B –   Stereo + Centre + Surround L & R + mono Surround Back + LFE<br> <br>(6.1, e.g.  DTS ES Discrete)<br>0x1C – Stereo + Centre + Surround L & R + Surround Back L & R + LFE (7.1)<br>0x1D – Stereo + Centre + Surround L & R + LFE, containing matrix<br> <br> <br>information for surround back L&R (6.1 e.g. Dolby Digital EX)<br>0x1E –  Stereo Downmix (Lt Rt) + LFE<br>0x1F –  Stereo Only (Lo Ro) + LFE<br>0x20 –  Unknown<br>0x21 –  Undetected|
+
+
+
+29
+
+
+30
+
+
+**Speaker Types (0x2A)**
+Set / request speaker type menu info.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x2A|
+|Dl|0x01 / 0x0D|
+|Data1<br>Data 1-10|0xF0 - request Speaker Types<br>set Speaker Types as below|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x2A|
+|Ac|Answer code|
+|Dl|0x0D|
+|Data1-6<br>1=L/R<br>2=Centre<br>3=Surr.<br>4=Back<br>5=Height1<br>6=Height2<br>Data7<br>Data8<br>Data9<br>Data10<br>Data11|Speaker type<br>0x00 - Large<br>0x01 - Small, 40Hz<br>0x02 - Small, 50Hz<br>0x03 - Small, 60Hz<br>0x04 - Small, 70Hz<br>0x05 - Small, 80Hz<br>0x06 - Small, 90Hz<br>0x07 - Small, 100Hz<br>0x08 - Small, 110Hz<br>0x09 - Small, 120Hz<br>0x0A - Small, 150Hz<br>0x0B - Small, 160Hz<br>0x0C - Small, 170Hz<br>0x0D - Small, 180Hz<br>0x0E - Small, 180Hz<br>0x0F - Small, 200Hz<br>0x10 - None<br>Subwoofer<br>0x00 - Subwoofer<br>0x01 - None<br>Channel 13 & 14 (not AVR5, AVR10 - report 0x11)<br>0x00 - Front wides, large<br>0x01 - Front wide, small, 40Hz<br>0x02 - Front wide, small, 50Hz<br>0x03 - Front wide, small, 60Hz<br>0x04 - Front wide, small, 70Hz<br>0x05 - Front wide, small, 80Hz<br>0x06 - Front wide, small, 90Hz<br>0x07 - Front wide, small, 100Hz<br>0x08 - Front wide, small, 110Hz<br>0x09 - Front wide, small, 120Hz<br>0x0A - Front wide, small, 150Hz<br>0x0B - Front wide, small, 160Hz<br>0x0C - Front wide, small, 170Hz<br>0x0D - Front wide, small, 180Hz<br>0x0E - Front wide, small, 190Hz<br>0x0F - Front wide, small, 200Hz<br>0x10 - Front subs<br>0x11 - None<br>Channel 15 & 16 (not AVR5, AVR10, report 0x21)<br>0x00 - Middle heights, large, 0x10 - CH & TS large<br>0x01 - Middle heights, small, 40Hz, 0x10 - CH & TS, small, 40Hz<br>0x02 - Middle heights, small, 50Hz, 0x12 - CH & TS, small, 50Hz<br>0x03 - Middle heights, small, 60Hz, 0x13 - CH & TS, small, 60Hz<br>0x04 - Middle heights, small, 70Hz, 0x14 - CH & TS, small, 70Hz<br>0x05 - Middle heights, small, 80Hz, 0x15 - CH & TS, small, 80Hz<br>0x06 - Middle heights, small, 90Hz, 0x16 - CH & TS, small, 90Hz<br>0x07 - Middle heights, small, 100Hz, 0x17 - CH & TS, small, 100Hz<br>0x08 - Middle heights, small, 110Hz, 0x18 - CH & TS, small, 110Hz<br>0x09 - Middle heights, small, 120Hz, 0x19 - CH & TS, small, 120Hz<br>0x0A - Middle heights, small, 150Hz, 0x1A - CH & TS, small, 150Hz<br>0x0B - Middle heights, small, 160Hz, 0x1B - CH & TS, small, 160Hz<br>0x0C - Middle heights, small, 170Hz, 0x1C - CH & TS, small, 170Hz<br>0x0D - Middle heights, small, 180Hz, 0x1D - CH & TS, small, 180Hz<br>0x0E - Middle heights, small, 190Hz, 0x1E - CH & TS, small, 190Hz<br>0x0F - Middle heights, small, 200Hz, 0x1F - CH & TS, small, 200Hz<br>0x20 - Rear subs<br>0x21 - None<br>Height type<br>0x00 - Top<br>0x01 - Dolby Enabled<br>Use channel 6&7<br>0x00 - Surround back<br>0x01 - Bi-Amp L+R<br>0x02 - Zone2 (not AVR5, AVR10)<br>0x03 - Height1|
+
+
+
+31
+
+
+|Data12<br>Data13|Filter slope<br>0x00 - 12dB<br>0x01 - 24dB<br>0x02 - 36dB<br>0x03 - 48dB<br>Sub gain<br>0x00 - 0dB<br>0x01 - -6dB<br>0x02 - -12dB<br>0x03 - -18dB<br>0x04 - -24dB<br>0x05 - -30dB|
+|---|---|
+|Et|0x0D|
+
+
+
+**Speaker Distances (0x2B)**
+Set / request speaker distance menu info.
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x2B|
+|Dl|0x01 / 0x21|
+|Data1<br>Data 1-33|0xF0 - request Speaker Distance<br>set Speaker Distance as below|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x2B|
+|Ac|Answer code|
+|Dl|0x21|
+|Data1<br>Data2-33|Units<br>0x00 - metres<br>0x01 - feet<br>0x02 - mS<br>Distance in 2 bytes per speaker (m:cm / ft:in)<br>Front Left<br>Centre<br>Front Right<br>Surr. Right<br>Surr. Back Right<br>Surr. Back Left<br>Surr. Left<br>Left Top Front<br>Right Top Front<br>Left Top Back<br>Right Top Back<br>Subwoofer<br>Channel13 (not AVR5, AVR10, reports 0x00, 0x00)<br>Channel14 (not AVR5, AVR10, reports 0x00, 0x00)<br>Channel15 (not AVR5, AVR10, reports 0x00, 0x00)<br>Channel 16 (not AVR5, AVR10, reports 0x00, 0x00)|
+|Et|0x0D|
+
+
+
+32
+
+
+**Speaker Levels (0x2C)**
+Set / request speaker level menu info.
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x2C|
+|Dl|0x01 / 0x12|
+|Data1<br>Data 1-16|0xF0 - request Speaker Levels<br>set Speaker Levels as below|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x2C|
+|Ac|Answer code|
+|Dl|0x12|
+|Data1<br>Data2-17<br>Data18|Test tone<br>0x00 - Internal<br>0x01 - External<br>Speaker level<br>0x00 — 0x14 –0dB — +10dB<br>0x81 — 0x94 –0.5dB — -10dB<br>Front Left, Centre<br>Front Right<br>Surr. Right<br>Surr. Back Right<br>Surr. Back Left<br>Surr. Left<br>Left Top Front<br>Right Top Front<br>Left Top Back<br>Right Top Back<br>Subwoofer<br>Channel13 (not AVR5, AVR10, reports 0x14)<br>Channel14 (not AVR5, AVR10, reports 0x14)<br>Channel15 (not AVR5, AVR10, reports 0x14)<br>Channel 16 (not AVR5, AVR10, reports 0x14)<br>Noise output<br>0x00 - None (switch off audio noise output)<br>0x01 - Front Left<br>0x02 - Centre<br>0x03 - Front Right<br>0x04 - Surr. Right<br>0x05 - Surr. Back Right<br>0x06 - Surr. Back Left<br>0x07 - Surr. Left<br>0x08 - Left Top Front<br>0x09 - Right Top Front<br>0x0A - Left Top Back<br>0x0B - Right Top Back<br>0x0C - Subwoofer<br>0x0D - Channel 13 (not AVR5, AVR10)<br>0x0E - Channel 14 (not AVR5, AVR10)<br>0x0F - Channel 15 (not AVR5, AVR10)<br>0x10 - Channel 16 (not AVR5, AVR10)|
+|Et|0x0D|
+
+
+
+33
+
+
+**Video Inputs (0x2D)**
+Set / request speaker level menu info.
+
+
+**HDMI settings (0x2E)**
+Set / request HDMI settings menu info.
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x2D|
+|Dl|0x01 / 0x06|
+|Data1<br>Data 1-16|0xF0 - request Video Inputs config<br>set Video Inputs as below|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x2D|
+|Ac|Answer code|
+|Dl|0x06|
+|Data1-6|Video input in order for:<br>Data1-CD, Data2-Aux, Data3-FM, Data4-DAB, Data5-NET, Data6-BT<br>0x00 - STB<br>0x01 - GAME<br>0x02 - AV<br>0x03 - SAT<br>0x04 - BD<br>0x05 - VCR<br>0x06 - PVR<br>0x07 - None|
+|Et|0x0D|
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x2|
+|Dl|0x01 / 0x0A|
+|Data1<br>Data 1-09|0xF0 - request HDMI config<br>set HDMI config as below|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x2E|
+|Ac|Answer code|
+|Dl|0x0A|
+|Data1<br>Data2<br>Data3<br>Data4<br>Data5<br>Data6<br>Data7<br>Data8<br>Data9<br>Data10|Zone 1 OSD<br>0x00 - Off<br>0x01 - On<br>Zone 1 Out<br>0x00 - Out 1 & 2<br>0x01 - Out 1<br>0x02 - Out 2<br>Zone 1 lip sync (information only)<br>0x00 - 0xFA lipsync in 1mS steps<br>HDMI Audio to TV<br>0x00 - Off<br>0x01 - On<br>HDMI Bypass & IP<br>0x00 - Off<br>0x01 - HDMI & IP On<br>HDMI Bypass source<br>0x00 - Last<br>0x01 - STB<br>0x02 - Game<br>0x03 - AV<br>0x04 - SAT<br>0x05 - BD<br>0x06 - VCR<br>0x07 - PVR<br>CEC Control<br>0x00 - Off<br>0x01 - Output1<br>ARC Control<br>0x00 - Off<br>0x01 - Auto<br>TV Audio<br>0x00 - Off<br>0x01 - Auto<br>Power Off Control<br>0x00 - Off<br>0x01 - Auto|
+|Et|0x0D|
+
+
+
+34
+
+
+**Zone settings (0x2F) (not AVR5, AVR10)**
+Set / request Zone settings menu info.
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x2F|
+|Dl|0x01 / 0x06|
+|Data1<br>Data 1-10|0xF0 - request Zone settings<br>set Zone settings as below|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x2F|
+|Ac|Answer code|
+|Dl|0x06|
+|Data1<br>Data2<br>Data3<br>Data4<br>Data5<br>Data6|Zone 2 Input (not AVR5, AVR10)<br>0x00 - Follow Zone1<br>0x01 - CD<br>0x02 - BD<br>0x03 - AV<br>0x04 - SAT<br>0x05 - PVR<br>0x06 - VCR<br>0x07 - STB<br>0x08 - Game<br>0x09 - FM<br>0x0A - DAB<br>0x0B - NET<br>0x0C - BT<br>0x0D - Aux<br>0x0E - Display<br>Zone 2 Status<br>0x00 - Standby<br>0x01 - On<br>Zone 2 Volume<br>0x14 (20) – 0x53 (83)<br>Zone 2 Max. Volume<br>0x14 (20) – 0x53 (83)<br>Zone 2 fixed volume<br>0x00 - No<br>0x01 - Yes<br>Zone 2 Maximum On Volume<br>0x14 (20) – 0x53 (83)|
+|Et|0x0D|
+
+
+
+35
+
+
+**Network (0x30)**
+Set / request Network menu info.
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x30|
+|Dl|0x01 / 0x45|
+|Data1<br>Data 1-69|0xF0 - request Network settings<br>set Network settings as below|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x30|
+|Ac|Answer code|
+|Dl|0x45|
+|Data1<br>Data2-21<br>Data22-41<br>Data42-45<br>Data46-49<br>Data50-69|Net source<br>0x00 - Follow Zone1<br>0x01 - Follow Zone2<br>SSID name (20 character limit)<br>Network key (20 character limit - set only)<br>IP address<br>0x00-0xFF<br>MAC address<br>0x00 -0xFF<br>Friendly name (20 characters)<br>name in ASCII characters|
+|Et|0x0D|
+
+
+
+36
+
+
+**Bluetooth (0x32)**
+Set / request Bluetooth menu info.
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x32|
+|Dl|0x01 / 0x02 / 0xnn|
+|Data1<br>Data 1-2|0xF0 - request Bluetooth settings<br>set Bluetooth settings as below (only pair & clear can be set)|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x32|
+|Ac|Answer code|
+|Dl|0xn - dependant on number of paired devices|
+|Data1<br>Data2<br>Data3-22<br>Data23-42<br>Data43-<br><n>|Pair Device (set only)<br>0x00 - no effect<br>0x01 - Start Pair Device<br>Clear Paired Devices (set only)<br>0x00 - no effect<br>0x01 - Clear Paired Devices<br>Paired device1 name (read only / 20 characters)<br>name in ASCII characters<br>Paired device2 name (read only / 20 characters)<br>name in ASCII characters<br>Paired device3-8 name (read only / 20 characters)<br>name in ASCII characters|
+|Et|0x0D|
+
+
+
+37
+
+
+**Engineering menu (0x33)**
+Set / request Engineering menu info.
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x33|
+|Dl|0x01 / 0x33|
+|Data1<br>Data 1-|0xF0 - request Engineering menu settings<br>set Engineering menu settings as below|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x33|
+|Ac|Answer code|
+|Dl|0x2B|
+|Data1<br>Data2<br>Data3<br>Data4<br>Data5<br>Data6<br>Data7-10<br>Data11<br>Data12<br>Data13<br>Data14<br>Data15<br>Data16<br>Data17<br>Data18<br>Data19<br>Data20<br>Data21-29<br>Data30-33<br>Data34-37<br>Data38-51|Reset Factory Defaults (set only)<br>0x00 - no effect<br>0x01 - Reset factory defaults<br>Check for update (set only)<br>0x00 - no effect<br>0x01 - Check for Update<br>Restore Secure backup<br>0x00 - no effect<br>0x01 - Restore secure backup<br>Store Secure Backup<br>0x00 - no effect<br>0x01 - Store secure backup<br>Restore USB backup<br>0x00 - no effect<br>0x01 - Restore USB backup<br>Store USB Backup<br>0x00 - no effect<br>0x01 - Store USB<br>Pin in hex 1-4<br>Region<br>0x00 - Europe<br>0x01 - US<br>0x02 - Canada<br>0x03 - Australia<br>0x04 - China<br>Remote Code<br>0x00 - 16<br>0x01 - 19<br>Standby Mode<br>0x00 - Auto<br>0x01 - Manual<br>Protection sensitivity<br>0x00 - High (default)<br>0x01 - Medium<br>0x02 - Low<br>Use Display HDMI<br>0x00 - Yes<br>0x01 - No<br>Display type<br>0x00 - 16:9<br>0x01 - 21:9<br>DANTE enable<br>0x00 - Off<br>0x01 - On<br>C4 SDDP<br>0x00 - Off<br>0x01 - On<br>Send C4 Identify<br>0x00 - No effect<br>0x01 - Send C4 Identify<br>Shut down code (info only)<br>0x00 - 00 (normal)<br>0x01 - 01 (amp DC offset)<br>0x02 - 02 (amp overtemp)<br>0x03 - 03 (amp overcurrent)<br>Host/IAP version (info only)<br>Version in ASCII e.g. “2.01/0.03”<br>DSP version (info only)<br>Version in ASCII e.g. “1.03”<br>OSD version (info only)<br>Version in ASCII e.g. “0.11”<br>NET version (info only)<br>Version in ASCII e.g. “2.5.13.50017-6”|
+|Et|0x0D|
+
+
+
+38
+
+
+**AV RC5 command codes**
+
+These codes are recognised as infra-red signals received by the front panel,
+RC5 electrical signals received by the remote in jacks and as control data using
+the ‘Simulate RC5 IR Command’ (0x 08).
+
+**Basic Functions**
+These RC5 codes are present on the supplied IR remote control and provide
+control over basic amplifier and video processing functions.
+
+
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|BD|16-98|0x10 - 0x62|
+|CD|16-118|0x10 - 0x76|
+|STB|16-100|0x10 - 0x64|
+|UHD|16-125|0x10 - 0x7D|
+|BT|16-122|0x10 - 0x7A|
+|Display|16-58|0x10 - 0x3A|
+|Power On|16-123|0x10 - 0x7B|
+|Power Off|16-124|0x10 - 0x7C|
+
+
+|Function|RC5 code<br>[system-<br>command]|RC5 code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Standby|16-12|0x10 - 0x0C|
+|Eject (Speaker trim)|16-45|0x10 - 0x2D|
+|1|16-1|0x10 - 0x01|
+|2|16-2|0x10 - 0x02|
+|3|16-3|0x10 - 0x03|
+|4|16-4|0x10 - 0x04|
+|5|16-5|0x10 - 0x05|
+|6|16-6|0x10 - 0x06|
+|7|16-7|0x10 - 0x07|
+|8|16-8|0x10 - 0x08|
+|9|16-9|0x10 - 0x09|
+|SYNC - Access Lipsync Delay control|16-50|0x10 - 0x32|
+|0|16-0|0x10 - 0x00|
+|INFO - Cycle between VFD information panels|16-55|0x10 - 0x37|
+|Rewind|16-121|0x10 - 0x79|
+|Fast Forward|16-52|0x10 - 0x34|
+|Skip Back|16-33|0x10 - 0x21|
+|Skip Forward|16-11|0x10 - 0x0B|
+|Stop|16-54|0x10 - 0x36|
+|Play|16-53|0x10 - 0x35|
+|Pause|16-48|0x10 - 0x30|
+|Disc (Record) (DTS dialogue control)|16-90|0x10 - 0x5A|
+|MENU (Enter system menu)|16-82|0x10 - 0x52|
+|Navigate Up|16-86|0x10 - 0x56|
+|Pop Up (Dolby Volume on/off)|16-70|0x10 - 0x46|
+|Navigate Left|16-81|0x10 - 0x51|
+|OK|16-87|0x10 - 0x57|
+|Navigate Right|16-80|0x10 - 0x50|
+|Audio (Room EQ on/off)|16-30|0x10 - 0x1E|
+|Navigate Down|16-85|0x10 - 0x55|
+|RTN (Access Subwoofer Trim control)|16-51|0x10 - 0x33|
+|HOME|16-43|0x10 - 0x2B|
+|Mute|16-13|0x10 - 0x0D|
+|Increase volume (+)|16-16|0x10 - 0x10|
+|MODE (Cycle between decoding modes)|16-32|0x10 - 0x20|
+|DISP (Change VFD brightness)|16-59|0x10 - 0x3B|
+|Activate DIRECT mode|16-10|0x10 - 0x0A|
+|Decrease volume (-)|16-17|0x10 - 0x11|
+|Red|16-41|0x10 - 0x29|
+|Green|16-42|0x10 - 0x2A|
+|Yellow|16-43|0x10 - 0x2B|
+|Blue|16-55|0x10 - 0x37|
+|Radio|16-91|0x10 - 0x5B|
+|Aux|16-99|0x10 - 0x63|
+|Net|16-92|0x10 - 0x5C|
+|AV|16-94|0x10 - 0x5E|
+|Sat|16-27|0x10 - 0x1B|
+|PVR|16-96|0x10 - 0x60|
+|Game|16-97|0x10 - 0x61|
+
+
+
+39
+
+
+**Advanced Functions**
+These RC5 codes are not present on the supplied remote control but have been
+created for custom install use. In order for the AVR to respond to these codes
+they must be transmitted from a programmable IR remote control or over the
+control link using the ‘Simulate RC5 IR Command’ (0x08).
+
+
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Zone 2 Power Off (not AVR5, AVR10)|23-124|0x17 - 0x7C|
+|Zone 2 Vol+ (not AVR5, AVR10)|23-1|0x17 - 0x01|
+|Zone 2 Vol-(not AVR5, AVR10)|23-2|0x17 - 0x02|
+|Zone 2 Mute (not AVR5, AVR10)|23-3|0x17 - 0x03|
+|Zone 2 Mute On (not AVR5, AVR10)|23-4|0x17 - 0x04|
+|Zone 2 Mute Off (not AVR5, AVR10)|23-5|0x17 - 0x05|
+|Zone 2 CD (not AVR5, AVR10)|23-6|0x17 - 0x06|
+|Zone 2 BD (not AVR5, AVR10)|23-7|0x17 - 0x07|
+|Zone 2 STB (not AVR5, AVR10)|23-8|0x17 - 0x08|
+|Zone 2 AV (not AVR5, AVR10)|23-9|0x17 - 0x09|
+|Zone 2 Game (not AVR5, AVR10)|23-11|0x17 - 0x0B|
+|Zone 2 Aux (not AVR5, AVR10)|23-13|0x17 - 0x0D|
+|Zone 2 PVR (not AVR5, AVR10)|23-15|0x17 - 0x0F|
+|Zone 2 FM (not AVR5, AVR10)|23-14|0x17 - 0x0E|
+|Zone 2 DAB (not AVR5, AVR10)|23-16|0x17 - 0x10|
+|Zone 2 USB (not AVR5, AVR10)|23-18|0x17 - 0x12|
+|Zone 2 NET (not AVR5, AVR10)|23-19|0x17 - 0x13|
+|Zone 2 SAT (not AVR5, AVR10)|23-20|0x17 - 0x14|
+|Zone 2 UHD (not AVR5, AVR10)|23-23|0x17 - 0x17|
+|Zone 2 BT (not AVR5, AVR10)<br>|23-22<br>|0x17 - 0x16<br>|
+|Select HDMI Out 1<br>|16-73<br>|0x10 - 0x49<br>|
+|Select HDMI Out 2<br>|16-74<br>|0x10 - 0x4A<br>|
+|Select HDMI Out 1 & 2|16-75|0x10 - 0x4B|
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Change control to next zone|16-95|0x10 - 0x5F|
+|Access Bass control|16-39|0x10 - 0x27|
+|Access Speaker Trim controls|16-37|0x10 - 0x25|
+|Access Treble control<br>|16-14<br>|0x10 - 0x0E<br>|
+|Random<br>|16-76<br>|0x10 - 0x4C<br>|
+|Repeat<br>|16-49<br>|0x10 - 0x31<br>|
+|Direct mode On<br>|16-78<br>|0x10 - 0x4E<br>|
+|Direct mode Off<br>|16-79<br>|0x10 - 0x4F<br>|
+|Multi Channel<br>|16-106<br>|0x10 - 0x6A<br>|
+|Stereo<br>|16-107<br>|0x10 - 0x6B<br>|
+|Dolby Surround<br>|16-110<br>|0x10 - 0x6E<br>|
+|DTS Neo:6 Cinema<br>|16-111<br>|0x10 - 0x6F<br>|
+|DTS Neo:6 Music<br>|16-112<br>|0x10 - 0x70<br>|
+|DTS Neural:X<br>|16-113<br>|0x10 - 0x71<br>|
+|Reserved<br>|16-114<br>|0x10 - 0x72<br>|
+|Virtual Height<br>|16-115<br>|0x10 - 0x73<br>|
+|5/7 Ch Stereo<br>|16-69<br>|0x10 - 0x45<br>|
+|Dolby D EX|16-23|0x10 - 0x17|
+|Auro Matic-3D|16-71|0x10 - 0x47|
+|Auro Native|16-103|0x10 - 0x67|
+|Auro 2D|16-104|0x10 - 0x68|
+|Mute On|16-26|0x10 - 0x1A|
+|Mute Off|16-120|0x10 - 0x78|
+|FM|16-28|0x10 - 0x1C|
+|DAB|16-72|0x10 - 0x48|
+|Lip Sync +5ms|16-15|0x10 - 0x0F|
+|Lip sync -5ms|16-101|0x10 - 0x65|
+|Sub trim +0.5dB|16-105|0x10 - 0x69|
+|Sub trim -0.5dB|16-108|0x10 - 0x6C|
+|Display Off|16-31|0x10 - 0x1F|
+|Display L1|16-34|0x10 - 0x22|
+|Display L2|16-35|0x10 - 0x23|
+|Balance left|16-38|0x10 - 0x26|
+|Balance right|16-40|0x10 - 0x28|
+|Bass +1|16-44|0x10 - 0x2C|
+|Bass -1|16-56|0x10 - 0x38|
+|Treble +1|16-46|0x10 - 0x2E|
+|Treble -1|16-102|0x10 - 0x66|
+|Set Zone 2 to Follow Zone 1|16-20|0x10 - 0x14|
+|Zone 2 Power On (not AVR5, AVR10)|23-123|0X17 - 0x7B|
+
+
+
+40
+
+
+## 23425
+
+**SH289E Issue E** **WATERBEACH, CAMBRIDGE CB25 9PB, England**
+
+**+44 (0)1223 203200** **http://www.arcam.co.uk**
+
+
+
+41
+
+

--- a/docs/specs/RS232_860_850_550_390_250_SH274E_D_181018.md
+++ b/docs/specs/RS232_860_850_550_390_250_SH274E_D_181018.md
@@ -1,0 +1,2342 @@
+# Custom Installation Notes:
+## Serial programming interface and IR remote commands for Arcam AVR390/AVR550/AVR850/AV860/SR250
+
+
+**Contents**
+
+**Introduction................................................................3**
+**Set-up...........................................................................3**
+**Conventions................................................................3**
+**Command and response formats...........................3**
+**Serial Cable Specification.........................................3**
+
+Data transfer format **.** ....................................................................3
+AMX Duet™ Support.....................................................................4
+Zone numbers **.** ...............................................................................4
+Answer codes **.** .................................................................................4
+State changes as a result of other inputs.............................4
+Reserved Commands...................................................................4
+**Example command and response sequence........4**
+**System Command Specifications............................5**
+
+Power (0x00) **.** ...................................................................................5
+Display Brightness (0x01) **.** ..........................................................5
+Headphones (0x02).......................................................................5
+FM genre (0x03) .............................................................................6
+Software version (0x04) **.** .............................................................6
+Restore factory default settings (0x05).................................6
+Save/Restore secure copy of settings (0x06) .....................7
+Simulate RC5 IR Command (0x08)..........................................7
+Display Information Type (0x09)..............................................8
+Request current source (0x1D).................................................9
+Headphone Over-ride (0x1F) **.** ..................................................9
+**Input Command Specifications ........................... 10**
+
+Video selection (0x0A) **.** .............................................................10
+Select analogue/digital (0x0B) **.** .............................................10
+**Output Command Specifications......................... 11**
+
+Set/Request Volume (0x0D) **.** ..................................................11
+Request Mute status (0x0E) **.** ...................................................11
+Request direct mode status (0x0F)......................................11
+Request decode mode status — 2ch (0x10) **.** ..................12
+Request Decode mode status — MCH (0x11) **.** ...............12
+Request RDS information (0x12) **.** .........................................13
+Request Video Output Resolution (0x13) **.** ........................13
+
+
+
+**Menu Command Specifications........................... 14**
+
+Request menu status (0x14)...................................................14
+Request tuner preset (0x15)...................................................14
+Tune (0x16)....................................................................................14
+Request DAB station (0x18)....................................................15
+Prog. Type/Category (0x19) **.** ..................................................15
+DLS/PDT info. (0x1A)..................................................................15
+Request preset details (0x1B) **.** ...............................................16
+Network playback status (0x1C) ..........................................16
+IMAX Enhanced (0x0C).............................................................16
+**Setup Adjustment Command Specifications.... 17**
+
+Treble Equalisation (0x35).......................................................17
+Bass Equalisation (0x36)...........................................................17
+Room Equalisation (0x37) **.** ......................................................17
+Dolby Volume (0x38).................................................................18
+Dolby Leveller (0x39).................................................................18
+Dolby Volume Calibration Offset (0x3A) **.** ..........................18
+Balance (0x3B)..............................................................................19
+Subwoofer Trim (0x3F)..............................................................19
+Lipsync Delay (0x40)..................................................................19
+Compression (0x41)...................................................................20
+Request incoming video parameters (0x42) **.** ..................20
+Request incoming audio format (0x43).............................21
+Request incoming audio sample rate (0x44) **.** .................22
+Set/Request Sub Stereo Trim (0x45) **.** ..................................22
+Set/Request Zone 1 OSD on/off (0x4E) **.** ............................23
+Set/Request Video Output Switching (0x4F) **.** .................23
+Set/request input name (0x20) **.** ............................................23
+FM Scan up/down (0x23).........................................................24
+DAB Scan (0x24) **.** .........................................................................24
+Heartbeat (0x25) **.** ........................................................................24
+Reboot (0x26)...............................................................................25
+**AV RC5 command codes........................................ 26**
+
+Basic Functions **.** ...........................................................................26
+Advanced Functions..................................................................26
+
+#### **Applicability**
+
+
+**Changelog**
+Issue A.0: First draft
+
+Issue B.0: Typo in command 0x43 fixed (R#1694)
+
+Issue C.0: Command 0x3F step size corrected (M#18990)
+
+Neural:X support
+
+AVR390/AV860 Added
+
+Treble - RC5 direct command corrected
+
+issue D.0: Added reserved mode command. Added DTS Virtual:X command
+to IR & commands 0x10 & 0x11. Added IMAX ENHANCED to
+command 0x43 & created command 0x0C. Valid for unit code
+v7.13 and above.
+
+
+
+2
+
+
+### **Controlling via RS232/NET**
+
+**Introduction**
+
+This document describes the remote control protocol for controlling via the RS232/NET interface. The AV implements virtual IR commands in order
+to simplify the protocol. Any operation that can be invoked using the IR remote control can be achieved over a control link using the Simulate RC5 IR
+command (0x08). See page 7 for details of this command. The RC5 IR code set is listed from page 26.
+
+
+**Set-up**
+
+The AV must be correctly configured for Control; by default, Control is disabled for minimum standby power consumption. RS232 control can be
+enabled using the front panel: press and hold the front panel **DIRECT** button for 4 seconds until “RS232 CONTROL ON” is displayed on the VFD.
+Alternatively, Control for RS232 or IP can be enabled using the OSD menu. Press A followed by U on the remote control in order to access the setup
+menu. Use the cursor keys < >, ' and O to enter the General Setup menu and locate the option _**Control**_ . Press O,, then O to change
+this parameter to ‘On’. IP control is via port 50000 of the IP address of the unit (in the Network Settings menu).
+
+
+**Conventions**
+
+   -  All hexadecimal numbers begin 0x.
+
+   -  Any character in single quotes gives the ASCII equivalent of a hex value.
+
+   -  <n> represents an unknown or variable number.
+
+
+**Serial Cable Specification**
+
+
+The cable is wired as a null modem:
+
+|Connector 1 pin|Connector 2 pin|Function|
+|---|---|---|
+|2|3|Rx  Tx|
+|3|2|<br>Tx  Rx|
+|5|5|<br>RS232 Ground|
+
+
+
+**Data transfer format**
+
+   -  Transfer rate: 38,400bps.
+
+   -  1 start bit, 8 data bits, 1 stop bit, no parity, no flow control.
+
+
+**Command and response formats**
+
+Communication between the remote controller (RC) and the AV takes the form of sequences of bytes, with all commands and responses having the
+same basic format. The AV shall always respond to a received command, but may also send messages at other times.
+
+
+Each transmission by the RC is the following format:
+
+<St> <Zn> <Cc> <Dl> <Data> <Et>
+
+   -  St (Start transmission): 0x21 ‘!’
+
+   -  Zn (Zone number): see below.
+
+   -  Cc (Command code): the code for the command
+
+   -  Dl (Data length): the number of data items following this item,excluding the ETR
+
+   -  Data: the parameters for the command
+
+   -  Et (End transmission): 0x0D
+
+
+Each response by the AVR is the following format::
+
+<St> <Zn> <Cc> <Ac> <Dl> <Data> <Et>
+
+   -  St (Start transmission): 0x21 ‘!’
+
+   -  Zn (Zone number): see below.
+
+   -  Cc (Command code): the code for the command
+
+   -  Ac (Answer code): see below.
+
+   -  Dl (Data Length): the number of data items following this item, excluding the ETR
+
+   -  Data: the parameters for the response of length n. n is limited to 255.
+
+   -  Et (End transmission): 0x0D
+
+The AV responds to each command from the RC within three seconds. The RC may send further commands before a previous command response has
+been received.
+
+
+
+3
+
+
+**Zone numbers**
+
+The following zone numbers are defined:
+
+   -  0x01 – Zone number 1. (Zone 1 is the master zone. Commands that appear zone-less refer to the master zone)
+
+   -  0x02 – Zone number 2.
+
+**Answer codes**
+
+The following answer codes are defined:
+
+   -  0x00 – Status update.
+
+   -  0x82 – Zone Invalid.
+
+   -  0x83 – Command not recognised.
+
+   -  0x84 – Parameter not recognised.
+
+   -  0x85 – Command invalid at this time.¹
+
+   -  0x86 – Invalid data length.
+¹Certain commands cannot be processed when the Setup Menu is being displayed. An answer code of 0x85 will be returned in these circumstances. Also,
+commands for tuner control cannot be processed when the tuner input is not selected, etc.
+
+**State changes as a result of other inputs**
+
+It is possible that the state of the AV may be changed as a result of user input via the front panel buttons or via the IR remote control. Any change
+resulting from these inputs is relayed to the RC using the appropriate message type.
+
+For example, if the user changed the front panel display brightness using the DISPLAY button on the front panel, a display message (defined below)
+would be sent to the RC. A similar action would be taken for all other state changes (including decode mode changes).
+
+**Reserved Commands**
+
+
+Commands 0xF0 to 0xFF (inclusive) are reserved for test functions and should never be used.
+
+
+**Example command and response sequence**
+
+As an example, the command to simulate the RC5 command “16-16”, volume up:
+
+|STR|ZONE|CC|DL|Data 1|Data 2|ETR|
+|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x02|0x10|0x10|0x0D|
+
+
+
+Assuming that the command was accepted by the AV Receiver and is being processed, the AV responds to this command with the following sequence:
+
+|STR|ZONE|CC|AC|DL|Data 1|Data 2|ETR|
+|---|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x00|0x02|0x10|0x10|0x0D|
+
+
+
+**AMX Duet™ Support**
+
+The AV shall be fully compatible with AMX Duet™ Dynamic Device Discovery Protocol (DDDP) The following description of Dynamic Device
+Discovery comes from the AMX website (www.amx.com). Dynamic Device Discovery is part of AMX’s Duet™ platform, which combines the proven
+reliability and power of NetLinx with the extensive capabilities of the Java 2 Micro Edition (J2ME) platform. When integrating a serial or IP device
+from a manufacturer embedding the Dynamic Device Discovery Protocol (DDDP), Duet recognizes the device and loads the appropriate Duet
+module, which automatically installs the new device. AMX’s NetLinx Master can then find and install the Duet device module either from a library
+on the master, from AMX’s Web site, or from the manufacturer’s Web site. Duet also allows for device swapping so that programming changes are
+not required when devices with DDDP are removed or replaced – a huge benefit for end users. The Duet platform is an extension AMX’s InConcert®
+manufacturer partner program, which was developed to ensure seamless communication between partners’ devices and the AMX control system.
+
+Data is specified in the ASCII format. All ASCII characters between the quotes “” should be recognised/transmitted. “\r” is a carriage return (0x0D)
+
+Command: “AMX\r”
+
+AV860 Response:
+“AMXB<Device-SDKClass=Receiver><Device-Make=ARCAM><Device-Model=AV860><Device-Revision=x.y.z>\r”
+
+AVR850 Response:
+“AMXB<Device-SDKClass=Receiver><Device-Make=ARCAM><Device-Model=AVR850><Device-Revision=x.y.z>\r”
+
+AVR550 Response:
+“AMXB<Device-SDKClass=Receiver><Device-Make=ARCAM><Device-Model=AVR550><Device-Revision=x.y.z>\r”
+
+AVR390 Response:
+“AMXB<Device-SDKClass=Receiver><Device-Make=ARCAM><Device-Model=AVR390><Device-Revision=x.y.z>\r”
+
+SR250 Response:
+“AMXB<Device-SDKClass=Receiver><Device-Make=ARCAM><Device-Model=SR250><Device-Revision=x.y.z>\r”
+
+Where
+
+x.y.z = RS232 protocol version number.
+
+
+
+4
+
+
+**System Command Specifications**
+
+
+**Power (0x00)**
+Request the stand-by state of a zone.
+
+
+**Example**
+Command/response sequence to request the power state of zone 1 where
+zone 1 has power on:
+
+Command: 0x21 0x01 0x00 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x00 0x00 0x01 0x01 0x0D
+
+
+**Display Brightness (0x01)**
+Request the brightness of the front panel display.
+
+
+**Example**
+Command/response sequence for requesting the brightness of the display
+where the display is off:
+
+Command: 0x21 0x01 0x01 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x01 0x00 0x01 0x00 0x0D
+
+
+**Headphones (0x02)**
+Determine whether headphones are connected.
+
+
+**Example**
+Command/response sequence to request the headphone status where the
+headphones are not connected:
+
+Command: 0x21 0x01 0x02 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x02 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Dl|0x01|
+|Data|0xF0 – Request power state|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Zone is in stand-by<br>0x01 – Zone is powered on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x01|
+|Dl|0x01|
+|Data|0xF0 – Request brightness|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x01|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Front panel is off<br>0x01 – Front panel L1<br>0x02 – Front panel L2|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x02|
+|Dl|0x01|
+|Data|0xF0 – Request current headphone connection status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x02|
+|Ac|Answer code|
+|Dl|0x01 (Data length)|
+|Data|0x00 – Headphones are not connected.<br>0x01 – Headphones are connected|
+|Et|0x0D|
+
+
+
+5
+
+
+**FM genre (0x03)**
+Request information on the current station programme type from FM source
+in a given zone. If FM is not selected on the given zone an error 0x85 is
+returned.
+
+
+**Example**
+Command/response sequence to request the programme type on zone 1 where
+the programme type is “POP MUSIC”:
+
+Command: 0x21 0x01 0x03 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x03 0x00 0x09 0x50 0x4F 0x50 0x20 0x4D
+0x55 0x53 0x49 0x43 0x0D
+
+
+**Software version (0x04)**
+Request the version number of the various pieces of software on the AVR.
+
+
+**Example**
+Command/response sequence to request the RS232 protocol version (1.4):
+
+Command: 0x21 0x01 0x04 0x01 0xF0 0x0D
+
+Response: 0x21 0x01 0x04 0x00 0x03 0xF0 0x01 0x04 0x0D
+
+
+**Restore factory default settings (0x05)**
+Force a restore of the factory default settings.
+
+
+**Example**
+Command/response sequence to restore factory defaults:
+
+Command: 0x21 0x01 0x05 0x02 0xAA 0xAA 0x0D
+Response: 0x21 0x01 0x05 0x00 0x00 0x0D
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x03|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – FM program type|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x03|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1 –<br>Data<n>|The radio programme type in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x04|
+|Dl|0x01|
+|Data|0xF0 – Request RS232 version<br>0xF1 – Request Host version<br>0xF2 – Request OSD version<br>0xF3 – Request DSP version<br>0xF4 – Request NET version<br>0xF5 – Request IAP version|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x04|
+|Ac|Answer code|
+|Dl|0x03|
+|Data1|Echo data from command|
+|Data2|Major version number|
+|Data3|Minor version number|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x05|
+|Dl|0x02|
+|Data1|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Data2|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x05|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+
+6
+
+
+**Save/Restore secure copy of settings (0x06)**
+Force a restore of the secure copy of the settings. Note: If no secure copy has
+been made, this command will return an answer code of 0x85.
+
+If the system is currently doing a save and another save is requested. The
+second save will fail silently. If a command 0x1E is being processed this
+command will fail with a answer code 0x85
+
+
+**Example**
+Command/response sequence to restore secure backup:
+
+Command: 0x21 0x01 0x06 0x07 0x01 0x55 0x55 0x01 0x02 0x03 0x040x0D
+Response: 0x21 0x01 0x06 0x00 0x00 0x0D
+
+
+**Simulate RC5 IR Command (0x08)**
+Simulate an RC5 command via the RS232 port. An additional status message
+will be sent in most cases as a result of the IR command.
+
+
+**Example**
+Command/response sequence to RC5 16-17 (AVR volume down in zone 1):
+
+Command: 0x21 0x01 0x08 0x02 0x10 0x11 0x0D
+Response: 0x21 0x01 0x08 0x00 0x02 0x10 0x11 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0X06|
+|Dl|0x07|
+|Data1|0x00 – Save secure backup<br>0x01 – Restore secure backup|
+|Data2|0x55 (Confirmation data pattern to avoid accidental save/restore)|
+|Data3|0x55 (Confirmation data pattern to avoid accidental save/restore)|
+|Data4|Pin digit 1|
+|Data5|Pin Digit 2|
+|Data5|Pin Digit 3|
+|Data7|Pin Digit 4|
+|Et|0x0D|
+|_RESPONSE:_|_RESPONSE:_|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x06|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+
+
+
+7
+
+
+**Display Information Type (0x09)**
+Set the VFD display information type (where applicable).
+
+The return data echoes the data sent.
+
+
+**Example**
+Command/response sequence to set the display text to show the current FM
+radio text with FM playing in zone 2:
+
+Command: 0x21 0x02 0x09 0x01 0x01 0x0D
+Response: 0x21 0x02 0x09 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x09|
+|Dl|0x01|
+|Data|**For all sources:**<br>0x00 – Set the display to Processing mode<br>0xE0 – Cycle though all displayable information.<br>0xF0 – Request the current display type<br>**If the current source is FM:**<br>0x01 – Set the display to Radio text<br>0x02 – Set the display to Programme type<br>0x03 – Set the display to Signal strength<br>**If the current source is DAB (AVR450/750 only):**<br>0x01 – Set the display to Radio text<br>0x02 – Set the display to Genre<br>0x03 – Set the display to Signal quality<br>0x04 – Set the display to Bit rate<br>**If the current source is NET/USB**<br>0x01 – Set the display to Track<br>0x02 – Set the display to Artist<br>0x03 - Set the display to Album<br>0x04 – Set the display to audio type<br>0x05 – Set the display to rate|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x09|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|The current display is returned, as for the command.|
+|Et|0x0D|
+
+
+
+8
+
+
+**Request current source (0x1D)**
+Request the source currently selected for a given zone.
+
+
+**Example**
+Command/response sequence to request the current source for Zone 1 where
+the source is set to ‘SAT’:
+
+
+Command: 0x21 0x01 0x1D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x1D 0x00 0x01 0x04 0x0D
+
+
+**Headphone Over-ride (0x1F)**
+Activate/deactivate the mute relays (does not zero the volume).
+
+
+**Example**
+Command/response sequence to activate the mute relays:
+
+Command: 0x21 0x01 0x1F 0x01 0x01 0x0D
+Response: 0x21 0x01 0x1F 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Dl|0x01|
+|Data|0xF0|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|The current source in the indicated zone:<br>0x00 – Follow Zone 1<br>0x01 – CD<br>0x02 – BD<br>0x03 – AV<br>0x04 – SAT<br>0x05 – PVR<br>0x06 – VCR<br>0x08 – AUX<br>0x09 – DISPLAY<br>0x0B – TUNER (FM)<br>0x0C – TUNER (DAB)**(AVR450/750 only)**<br>0x0E – NET<br>0x0F – USB<br>0x10 - STB<br>0x11 - GAME|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Dl|0x01|
+|Data|0x00 – Headphone/Over-ride Clear (speakers muted if headphones present)<br>0x01 – Headphone/Over-ride Set (speakers unmuted if headphones present)|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|Relay state|
+|Et|0x0D|
+
+
+
+9
+
+
+**Input Command Specifications**
+
+
+**Video selection (0x0A)**
+Changes the video input. Returns invalid (0x85) if OSD is showing setup
+screen.
+
+
+**Example**
+Command/response sequence to change the video source for zone 1 to ‘PVR’:
+
+Command: 0x21 0x01 0x0A 0x01 0x03 0x0D
+Response: 0x21 0x01 0x0A 0x00 0x01 0x03 0x0D
+
+
+**Select analogue/digital (0x0B)**
+Select an analogue/digital audio input for the current source. Returns invalid
+(0x85) if OSD is showing setup screen.
+
+
+**Example**
+Command/response sequence to change the audio input to ‘digital’ in zone 1:
+
+Command: 0x21 0x01 0x0B 0x01 0x01 0x0D
+Response: 0x21 0x01 0x0B 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0A|
+|Dl|0x01|
+|Data|Source:<br>0x00 – BD<br>0x01 – SAT<br>0x02 – AV<br>0x03 – PVR<br>0x04 – VCR<br>0x05 - Game<br>0x06 - STB<br>0xF0 – Request current input|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0A|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Response:<br>The current video source is returned, as for the command|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0B|
+|Dl|0x01|
+|Data|0x00 – Use the analogue audio for the current source.<br>0x01 – Use the digital audio for the current source (if available).<br>0x02 – Use HDMI for the current source (if available).<br>0xF0 – Request the audio type in use for the current source.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Response:<br>0x00 – Analogue audio is in use for the current source.<br>0x01 – Digital audio is in use for the current source.<br>0x02 – HDMI audio is in use for the current source.|
+|Et|0x0D|
+
+
+
+10
+
+
+**Output Command Specifications**
+
+
+**Set/Request Volume (0x0D)**
+Set or request the volume of a zone.
+
+This command returns the volume even if the zone requested is in mute. The
+“Request Mute status” command can be used to discover if the zone is muted.
+
+Response data format:
+e.g. for volume 42dB: Data1=0x2A (42)
+**Example**
+
+Command/response sequence for setting the volume in Zone 1 to 45dB:
+
+Command: 0x21 0x01 0x0D 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x0D 0x00 0x01 0x2D 0x0D
+
+
+**Request Mute status (0x0E)**
+Request the mute status of the audio in a zone.
+
+
+**Example**
+Command/response sequence to request the mute status of zone 1 where zone
+1 is muted:
+
+Command: 0x21 0x01 0x0E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0E 0x00 0x01 0x00 0x0D
+
+
+**Request direct mode status (0x0F)**
+Request the direct mode status on Zone 1.
+
+
+**Example**
+Command/response sequence to request the Direct mode status in zone 1
+where the mode is direct:
+
+Command: 0x21 0x01 0x0F 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0F 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the volume<br>0xF0 – Request the current volume|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|Zone volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Dl|0x01|
+|Data|0xF0 – Request mute status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Ac|Answer code|
+|Dl|0x01|
+|P2|0x00 – Zone is muted<br>0x01 – Zone is not muted|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0F|
+|Dl|0x01|
+|Data|0xF0 – Request mode setting|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – ‘Direct mode’ is off<br>0x01 – ‘Direct mode’ is on|
+|Et|0x0D|
+
+
+
+11
+
+
+**Request decode mode status — 2ch (0x10)**
+Request the decode mode for two-channel material in zone 1.
+
+
+**Example**
+Command/response sequence to request the decode mode in zone 1 where the
+mode is Dolby Surround Mode:
+
+Command: 0x21 0x01 0x10 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x10 0x00 0x01 0x04 0x0D
+
+
+**Request Decode mode status — MCH (0x11)**
+Request the decode mode for multi-channel material in zone 1.
+
+
+**Example**
+Command/response sequence to request the decode mode in zone 1 where the
+mode is Dolby Surround Mode:
+
+Command: 0x21 0x01 0x11 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x11 0x00 0x01 0x06 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x10|
+|Dl|0x01|
+|Data|0xF0 – Request decode mode|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x10|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x01 – Stereo<br>0x04 – Dolby Surround<br>0x07 – Neo:6 Cinema<br>0x08 – Neo:6 Music<br>0x09 - 5/7 Ch Stereo<br>0x0A - DTS Neural:X<br>0x0B - Reserved<br>0x0C - DTS Virtual:X|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x11|
+|Dl|0x01|
+|Data|0xF0 – Request decode mode|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x11|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x01 – Stereo down-mix<br>0x02 – Multi-channel mode<br>0x03 – DTS-ES / Neural:X mode<br>0x06 – Dolby Surround mode<br>0x0B - Reserved<br>0x0C - DTS Virtual:X|
+|Et|0x0D|
+
+
+
+12
+
+
+**Request RDS information (0x12)**
+Request RDS information from the current radio station in a given zone. If FM
+is not selected on the given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence to request the RDS information on FM in zone
+1, where the response is “Playing your favourite music”.
+
+Command: 0x21 0x01 0x12 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x12 0x00 0x1C 0x00 0x50 0x6C 0x61 0x79
+0x69 0x6E 0x67 0x20 0x79 0x6F 0x75 0x72 0x20 0x66
+0x61 0x76 0x6F 0x75 0x72 0x69 0x74 0x65 0x20 0x6D
+0x75 0x73 0x69 0x63 0x0D
+
+
+**Request Video Output Resolution (0x13)**
+Request the Video Output Resolution of zone 1.
+**Example**
+
+Command/response sequence to request the video output in zone 1 where the
+resolution is 1080p:
+
+Command: 0x21 0x01 0x13 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x13 0x00 0x01 0x05 0x0D
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x12|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – FM|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x12|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1 –<br>Data<n>|The radio programme type in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x13|
+|Dl|0x01|
+|Data|0xF0 – Request the video output.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x13|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x02 – SD Progressive.<br>0x03 – 720p.<br>0x04 – 1080i.<br>0x05 – 1080p<br>0x06 – ‘Preferred’<br>0x07 – Bypass<br>0x08 - 4k|
+|Et|0x0D|
+
+
+
+13
+
+
+**Menu Command Specifications**
+
+
+**Request menu status (0x14)**
+Request which (if any) menu is open in the unit.
+
+
+**Example**
+Command/response sequence to request which menu is open where the ‘Trim’
+menu is open:
+
+Command: 0x21 0x01 0x14 0x01 0xF0 0x0D
+
+Response: 0x21 0x01 0x14 0x00 0x01 0x03 0x0D
+
+
+**Request tuner preset (0x15)**
+Request the current tuner preset number. If the tuner is not selected on the
+given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence to request the preset number where the present
+number is 10 on zone 1:
+
+Command: 0x21 0x01 0x15 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x15 0x00 0x01 0x0A 0x0D
+
+
+**Tune (0x16)**
+Increment/Decrement the tuner frequency in 0.05MHz steps (FM).
+
+The returned frequency is calculated as follows:
+
+FM freq. (MHz) = reported freq. (MHz)
+FM freq. (kHz) = reported freq. (kHz)
+
+For these reasons, this command may return values that cannot be translated
+into ASCII characters.
+
+If the tuner is not selected on the given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence to increment the FM tuning from 85.0MHz to
+85.05MHz in zone 1:
+
+Command: 0x21 0x01 0x16 0x01 0x01 0x0D
+Response: 0x21 0x01 0x16 0x00 0x02 0x55 0x05 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x14|
+|Dl|0x01|
+|Data|0xF0 – Request the open menu state|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x14|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – No menu is open<br>0x02 – Set-up Menu Open<br>0x03 – Trim Menu Open<br>0x04 – Bass Menu Open<br>0x05 – Treble Menu Open<br>0x06 – Sync Menu Open<br>0x07 – Sub Menu Open<br>0x08 – Tuner Menu Open<br>0x09 – Network menu Open<br>0x0A – USB Menu Open|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x15|
+|Dl|0x01|
+|Data|0x01 – 0x32 (1-50) number of required preset.<br>0xF0 – Request the current preset number.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x15|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0xFF – Currently no preset selected<br>0x01- 0x32: (1-50) the current preset number.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x16|
+|Dl|0x01|
+|Data1|0x00 – Decrement tuner frequency by 1 step.<br>0x01 – Increment tuner frequency by 1 step.<br>0xF0 – Request the current tuner frequency.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x16|
+|Ac|Answer code|
+|Dl|0x02 (Data length)|
+|Data1|FM: New frequency (MHz)|
+|Data2|FM: New frequency (10’s kHz)|
+|Et|0x0D|
+
+
+
+14
+
+
+**Request DAB station (0x18)**
+Request the current DAB station selected. If DAB is not selected on the given
+zone, an error 0x85 is returned.
+**Example**
+
+Command/response sequence to request the DAB station selection where the
+station is called “DAB STATION 2” in zone 1:
+
+Command: 0x21 0x01 0x18 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x18 0x00 0x10 0x44 0x41 0x42 0x20 0x53 0x54 0x41
+
+0x54 0x49 0x4F 0x4E 0x20 0x32 0x20 0x20 0x20 0x0D
+
+
+**Prog. Type/Category (0x19)**
+Request information on the current station programme type from DAB source
+in a given zone. If DAB is not selected on the given zone an error 0x85 is
+returned.
+
+
+**Example**
+Command/response sequence to request the programme type on zone 1 where
+the programme type is “POP MUSIC”:
+
+Command: 0x21 0x01 0x19 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x19 0x00 0x10 0x50 0x4F 0x50 0x20 0x4D
+0x55 0x53 0x49 0x43 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x0D
+
+
+**DLS/PDT info. (0x1A)**
+Request DLS/PDT information (digital radio text) from the current radio
+station in a given zone. If DAB is not selected on the given zone an error 0x85
+is returned.
+
+
+**Example**
+Command/response sequence to request the DLS information on DAB in zone
+1, where the response is “Playing your favourite music”.
+
+Command: 0x21 0x01 0x1A 0xF0 0x0D
+Response: 0x21 0x01 0x1A 0x00 0x80 0x00 0x50 0x6C 0x61 0x79
+0x69 0x6E 0x67 0x20 0x79 0x6F 0x75 0x72 0x20 0x66
+0x61 0x76 0x6F 0x75 0x72 0x69 0x74 0x65 0x20 0x6D
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x0D
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x18|
+|Dl|0x01|
+|Data|0xF0 – Request the current DAB station|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x18|
+|Ac|Answer code|
+|Dl|Data length, fixed to 16 bytes (ASCII characters)|
+|Data1 –<br>Data128|The service label of the DAB station in ASCII characters.<br>The data is padded to 16 bytes with the space character (0x20)|
+|Et|0x0D|
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x19|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – DAB program type|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x19|
+|Ac|Answer code|
+|Dl|Data length, fixed to 16 bytes (ASCII characters)|
+|Data1 –<br>Data128|The radio programme type in ASCII characters.<br>The data is padded to 16 bytes with the space character (0x20)|
+|Et|0x0D|
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1A|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – DAB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1A|
+|Ac|Answer code|
+|Dl|Data length, fixed to 128 bytes (ASCII characters)|
+|Data1 –<br>Data<n>|The radio programme type in ASCII characters.<br>The data is padded to 128 bytes with the space character (0x20)|
+|Et|0x0D|
+
+
+
+15
+
+
+**Request preset details (0x1B)**
+Request details of tuner presets.
+
+
+**Example**
+Command/response sequence to request preset 1 where the response is a preset
+on DAB called “DAB STATION 2”:
+
+Command: 0x21 0x01 0x1B 0x01 0x01 0x0D
+Response: 0x21 0x01 0x1B 0x00 0x0F 0x01 0x02 0x44 0x41 0x42
+0x20 0x53 0x54 0x41 0x54 0x49 0x4F 0x4E 0x20 0x32
+0x0D
+
+
+**Network playback status (0x1C)**
+Network message format.
+
+If the network is not selected on the given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence where the network module is playing a file “File.
+mp3” on zone 1:
+
+Command: 0x21 0x01 0x1C 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x1C 0x00 0x09 0x01 0x46 0x69 0x6C 0x65
+
+0x2e 0x6d 0x70 0x33 0x0D
+
+
+**IMAX Enhanced (0x0C)**
+Controls IMAX Enhanced.
+
+
+**Example**
+Command/response sequence to set IMAX Enhanced to Auto:
+
+Command: 0x21 0x01 0x0C 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x0C 0x00 0x01 0x02 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1B|
+|Dl|0x01|
+|Data|0x01- 0x32: (1-50) The number of the required preset|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1B|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1|0x01- 0x32: (1-50) The number of the requested preset|
+|Data2|0x01 : FM frequency<br>0x02 : FM RDS name<br>0x03 : DAB (AVR450/750 only)|
+|Data3<br> <br>Data4<br>Data<n>|FM: New frequency (MHz)<br>FM: New frequency (10’skHz)<br>The name (DAB,  FM if RDS)<br>in ASCII characters|
+|Et|0x0D|
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Dl|0x01|
+|Data|0xF0 – Request Network playback status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1|0x00 – Navigating<br>0x01 – Playing<br>0x02 – Paused<br>0xFF  - Busy/Not Playing|
+|Data2 –<br>Data<n>|name of folder in ASCII if navigating<br>name of file in ASCII if playing or paused|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0C|
+|Dl|0x01|
+|Data|0xF0 – Request current IMAX Enhanced state<br>0xF1 – IMAX Enhaned Auto<br>0xF2 – IMAX Enhanced On<br>0xF3 - IMAX Enhanced Off|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – IMAX Enhanced Off<br>0x01 – IMAX Enhanced On<br>0x02 – IMAX Enhanced Auto|
+|Et|0x0D|
+
+
+
+16
+
+
+**Setup Adjustment Command Specifications**
+
+
+**Treble Equalisation (0x35)**
+Adjust the amount of treble equalisation.
+
+
+**Example**
+Command/response sequence to set the treble to -2dB:
+
+Command: 0x21 0x01 0x35 0x01 0x82 0x0D
+Response: 0x21 0x01 0x35 0x00 0x01 0x82 0x0D
+
+
+**Bass Equalisation (0x36)**
+Adjust the amount of bass equalisation.
+
+
+**Example**
+Command/response sequence to increase the bass EQ by 1dB when it was 0dB:
+
+Command: 0x21 0x01 0x36 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x36 0x00 0x01 0x01 0x0D
+
+
+**Room Equalisation (0x37)**
+Turn the room equalisation system on/off.
+
+
+**Example**
+Command/response sequence to turn the room equalisation system on:
+
+Command: 0x21 0x01 0x37 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x37 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x35|
+|Dl|0x01|
+|Data|0x00 — 0x0C – Set treble to 0dB — +12dB<br>0x81 — 0x8C – Set treble to -1dB — -12dB<br>0xF0 – Request current treble value<br>0xF1 – Increment treble by 1dB<br>0xF2 – Decrement treble by 1dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x35|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x0C – Treble is 0dB — +12dB<br>0x81 — 0x8C – Treble is -1dB — -12dB|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x36|
+|Dl|0x01|
+|Data|0x00 — 0x0C – Set bass to 0dB — +12dB<br>0x81 — 0x8C – Set bass to -1dB — -12dB<br>0xF0 – Request current bass value<br>0xF1 – Increment bass by 1dB<br>0xF2 – Decrement bass by 1dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x36|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x0C – Bass is 0dB — +12dB<br>0x81 — 0x8C – Bass is -1dB — -12dB|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x37|
+|Dl|0x01|
+|Data|0xF0 – Request current Room EQ state<br>0xF1 – Room EQ on<br>0xF2 – Room EQ off|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x37|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Room EQ is off<br>0x01 – Room EQ is on<br>0x02 – Room EQ has not been calculated and is therefore off|
+|Et|0x0D|
+
+
+
+17
+
+
+**Dolby Volume (0x38)**
+Control the status of the Dolby volume system.
+
+
+**Example**
+Command/response sequence to turn the Dolby Volume system on:
+
+Command: 0x21 0x01 0x38 0x01 0x01 0x0D
+Response: 0x21 0x01 0x38 0x00 0x01 0x02 0x0D
+
+
+**Dolby Leveller (0x39)**
+Control the status of the leveller component of the Dolby volume system.
+
+
+**Example**
+Command/response sequence to set the Dolby Leveller to 5:
+
+Command: 0x21 0x01 0x39 0x01 0x05 0x0D
+Response: 0x21 0x01 0x39 0x00 0x01 0x05 0x0D
+
+
+**Dolby Volume Calibration Offset (0x3A)**
+Adjust the calibration offset of the Dolby volume system.
+
+
+**Example**
+Command/response sequence to set the calibration offset to -5dB:
+
+Command: 0x21 0x01 0x3A 0x01 0x85 0x0D
+Response: 0x21 0x01 0x3A 0x00 0x01 0x85 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x38|
+|Dl|0x01|
+|Data|0x00 – Dolby Volume off<br>0x01 – Dolby Volume on<br>0xF0 – Request current Dolby Volume mode|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x38|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Dolby Volume is off<br>0x01 – Dolby Volume is on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x39|
+|Dl|0x01|
+|Data|0x00 — 0x0A – Set Dolby Leveller to 0 — 10<br>0xF0 – Request current Dolby Leveller setting<br>0xF1 – Increment Dolby Leveller setting<br>0xF2 – Decrement Dolby Leveller setting<br>0xFF – Turn off Dolby Leveller|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x39|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x0A – Dolby Leveller setting is 0 — 10<br>0xFF – Dolby Leveller is off|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3A|
+|Dl|0x01|
+|Data|0x00 — 0x0F – Set the calibration offset to 0 — 15dB<br>0x80 — 0x8F – Set the calibration offset to -1 — -15dB<br>0xF0 – Request current calibration offset<br>0xF1 – Increment the calibration offset by 1dB<br>0xF2 – Decrement the calibration offset by 1dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3A|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x0F – Calibration offset is 0 — 15dB<br>0x80 — 0x8F – Calibration offset is -1 — -15dB|
+|Et|0x0D|
+
+
+
+18
+
+
+**Balance (0x3B)**
+Adjust the balance control.
+
+
+**Example**
+Command/response sequence to set the balance to -3:
+
+Command: 0x21 0x01 0x3B 0x01 0x83 0x0D
+Response: 0x21 0x01 0x3B 0x00 0x01 0x83 0x0D
+
+
+**Subwoofer Trim (0x3F)**
+Adjust the value of subwoofer trim.
+
+
+**Example**
+Command/response sequence to set the subwoofer trim to -1.5dB:
+
+Command: 0x21 0x01 0x3F 0x01 0x85 0x0D
+Response: 0x21 0x01 0x3F 0x00 0x01 0x85 0x0D
+
+
+**Lipsync Delay (0x40)**
+Adjust the lipsync delay value.
+
+
+**Example**
+Command/response sequence to set the lipsync delay to 50ms:
+
+Command: 0x21 0x01 0x40 0x01 0x0A 0x0D
+Response: 0x21 0x01 0x40 0x00 0x01 0x0A 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Dl|0x01|
+|Data|0x00 — 0x06 – Set the balance to 0 — 6<br>0x81 — 0x86 – Set the balance to -1 — -6<br>0xF0 – Request current balance<br>0xF1 – Increment the balance by 1dB<br>0xF2 – Decrement the balance by 1dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x06 – Balance is 0 — 6<br>0x81 — 0x86 – Balance is -1 — -6|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3F|
+|Dl|0x01|
+|Data|0x00 — 0x14 – Set positive subwoofer trim in 0.5dB steps (e.g. 0x02 = +1.0dB)<br>0x81 — 0x94 – Set negative sub. trim in 0.5dB steps (e.g. 0x82 = -1.0dB)<br>0xF0 – Request current subwoofer trim value<br>0xF1 – Increment the subwoofer trim by 0.5dB<br>0xF2 – Decrement the subwoofer trim by 0.5dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x14 – Positive subwoofer trim in 0.5dB steps (e.g. 0x02 = +1.0dB)<br>0x81 — 0x94 – Negative subwoofer trim in 0.5dB steps (e.g. 0x82 = -1.0dB)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x40|
+|Dl|0x01|
+|Data|0x00 — 0x32 – set the lipsync delay in 5ms steps (e.g. 0x08 = 40ms)<br>0xF0 – Request current lipsync delay value<br>0xF1 – Increment the lipsync delay by 5ms<br>0xF2 – Decrement the lipsync delay by 5ms|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x40|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x32 – the lipsync delay in 5ms steps (e.g. 0x10 = 80ms)|
+|Et|0x0D|
+
+
+
+19
+
+
+**Compression (0x41)**
+Adjust the dynamic range compression setting.
+
+
+**Example**
+Command/response sequence to set compression to medium:
+
+Command: 0x21 0x01 0x41 0x01 0x01 0x0D
+Response: 0x21 0x01 0x41 0x00 0x01 0x01 0x0D
+
+
+**Request incoming video parameters (0x42)**
+Request the incoming video resolution, refresh rate and aspect ratio.
+
+
+**Example**
+Command/response sequence to request video parameters, where the video is
+1280x720 (720p) 50Hz 16:9:
+
+Command: 0x21 0x01 0x42 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x42 0x00 0x07 0x05 0x00 0x02 0xD0 0x32 0x00 0x02
+
+0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x41|
+|Dl|0x01|
+|Data|0x00 – Compression off<br>0x01 – Set compression to medium<br>0x02 – Set compression to high<br>0xF0 – Request current compression setting|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x41|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Compression off<br>0x01 – medium<br>0x02 – high|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x42|
+|Dl|0x01|
+|Data|0xF0 – Request incoming video parameters|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x42|
+|Ac|Answer code|
+|Dl|0x07|
+|Data1|Horizontal resolution MSB (e.g. for 720p: 0x05 since 1280 = 0x0500)|
+|Data2|Horizontal resolution LSB (e.g. for 720p: 0x00 since 1280 = 0x0500)|
+|Data3|Vertical resolution MSB (e.g. for 720p: 0x02 since 720 = 0x02D0)|
+|Data4|Vertical resolution LSB (e.g. for 720p: 0xD0 since 720 = 0x02D0)|
+|Data5|Refresh rate for full image update (half the field rate for interlaced signals)<br>(e.g. for 50Hz progressive: 0x32)|
+|Data6|Interlaced flag:<br>0x00 – Progressive<br>0x01 – Interlaced|
+|Data7|Aspect ratio:<br>0x00 – Undefined<br>0x01 – 4:3<br>0x02 – 16:9|
+|Et|0x0D|
+
+
+
+20
+
+
+**Request incoming audio format (0x43)**
+Request the incoming audio format.
+
+
+**Example**
+Command/response sequence to request the incoming audio format, where the
+format is Dolby Digital 5.1:
+
+Command: 0x21 0x01 0x43 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x43 0x00 0x02 0x02 0x1A 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x43|
+|Dl|0x01|
+|Data|0xF0 – Request incoming audio format|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x43|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|Audio stream format:<br>0x00 – PCM<br>0x01 – Analogue Direct<br>0x02 – Dolby Digital<br>0x03 – Dolby Digital EX<br>0x04 – Dolby Digital Surround<br>0x05 – Dolby Digital Plus<br>0x06 – Dolby Digital True HD<br>0x07 – DTS<br>0x08 – DTS 96/24<br>0x09 – DTS ES Matrix<br>0x0A – DTS ES Discrete<br>0x0B – DTS ES Matrix 96/24<br>0x0C – DTS ES Discrete 96/24<br>0x0D – DTS HD Master Audio<br>0x0E – DTS HD High Res Audio<br>0x0F – DTS Low Bit Rate<br>0x10 – DTS Core<br>0x13 – PCM Zero<br>0x14 – Unsupported<br>0x15 – Undetected<br>0x16 - Dolby Atmos<br>0x17 - DTS:X<br>0x18 - IMAX ENHANCED|
+|Data2|Audio channel configuration:<br>0x00 –  Dual Mono<br>0x01 –  Centre only<br>0x02 –  Stereo only<br>0x03 –  Stereo + mono surround<br>0x04 –  Stereo + Surround L & R<br>0x05 –  Stereo + Surround L & R + mono Surround Back<br>0x06 –  Stereo + Surround L & R + Surround Back L & R<br>0x07 –  Stereo + Surround L & R containing matrix information for surround<br> <br>back L&R<br>0x08 –  Stereo + Centre<br>0x09 –  Stereo + Centre + mono surround<br>0x0A –  Stereo + Centre + Surround L & R<br>0x0B –  Stereo + Centre + Surround L & R + mono Surround Back<br>0x0C –  Stereo + Centre + Surround L & R + Surround Back L & R<br>0x0D –  Stereo + Centre + Surround L & R  containing matrix information for<br> <br>surround back L&R<br>0x0E –  Stereo Downmix Lt Rt<br>0x0F –  Stereo Only (Lo Ro)<br>0x10 –  Dual Mono + LFE<br>0x11 –  Centre + LFE<br>0x12 –  Stereo + LFE<br>0x13 –  Stereo + single surround + LFE<br>0x14 –  Stereo + Surround L & R + LFE<br>0x15 –  Stereo + Surround L & R + mono Surround Back + LFE<br>0x16 –  Stereo + Surround L & R + Surround Back L & R + LFE<br>0x17 –  Stereo + Surround L & R + LFE<br>0x18 –  Stereo + Centre + LFE containing matrix information for<br> <br> <br>surround back L&R<br>0x19 –  Stereo + Centre + single surround + LFE<br>0x1A –  Stereo + Surround L & R + LFE (Standard 5.1)<br>0x1B –   Stereo + Centre + Surround L & R + mono Surround Back + LFE<br> <br>(6.1, e.g.  DTS ES Discrete)<br>0x1C – Stereo + Centre + Surround L & R + Surround Back L & R + LFE (7.1)<br>0x1D – Stereo + Centre + Surround L & R + LFE, containing matrix<br> <br> <br>information for surround back L&R (6.1 e.g. Dolby Digital EX)<br>0x1E –  Stereo Downmix (Lt Rt) + LFE<br>0x1F –  Stereo Only (Lo Ro) + LFE<br>0x20 –  Unknown<br>0x21 –  Undetected|
+|Et|0x0D|
+
+
+
+21
+
+
+**Request incoming audio sample rate (0x44)**
+Request the incoming audio sample rate.
+
+
+**Example**
+Command/response sequence to request the incoming audio sample rate,
+where the rate is 48kHz:
+
+Command: 0x21 0x01 0x44 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x44 0x00 0x01 0x02 0x0D
+
+
+**Set/Request Sub Stereo Trim (0x45)**
+Set/Request the subwoofer trim value for stereo mode.
+
+
+**Example**
+Command/response sequence to set the sub stereo trim to -1.5dB:
+
+Command: 0x21 0x01 0x45 0x01 0x83 0x0D
+Response: 0x21 0x01 0x45 0x00 0x01 0x83 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x44|
+|Dl|0x01|
+|Data|0xF0 – Request incoming audio sample rate|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|Incoming audio sample rate:<br>0x00 – 32 KHz<br>0x01 – 44.1 KHz<br>0x02 – 48 KHz<br>0x03 – 88.2 KHz<br>0x04 – 96 KHz<br>0x05 – 176.4 KHz<br>0x06 – 192 KHz<br>0x07 – Unknown<br>0x08 – Undetected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x45|
+|Dl|0x01|
+|Data|0x00 – set the Sub Stereo Trim value to 0dB<br>0x81 — 0x94 – set the Sub Stereo Trim value to -0.5dB — -10.00dB<br>0xF0 – Request Sub Stereo Trim value<br>0xF1 – Increment Sub Stereo Trim value by 0.5dB<br>0xF2 – Decrement Sub Stereo Trim value by 0.5dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x45|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00, 0x81 — 0x94 – Sub Stereo Trim value in -0.5dB steps|
+|Et|0x0D|
+
+
+
+22
+
+
+**Set/Request Zone 1 OSD on/off (0x4E)**
+Set/Request whether the Zone 1 OSD is shown.
+
+
+**Example**
+Command/response sequence to set the Zone 1 OSD to ‘Off’:
+
+Command: 0x21 0x01 0x4A 0x01 0xF2 0x0D
+Response: 0x21 0x01 0x4A 0x00 0x00 0x01 0x0D
+
+
+**Set/Request Video Output Switching (0x4F)**
+Set/Request the HDMI video output selection.
+
+
+**Example**
+Command/response sequence to set the video output to HDMI output 1:
+
+Command: 0x21 0x01 0x4F 0x01 0x02 0x0D
+Response: 0x21 0x01 0x4F 0x00 0x01 0x02 0x0D
+
+
+**Set/request input name (0x20)**
+This command returns the name of an input if renamed by the user. It can also
+be used to set the input name.
+
+
+**Example**
+Command/response sequence for setting the current input to “BDP300”:
+
+Command: 0x21 0x01 0x20 0x06 0x42 0x44 0x50 0x33 0x30 0x30
+0x0D
+Response: 0x20 0x01 0x20 0x00 0x06 0x42 0x44 0x50 0x33 0x30
+0x30 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4E|
+|Dl|0x01|
+|Data|0xF0 – Request current Zone 1 OSD on/off state.<br>0xF1 – Set Zone 1 OSD to On.<br>0xF2 – Set Zone 1 OSD to Off.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4E|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Zone 1 OSD is On.<br>0x01 – Zone 1 OSD is Off.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4F|
+|Dl|0x01|
+|Data|0x02 – Set HDMI Output 1.<br>0x03 – Set HDMI Output 2.<br>0x04 – Set HDMI Output 1 & 2.<br>0xF0 – Request current video output switching setting.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x02 – HDMI Output 1.<br>0x03 – HDMI Output 2.<br>0x04 – HDMI Output 1 & 2.|
+|Et|0x0D|
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x20|
+|Dl|0x01 (query) or <n> (limited to 10 characters) for setting name|
+|Data|F0 - query<br>1-<n>|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x20|
+|Ac|Answer code|
+|Dl|Data length - <n> if setting,  0x0A if requesting the name|
+|Data1 -<br>Data <n>|Input name in ASCII characters|
+|Et|0x0D|
+
+
+
+23
+
+
+**FM Scan up/down (0x23)**
+Initiates a FM scan up or down. Note: only valid if on FM input
+
+
+**Example**
+Command/response to starting a FM scan up:
+
+Command: 0x21 0x01 0x23 0x01 0x01 0x0D
+Response: 0x21 0x01 0x23 0x00 0x01 0xFF 0x0D
+
+
+**DAB Scan (0x24)**
+Initiates a DAB scan. Note: only valid if on DAB input
+
+
+**Example**
+Command/response to starting a DAB scan:
+
+Command: 0x21 0x01 0x24 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x24 0x00 0x01 0xFF 0x0D
+
+
+**Heartbeat (0x25)**
+Heartbeat command to check unit is still connected and communication - also
+resets the EuP standby timer.
+
+
+**Example**
+Command/response to sending a heartbeat command:
+
+Command: 0x21 0x01 0x25 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x25 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x23|
+|Dl|0x01|
+|Data|0x01 - Scan up<br>0x02 - Scan down|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x23|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0xFF - scanning|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x24|
+|Dl|0x01|
+|Data|0xF0 - Start DAB scan|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x24|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0xFF - scanning|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x25|
+|Dl|0x01|
+|Data|0xF0 - Heartbeat|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x25|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 - response|
+|Et|0x0D|
+
+
+
+24
+
+
+**Reboot (0x26)**
+Forces a reboot of the unit.
+
+
+**Example**
+Command/response to sending a reboot command:
+
+Command: 0x21 0x01 0x26 0x06 0x52 0x45 0x42 0x4F 0x4F 0x54
+0x0D
+Response: 0x21 0x01 0x26 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x26|
+|Dl|0x06|
+|Data1|0x52|
+|Data2|0x45|
+|Data3|0x42|
+|Data4|0x4F|
+|Data5|0x4F|
+|Data6|0x54|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x26|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 - response|
+|Et|0x0D|
+
+
+
+25
+
+
+**AV RC5 command codes**
+
+These codes are recognised as infra-red signals received by the front panel,
+RC5 electrical signals received by the remote in jacks and as control data using
+the ‘Simulate RC5 IR Command’ (0x 08).
+
+**Basic Functions**
+These RC5 codes are present on the supplied IR remote control and provide
+control over basic amplifier and video processing functions.
+
+
+
+**Advanced Functions**
+These RC5 codes are not present on the supplied remote control but have been
+created for custom install use. In order for the AVR to respond to these codes
+they must be transmitted from a programmable IR remote control or over the
+control link using the ‘Simulate RC5 IR Command’ (0x08).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|BD|16-98|0x10 - 0x62|
+|CD|16-118|0x10 - 0x76|
+|STB|16-100|0x10 - 0x64|
+|VCR|16-119|0x10 - 0x77|
+|Display|16-58|0x10 - 0x3A|
+|Power On|16-123|0x10 - 0x7B|
+|Power Off|16-124|0x10 - 0x7C|
+|Change control to next zone|16-95|0x10 - 0x5F|
+|Cycle between output resolutons|16-47|0x10 - 0x2F|
+|Access Bass control|16-39|0x10 - 0x27|
+|Access Speaker Trim controls|16-37|0x10 - 0x25|
+|Access Treble control|16-14|0x10 - 0x0E|
+|Random|16-76|0x10 - 0x4C|
+|Repeat|16-49|0x10 - 0x31|
+|Direct mode On|16-78|0x10 - 0x4E|
+|Direct mode Off|16-79|0x10 - 0x4F|
+|Multi Channel|16-106|0x10 - 0x6A|
+|Stereo|16-107|0x10 - 0x6B|
+|Dolby Surround|16-110|0x10 - 0x6E|
+|DTS Neo:6 Cinema|16-111|0x10 - 0x6F|
+|DTS Neo:6 Music|16-112|0x10 - 0x70|
+|DTS Neural:X|16-113|0x10 - 0x71|
+|Reserved|16-114|0x10 - 0x72|
+|DTS Virtual:X|16-115|0x10 - 0x73|
+|5/7 Ch Stereo|16-69|0x10 - 0x45|
+|Dolby D EX|16-23|0x10 - 0x17|
+|Mute On|16-26|0x10 - 0x1A|
+|Mute Off|16-120|0x10 - 0x78|
+|FM|16-28|0x10 - 0x1C|
+|DAB|16-72|0x10 - 0x48|
+|Lip Sync +5ms|16-15|0x10 - 0x0F|
+|Lip sync -5ms|16-101|0x10 - 0x65|
+|Sub trim +0.5dB|16-105|0x10 - 0x69|
+|Sub trim -0.5dB|16-108|0x10 - 0x6C|
+|Display Off|16-31|0x10 - 0x1F|
+|Display L1|16-34|0x10 - 0x22|
+|Display L2|16-35|0x10 - 0x23|
+|Balance left|16-38|0x10 - 0x26|
+|Balance right|16-40|0x10 - 0x28|
+|Bass +1|16-44|0x10 - 0x2C|
+|Bass -1|16-45|0x10 - 0x2D|
+|Treble +1|16-46|0x10 - 0x2E|
+|Treble -1|16-102|0x10 - 0x66|
+|Set Zone 2 to Follow Zone 1|16-20|0x10 - 0x14|
+|Zone 2 Power On<br>|23-123|0X17 - 0x7B|
+
+
+|Function|RC5 code<br>[system-<br>command]|RC5 code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Standby|16-12|0x10 - 0x0C|
+|1|16-1|0x10 - 0x01|
+|2|16-2|0x10 - 0x02|
+|3|16-3|0x10 - 0x03|
+|4|16-4|0x10 - 0x04|
+|5|16-5|0x10 - 0x05|
+|6|16-6|0x10 - 0x06|
+|7|16-7|0x10 - 0x07|
+|8|16-8|0x10 - 0x08|
+|9|16-9|0x10 - 0x09|
+|Access Lipsync Delay control|16-50|0x10 - 0x32|
+|0|16-0|0x10 - 0x00|
+|Cycle between VFD information panels|16-55|0x10 - 0x37|
+|Rewind|16-121|0x10 - 0x79|
+|Fast Forward|16-52|0x10 - 0x34|
+|Skip Back|16-33|0x10 - 0x21|
+|Skip Forward|16-11|0x10 - 0x0B|
+|Stop|16-54|0x10 - 0x36|
+|Play|16-53|0x10 - 0x35|
+|Pause|16-48|0x10 - 0x30|
+|Disc (Record) (Enter Trim Menu)|16-90|0x10 - 0x5A|
+|MENU (Enter system menu)|16-82|0x10 - 0x52|
+|Navigate Up|16-86|0x10 - 0x56|
+|Pop Up (Dolby Volume on/off)|16-70|0x10 - 0x46|
+|Navigate Left|16-81|0x10 - 0x51|
+|OK|16-87|0x10 - 0x57|
+|Navigate Right|16-80|0x10 - 0x50|
+|Audio (Room EQ on/off)|16-30|0x10 - 0x1E|
+|Navigate Down|16-85|0x10 - 0x55|
+|RTN (Access Subwoofer Trim control)|16-51|0x10 - 0x33|
+|HOME|16-43|0x10 - 0x2B|
+|Mute|16-13|0x10 - 0x0D|
+|Increase volume (+)|16-16|0x10 - 0x10|
+|MODE (Cycle between decoding modes)|16-32|0x10 - 0x20|
+|DISP (Change VFD brightness)|16-59|0x10 - 0x3B|
+|Activate DIRECT mode|16-10|0x10 - 0x0A|
+|Decrease volume (-)|16-17|0x10 - 0x11|
+|Red|16-41|0x10 - 0x29|
+|Green|16-42|0x10 - 0x2A|
+|Yellow|16-43|0x10 - 0x2B|
+|Blue|16-55|0x10 - 0x37|
+|Radio|16-91|0x10 - 0x5B|
+|Aux|16-99|0x10 - 0x63|
+|Net|16-92|0x10 - 0x5C|
+|USB|16-93|0x10 - 0x5D|
+|AV|16-94|0x10 - 0x5E|
+|Sat|16-27|0x10 - 0x1B|
+|PVR|16-96|0x10 - 0x60|
+|Game|16-97|0x10 - 0x61|
+
+
+
+26
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Zone 2 Power Off|23-124|0x17 - 0x7C|
+|Zone 2 Vol+|23-1|0x17 - 0x01|
+|Zone 2 Vol-|23-2|0x17 - 0x02|
+|Zone 2 Mute|23-3|0x17 - 0x03|
+|Zone 2 Mute On|23-4|0x17 - 0x04|
+|Zone 2 Mute Off|23-5|0x17 - 0x05|
+|Zone 2 CD|23-6|0x17 - 0x06|
+|Zone 2 BD|23-7|0x17 - 0x07|
+|Zone 2 STB|23-8|0x17 - 0x08|
+|Zone 2 AV|23-9|0x17 - 0x09|
+|Zone 2 Game|23-11|0x17 - 0x0B|
+|Zone 2 Aux|23-13|0x17 - 0x0D|
+|Zone 2 PVR|23-15|0x17 - 0x0F|
+|Zone 2 FM|23-14|0x17 - 0x0E|
+|Zone 2 DAB|23-16|0x17 - 0x10|
+|Zone 2 USB|23-18|0x17 - 0x12|
+|Zone 2 NET|23-19|0x17 - 0x13|
+|Zone 2 SAT|23-20|0x17 - 0x14|
+|Zone 2 VCR|23-21|0x17 - 0x15|
+|Select HDMI Out 1|16-73|0x10 - 0x49|
+|Select HDMI Out 2|16-74|0x10 - 0x4A|
+|Select HDMI Out 1 & 2|16-75|0x10 - 0x4B|
+
+
+
+27
+
+
+28
+
+
+## 23425
+
+**SH274E Issue D** **WATERBEACH, CAMBRIDGE CB25 9PB, England**
+
+**+44 (0)1223 203200** **http://www.arcam.co.uk**
+
+

--- a/docs/specs/RS232_AVR750450380_SH256E_3.md
+++ b/docs/specs/RS232_AVR750450380_SH256E_3.md
@@ -1,0 +1,2689 @@
+# Custom Installation Notes: Serial programming interface and IR remote commands for Arcam AVR380/450/750
+
+
+
+
+**Contents**
+
+**Introduction................................................................3**
+**Set-up...........................................................................3**
+**Conventions................................................................3**
+**Command and response formats...........................3**
+**Serial Cable Specification.........................................3**
+
+Data transfer format **.** ....................................................................3
+AMX Duet™ Support.....................................................................4
+Zone numbers **.** ...............................................................................4
+Answer codes **.** .................................................................................4
+State changes as a result of other inputs.............................4
+Reserved Commands...................................................................4
+**Example command and response sequence........4**
+**System Command Specifications............................5**
+
+Power (0x00) **.** ...................................................................................5
+Display Brightness (0x01) **.** ..........................................................5
+Headphones (0x02).......................................................................5
+FM genre (0x03) .............................................................................6
+Software version (0x04) **.** .............................................................6
+Restore factory default settings (0x05).................................6
+Save/Restore secure copy of settings (0x06) .....................7
+Simulate RC5 IR Command (0x08)..........................................7
+Display Information Type (0x09)..............................................8
+Request current source (0x1D).................................................9
+Headphone Over-ride (0x1F) **.** ..................................................9
+**Input Command Specifications ........................... 10**
+
+Video selection (0x0A) **.** .............................................................10
+Select analogue/digital (0x0B) **.** .............................................10
+Set/Request video input type (0x0C) **.** ................................10
+**Output Command Specifications......................... 11**
+
+Set/Request Volume (0x0D) **.** ..................................................11
+Request Mute status (0x0E) **.** ...................................................11
+Request direct mode status (0x0F)......................................11
+Request decode mode status — 2ch (0x10) **.** ..................12
+Request Decode mode status — MCH (0x11) **.** ...............12
+Request RDS information (0x12) **.** .........................................13
+Set/request Video Output Resolution (0x13) **.** .................13
+
+
+
+**Menu Command Specifications........................... 14**
+
+Request menu status (0x14)...................................................14
+Request tuner preset (0x15)...................................................14
+Tune (0x16)....................................................................................14
+Request DAB station (0x18) (AVR450/750 only)............15
+Prog. Type/Category (0x19) (AVR450/750 only) ...........15
+DLS/PDT info. (0x1A) (AVR450/750 only).........................15
+Request preset details (0x1B) **.** ...............................................16
+**Network Command Specifications...................... 16**
+
+Network playback status (0x1C) ..........................................16
+**Setup Adjustment Command Specifications.... 17**
+
+Treble Equalisaton (0x35) **.** .......................................................17
+Bass Equalisation (0x36)...........................................................17
+Room Equalisation (0x37) **.** ......................................................17
+Dolby Volume (0x38).................................................................18
+Dolby Leveller (0x39).................................................................18
+Dolby Volume Calibration Offset (0x3A) **.** ..........................18
+Balance (0x3B)..............................................................................19
+Dolby PLII/x Music Dimension (0x3C) **.** ...............................19
+Dolby PLII/x Music Centre Width (0x3D) **.** ..........................19
+Dolby PLII/x Music Panorama (0x3E) **.** .................................20
+Subwoofer Trim (0x3F)..............................................................20
+Lipsync Delay (0x40)..................................................................20
+Compression (0x41)...................................................................21
+Request incoming video parameters (0x42) **.** ..................21
+Request incoming audio format (0x43).............................22
+Request incoming audio sample rate (0x44) **.** .................23
+Set/Request Sub Stereo Trim (0x45) **.** ..................................23
+Set/Request Brightness (0x46) **.** .............................................23
+Set/Request Contrast (0x47) **.** .................................................24
+Set/Request Colour (0x48) **.** .....................................................24
+Set/Request Film Mode (0x49) **.** .............................................24
+Set/Request Edge Enhancement (0x4A) **.** ..........................25
+Set/Request Noise Reduction (0x4C)..................................25
+Set/Request MPEG Noise Reduction (0x4D)....................26
+Set/Request Zone 1 OSD on/off (0x4E) **.** ............................26
+Set/Request Video Output Switching (0x4F) **.** .................26
+Set/Request Output Frame Rate (0x50) **.** ...........................27
+**RS232 v2.0 commands........................................... 28**
+
+Set/request input name (0x20) **.** ............................................28
+FM Scan up/down (0x23).........................................................28
+DAB Scan (0x24) **.** .........................................................................28
+Heartbeat (0x25) **.** ........................................................................29
+**AVR380/450/750 RC5 command codes.............. 30**
+
+Basic Functions **.** ...........................................................................30
+Advanced Functions..................................................................30
+
+#### **Applicability**
+
+
+The latest version of this document is available on the Arcam Table of
+Resources, accessed via http://www.arcam.co.uk/extranethome/tor.
+
+
+**Changelog**
+Issue 1.0: First public release.
+
+Issue 2.0: USB VFD display data corrected in command 0x09
+
+Issue 3.0: RS232 version number 2.0 to indicate new commands 0x20, 0x23,
+0x24, 0x25, 0x26.
+
+
+### **Controlling the AVR380/450/750 via RS232/NET**
+
+**Introduction**
+
+This document describes the remote control protocol for controlling the AVR380/450/750 via the RS232/NET interface. The AVR380/450/750
+implements virtual IR commands in order to simplify the protocol. Any operation that can be invoked using the IR remote control can be achieved
+over a control link using the Simulate RC5 IR command (0x08). See page 7 for details of this command. The RC5 IR code set is listed from page
+30.
+
+**Set-up**
+
+The AVR380/450/750 must be correctly configured for Control; by default, Control is disabled for minimum standby power consumption. RS232
+control can be enabled using the front panel: press and hold the front panel **DIRECT** button for 4 seconds until “RS232 CONTROL ON” is displayed
+on the VFD. Pressing . Alternatively, Control for RS232 or IP can be enabled using the OSD menu. Press A followed by U on the CR450 remote
+control in order to access the setup menu. Use the cursor keys < >, ' and O to enter the General Setup menu and locate the option _**Control**_ .
+Press O,, then O to change this parameter to ‘On’. IP control is via port 50000 of the IP address of the unit (in the Network Settings menu).
+
+**Conventions**
+
+   -  All hexadecimal numbers begin 0x.
+
+   -  Any character in single quotes gives the ASCII equivalent of a hex value.
+
+   -  <n> represents an unknown or variable number.
+
+**Serial Cable Specification**
+
+
+The cable is wired as a null modem:
+
+|Connector 1 pin|Connector 2 pin|Function|
+|---|---|---|
+|2|3|Rx  Tx|
+|3|2|<br>Tx  Rx|
+|5|5|<br>RS232 Ground|
+
+
+
+**Data transfer format**
+
+   -  Transfer rate: 38,400bps.
+
+   -  1 start bit, 8 data bits, 1 stop bit, no parity, no flow control.
+
+
+**Command and response formats**
+
+Communication between the remote controller (RC) and the AVR380/450/750 takes the form of sequences of bytes, with all commands and responses
+having the same basic format. The AVR380/450/750 shall always respond to a received command, but may also send messages at other times.
+
+
+Each transmission by the RC is the following format:
+
+<St> <Zn> <Cc> <Dl> <Data> <Et>
+
+   -  St (Start transmission): 0x21 ‘!’
+
+   -  Zn (Zone number): see below.
+
+   -  Cc (Command code): the code for the command
+
+   -  Dl (Data length): the number of data items following this item,excluding the ETR
+
+   -  Data: the parameters for the command
+
+   -  Et (End transmission): 0x0D
+
+
+Each response by the AVR400 is the following format::
+
+<St> <Zn> <Cc> <Ac> <Dl> <Data> <Et>
+
+   -  St (Start transmission): 0x21 ‘!’
+
+   -  Zn (Zone number): see below.
+
+   -  Cc (Command code): the code for the command
+
+   -  Ac (Answer code): see below.
+
+   -  Dl (Data Length): the number of data items following this item, excluding the ETR
+
+   -  Data: the parameters for the response of length n. n is limited to 255.
+
+   -  Et (End transmission): 0x0D
+
+The AVR380/450/750 responds to each command from the RC within three seconds. The RC may send further commands before a previous command
+response has been received.
+
+
+
+2 3
+
+
+**Zone numbers**
+
+The following zone numbers are defined:
+
+   -  0x01 – Zone number 1. (Zone 1 is the master zone. Commands that appear zone-less refer to the master zone)
+
+   -  0x02 – Zone number 2.
+
+**Answer codes**
+
+The following answer codes are defined:
+
+   -  0x00 – Status update.
+
+   -  0x82 – Zone Invalid.
+
+   -  0x83 – Command not recognised.
+
+   -  0x84 – Parameter not recognised.
+
+   -  0x85 – Command invalid at this time.¹
+
+   -  0x86 – Invalid data length.
+¹Certain commands cannot be processed when the Setup Menu is being displayed. An answer code of 0x85 will be returned in these circumstances. Also,
+commands for tuner control cannot be processed when the tuner input is not selected, etc.
+
+**State changes as a result of other inputs**
+
+It is possible that the state of the AVR380/450/750 may be changed as a result of user input via the front panel buttons or via the IR remote control.
+Any change resulting from these inputs is relayed to the RC using the appropriate message type.
+
+For example, if the user changed the front panel display brightness using the DISPLAY button on the front panel, a display message (defined below)
+would be sent to the RC. A similar action would be taken for all other state changes (including decode mode changes).
+
+**Reserved Commands**
+
+
+Commands 0xF0 to 0xFF (inclusive) are reserved for test functions and should never be used.
+
+**Example command and response sequence**
+
+As an example, the command to simulate the RC5 command “16-16”, volume up:
+
+|STR|ZONE|CC|DL|Data 1|Data 2|ETR|
+|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x02|0x10|0x10|0x0D|
+
+
+
+Assuming that the command was accepted by the AV Receiver and is being processed, the AVR380/450/750 responds to this command with the
+following sequence:
+
+|STR|ZONE|CC|AC|DL|Data 1|Data 2|ETR|
+|---|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x00|0x02|0x10|0x10|0x0D|
+
+
+
+**AMX Duet™ Support**
+
+The AVR380/450/750 shall be fully compatible with AMX Duet™ Dynamic Device Discovery Protocol (DDDP) The following description of Dynamic
+Device Discovery comes from the AMX website (www.amx.com). Dynamic Device Discovery is part of AMX’s Duet™ platform, which combines the
+proven reliability and power of NetLinx with the extensive capabilities of the Java 2 Micro Edition (J2ME) platform. When integrating a serial or IP
+device from a manufacturer embedding the Dynamic Device Discovery Protocol (DDDP), Duet recognizes the device and loads the appropriate Duet
+module, which automatically installs the new device. AMX’s NetLinx Master can then find and install the Duet device module either from a library
+on the master, from AMX’s Web site, or from the manufacturer’s Web site. Duet also allows for device swapping so that programming changes are
+not required when devices with DDDP are removed or replaced – a huge benefit for end users. The Duet platform is an extension AMX’s InConcert®
+manufacturer partner program, which was developed to ensure seamless communication between partners’ devices and the AMX control system.
+
+
+Data is specified in the ASCII format. All ASCII characters between the quotes “” should be recognised/transmitted. “\r” is a carriage return (0x0D)
+
+
+Command: “AMX\r”
+
+AVR750 Response:
+“AMXB<Device-SDKClass=Receiver><Device-Make=ARCAM><Device-Model=AVR750><Device-Revision=x.y.z>\r”
+
+AVR450 Response:
+“AMXB<Device-SDKClass=Receiver><Device-Make=ARCAM><Device-Model=AVR450><Device-Revision=x.y.z>\r”
+
+AVR380 Response:
+“AMXB<Device-SDKClass=Receiver><Device-Make=ARCAM><Device-Model=AVR380><Device-Revision=x.y.z>\r”
+
+Where
+
+x.y.z = RS232 protocol version number.
+
+
+
+**System Command Specifications**
+
+
+**Power (0x00)**
+Request the stand-by state of a zone.
+
+
+**Example**
+Command/response sequence to request the power state of zone 1 where
+zone 1 has power on:
+
+Command: 0x21 0x01 0x00 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x00 0x00 0x01 0x01 0x0D
+
+
+**Display Brightness (0x01)**
+Request the brightness of the front panel display.
+
+
+**Example**
+Command/response sequence for requesting the brightness of the display
+where the display is off:
+
+Command: 0x21 0x01 0x01 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x01 0x00 0x01 0x00 0x0D
+
+
+**Headphones (0x02)**
+Determine whether headphones are connected.
+
+
+**Example**
+Command/response sequence to request the headphone status where the
+headphones are not connected:
+
+Command: 0x21 0x01 0x02 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x02 0x00 0x01 0x00 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Dl|0x01|
+|Data|0xF0 – Request power state|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Zone is in stand-by<br>0x01 – Zone is powered on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x01|
+|Dl|0x01|
+|Data|0xF0 – Request brightness|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x01|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Front panel is off<br>0x01 – Front panel L1<br>0x02 – Front panel L2|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x02|
+|Dl|0x01|
+|Data|0xF0 – Request current headphone connection status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x02|
+|Ac|Answer code|
+|Dl|0x01 (Data length)|
+|Data|0x00 – Headphones are not connected.<br>0x01 – Headphones are connected|
+|Et|0x0D|
+
+
+
+4 5
+
+
+**FM genre (0x03)**
+Request information on the current station programme type from FM source
+in a given zone. If FM is not selected on the given zone an error 0x85 is
+returned.
+
+
+**Example**
+Command/response sequence to request the programme type on zone 1 where
+the programme type is “POP MUSIC”:
+
+Command: 0x21 0x01 0x03 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x03 0x00 0x09 0x50 0x4F 0x50 0x20 0x4D
+0x55 0x53 0x49 0x43 0x0D
+
+
+**Software version (0x04)**
+Request the version number of the various pieces of software on the AVR.
+
+
+**Example**
+Command/response sequence to request the RS232 protocol version (1.4):
+
+Command: 0x21 0x01 0x04 0x01 0xF0 0x0D
+
+Response: 0x21 0x01 0x04 0x00 0x03 0xF0 0x01 0x04 0x0D
+
+
+**Restore factory default settings (0x05)**
+Force a restore of the factory default settings.
+
+
+**Example**
+Command/response sequence to restore factory defaults:
+
+Command: 0x21 0x01 0x05 0x02 0xAA 0xAA 0x0D
+Response: 0x21 0x01 0x05 0x00 0x00 0x0D
+
+
+
+
+
+
+
+
+
+
+
+
+
+**Save/Restore secure copy of settings (0x06)**
+Force a restore of the secure copy of the settings. Note: If no secure copy has
+been made, this command will return an answer code of 0x85.
+
+If the system is currently doing a save and another save is requested. The
+second save will fail silently. If a command 0x1E is being processed this
+command will fail with a answer code 0x85
+
+
+**Example**
+Command/response sequence to restore secure backup:
+
+Command: 0x21 0x01 0x06 0x07 0x01 0x55 0x55 0x01 0x02 0x03 0x040x0D
+Response: 0x21 0x01 0x06 0x00 0x00 0x0D
+
+
+**Simulate RC5 IR Command (0x08)**
+Simulate an RC5 command via the RS232 port. An additional status message
+will be sent in most cases as a result of the IR command.
+
+
+**Example**
+Command/response sequence to RC5 16-17 (AVR volume down in zone 1):
+
+Command: 0x21 0x01 0x08 0x02 0x10 0x11 0x0D
+Response: 0x21 0x01 0x08 0x00 0x02 0x10 0x11 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x03|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – FM program type|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|<br>0x03|
+|Ac|Answer code|
+|Dl|<br>Data length <n>|
+|Data1 –<br>Data<n>|The radio programme type in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0X06|
+|Dl|0x07|
+|Data1|0x00 – Save secure backup<br>0x01 – Restore secure backup|
+|Data2|0x55 (Confirmation data pattern to avoid accidental save/restore)|
+|Data3<br>|0x55 (Confirmation data pattern to avoid accidental save/restore)<br>|
+|Data4<br>|Pin digit 1<br>|
+|Data5<br>|Pin Digit 2<br>|
+|Data5<br>|Pin Digit 3<br>|
+|Data7<br>|Pin Digit 4<br>|
+|Et|0x0D|
+|_RESPONSE:_|_RESPONSE:_|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x06|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x04|
+|Dl|0x01|
+|Data|0xF0 – Request RS232 version<br>0xF1 – Request Host version<br>0xF2 – Request OSD version<br>0xF3 – Request DSP version<br>0xF4 – Request NET version<br>0xF5 – Request IAP version|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x04|
+|Ac|Answer code|
+|Dl|0x03|
+|Data1|Echo data from command|
+|Data2|Major version number|
+|Data3|Minor version number|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|<br>Zone number|
+|Cc|<br>0x08|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|<br>RC5 Command code|
+|Et|<br>0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x05|
+|Dl|0x02|
+|Data1|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Data2|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x05|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+
+6 7
+
+
+**Display Information Type (0x09)**
+Set the VFD display information type (where applicable).
+
+The return data echoes the data sent.
+
+
+**Example**
+Command/response sequence to set the display text to show the current FM
+radio text with FM playing in zone 2:
+
+Command: 0x21 0x02 0x09 0x01 0x01 0x0D
+Response: 0x21 0x02 0x09 0x00 0x01 0x01 0x0D
+
+
+
+
+
+
+
+**Request current source (0x1D)**
+Request the source currently selected for a given zone.
+
+
+**Example**
+Command/response sequence to request the current source for Zone 1 where
+the source is set to ‘SAT’:
+
+
+Command: 0x21 0x01 0x1D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x1D 0x00 0x01 0x04 0x0D
+
+
+**Headphone Over-ride (0x1F)**
+Activate/deactivate the mute relays (does not zero the volume).
+
+
+**Example**
+Command/response sequence to activate the mute relays:
+
+Command: 0x21 0x01 0x1F 0x01 0x01 0x0D
+Response: 0x21 0x01 0x1F 0x00 0x01 0x01 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Dl|0x01|
+|Data|0xF0|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data<br>|The current source in the indicated zone:<br>0x00 – Follow Zone 1<br>0x01 – CD<br>0x02 – BD<br>0x03 – AV<br>0x04 – SAT<br>0x05 – PVR<br>0x06 – VCR<br>0x08 – AUX<br>0x09 – DISPLAY<br>0x0B – TUNER (FM)<br>0x0C – TUNER (DAB)**(AVR450/750 only)**<br>0x0E – NET<br>0x0F – USB<br>0x10 - STB<br>0x11 - GAME<br>|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x09|
+|Dl|0x01|
+|Data|**For all sources:**<br>0x00 – Set the display to Processing mode<br>0xE0 – Cycle though all displayable information.<br>0xF0 – Request the current display type<br>**If the current source is FM:**<br>0x01 – Set the display to Radio text<br>0x02 – Set the display to Programme type<br>0x03 – Set the display to Signal strength<br>**If the current source is DAB (AVR450/750 only):**<br>0x01 – Set the display to Radio text<br>0x02 – Set the display to Genre<br>0x03 – Set the display to Signal quality<br>0x04 – Set the display to Bit rate<br>**If the current source is NET/USB**<br>0x01 – Set the display to Track<br>0x02 – Set the display to Artist<br>0x03 - Set the display to Album<br>0x04 – Set the display to audio type<br>0x05 – Set the display to rate|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|<br>Zone number|
+|Cc|<br>0x09|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|The current display is returned, as for the command.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Dl|0x01|
+|Data|0x00 – Headphone/Over-ride Clear (speakers muted if headphones present)<br>0x01 – Headphone/Over-ride Set (speakers unmuted if headphones present)|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|Relay state|
+|Et|0x0D|
+
+
+
+8 9
+
+
+**Input Command Specifications**
+
+
+**Video selection (0x0A)**
+Changes the video input. Returns invalid (0x85) if OSD is showing setup
+screen.
+
+
+**Example**
+Command/response sequence to change the video source for zone 1 to ‘PVR’:
+
+Command: 0x21 0x01 0x0A 0x01 0x03 0x0D
+Response: 0x21 0x01 0x0A 0x00 0x01 0x03 0x0D
+
+
+**Select analogue/digital (0x0B)**
+Select an analogue/digital audio input for the current source. Returns invalid
+(0x85) if OSD is showing setup screen.
+
+
+**Example**
+Command/response sequence to change the audio input to ‘digital’ in zone 1:
+
+Command: 0x21 0x01 0x0B 0x01 0x01 0x0D
+Response: 0x21 0x01 0x0B 0x00 0x01 0x01 0x0D
+
+
+**Set/Request video input type (0x0C)**
+Set/request the video input (CVBS/Component/HDMI) type in use for the
+current source.
+
+This command is only valid for zone 1.
+
+
+**Example**
+Command/response sequence for requesting the input video source where it
+is CVBS
+
+Command: 0x21 0x01 0x0C 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0C 0x00 0x01 0x04 0x0D
+
+
+
+
+
+
+
+**Output Command Specifications**
+
+
+**Set/Request Volume (0x0D)**
+Set or request the volume of a zone.
+
+This command returns the volume even if the zone requested is in mute. The
+“Request Mute status” command can be used to discover if the zone is muted.
+
+Response data format:
+e.g. for volume 42dB: Data1=0x2A (42)
+**Example**
+
+Command/response sequence for setting the volume in Zone 1 to 45dB:
+
+Command: 0x21 0x01 0x0D 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x0D 0x00 0x01 0x2D 0x0D
+
+
+**Request Mute status (0x0E)**
+Request the mute status of the audio in a zone.
+
+
+**Example**
+Command/response sequence to request the mute status of zone 1 where zone
+1 is muted:
+
+Command: 0x21 0x01 0x0E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0E 0x00 0x01 0x00 0x0D
+
+
+**Request direct mode status (0x0F)**
+Request the direct mode status on Zone 1.
+
+
+**Example**
+Command/response sequence to request the Direct mode status in zone 1
+where the mode is direct:
+
+Command: 0x21 0x01 0x0F 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0F 0x00 0x01 0x01 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the volume<br>0xF0 – Request the current volume|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1<br>|Zone volume, integer value:<br>0x00 (0) – 0x63 (99)<br>|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0A|
+|Dl|0x01|
+|Data|Source:<br>0x00 – BD<br>0x01 – SAT<br>0x02 – AV<br>0x03 – PVR<br>0x04 – VCR<br>0x05 - Game<br>0x06 - STB<br>0xF0 – Request current input|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|<br>0x01|
+|Cc|0x0A|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Response:<br>The current video source is returned, as for the command|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:<br>|Description:<br>|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Dl|0x01|
+|Data|0xF0 – Request mute status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Ac|Answer code|
+|Dl|0x01|
+|P2|0x00 – Zone is muted<br>0x01 – Zone is not muted|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0B|
+|Dl|0x01|
+|Data|0x00 – Use the analogue audio for the current source.<br>0x01 – Use the digital audio for the current source (if available).<br>0x02 – Use HDMI for the current source (if available).<br>0xF0 – Request the audio type in use for the current source.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Response:<br>0x00 – Analogue audio is in use for the current source.<br>0x01 – Digital audio is in use for the current source.<br>0x02 – HDMI audio is in use for the current source.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0F|
+|Dl|0x01|
+|Data|0xF0 – Request mode setting|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – ‘Direct mode’ is off<br>0x01 – ‘Direct mode’ is on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0C|
+|Dl|0x01|
+|Data|0x01 – HDMI.<br>0x02 – Component.<br>0x04 – CVBS.<br>0xF0 – Request the video type in use for the current source.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x01 – HDMI.<br>0x02 – Component.<br>0x04 – CVBS.|
+|Et|0x0D|
+
+
+
+10 11
+
+
+**Request decode mode status — 2ch (0x10)**
+Request the decode mode for two-channel material in zone 1.
+
+
+**Example**
+Command/response sequence to request the decode mode in zone 1 where the
+mode is Pro Logic II / x Movie Mode:
+
+Command: 0x21 0x01 0x10 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x10 0x00 0x01 0x02 0x0D
+
+
+**Request Decode mode status — MCH (0x11)**
+Request the decode mode for multi-channel material in zone 1.
+
+
+**Example**
+Command/response sequence to request the decode mode in zone 1 where the
+mode is Pro Logic IIx Movie Mode:
+
+Command: 0x21 0x01 0x11 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x11 0x00 0x01 0x04 0x0D
+
+
+
+
+
+
+
+**Request RDS information (0x12)**
+Request RDS information from the current radio station in a given zone. If FM
+is not selected on the given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence to request the RDS information on FM in zone
+1, where the response is “Playing your favourite music”.
+
+Command: 0x21 0x01 0x12 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x12 0x00 0x1C 0x00 0x50 0x6C 0x61 0x79
+0x69 0x6E 0x67 0x20 0x79 0x6F 0x75 0x72 0x20 0x66
+0x61 0x76 0x6F 0x75 0x72 0x69 0x74 0x65 0x20 0x6D
+0x75 0x73 0x69 0x63 0x0D
+
+
+**Set/request Video Output Resolution (0x13)**
+Set/request the Video Output Resolution of zone 1.
+**Example**
+
+Command/response sequence to request the video output in zone 1 where the
+resolution is 1080p:
+
+Command: 0x21 0x01 0x13 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x13 0x00 0x01 0x05 0x0D
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x12|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – FM|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x12|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1 –<br>Data<n>|The radio programme type in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x10|
+|Dl|0x01|
+|Data|0xF0 – Request decode mode|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x10|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x01 – Stereo<br>0x02 – Dolby PLII / x Movie Mode<br>0x03 – Dolby PLII / x Music Mode<br>0x05 – Dolby PLII / x Game<br>0x06 – Dolby PL<br>0x07 – Neo:6 Cinema<br>0x08 – Neo:6 Music<br>0x09 - 5/7 Ch Stereo|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x11|
+|Dl|0x01|
+|Data|0xF0 – Request decode mode|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x11|
+|Ac|Answer code|
+|Dl|<br>0x01|
+|Data|0x01 – Stereo down-mix<br>0x02 – Multi-channel mode<br>0x03 – Dolby D EX / DTS-ES mode<br>0x04 – Dolby PL IIx movie mode<br>0x05 – Dolby PL IIx music mode|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x13|
+|Dl|0x01|
+|Data|0x02 – Set resolution to SD Progressive.<br>0x03 – Set resolution to 720p.<br>0x04 – Set resolution to 1080i.<br>0x05 – Set resolution to 1080p.<br>0x06 – Set resolution to ‘Preferred’.<br>0x07 – Set resolution to Bypass.<br>0x08 - Set the resolution to 4k<br>0xF0 – Request the video output.<br>0xF1 – Increment the resolution setting.<br>0xF2 – Decrement the resolution setting.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x13|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x02 – SD Progressive.<br>0x03 – 720p.<br>0x04 – 1080i.<br>0x05 – 1080p<br>0x06 – ‘Preferred’<br>0x07 – Bypass<br>0x08 - 4k|
+|Et|0x0D|
+
+
+
+12 13
+
+
+**Menu Command Specifications**
+
+
+**Request menu status (0x14)**
+Request which (if any) menu is open in the unit.
+
+
+**Example**
+Command/response sequence to request which menu is open where the ‘Trim’
+menu is open:
+
+Command: 0x21 0x01 0x14 0x01 0xF0 0x0D
+
+Response: 0x21 0x01 0x14 0x00 0x01 0x03 0x0D
+
+
+**Request tuner preset (0x15)**
+Request the current tuner preset number. If the tuner is not selected on the
+given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence to request the preset number where the present
+number is 10 on zone 1:
+
+Command: 0x21 0x01 0x15 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x15 0x00 0x01 0x0A 0x0D
+
+
+**Tune (0x16)**
+Increment/Decrement the tuner frequency in 0.05MHz steps (FM).
+
+The returned frequency is calculated as follows:
+
+FM freq. (MHz) = reported freq. (MHz)
+FM freq. (kHz) = reported freq. (kHz)
+
+For these reasons, this command may return values that cannot be translated
+into ASCII characters.
+
+If the tuner is not selected on the given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence to increment the FM tuning from 85.0MHz to
+85.05MHz in zone 1:
+
+Command: 0x21 0x01 0x16 0x01 0x01 0x0D
+Response: 0x21 0x01 0x16 0x00 0x02 0x55 0x05 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x18|
+|Dl|0x01|
+|Data|0xF0 – Request the current DAB station|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x18|
+|Ac|Answer code|
+|Dl|Data length, fixed to 16 bytes (ASCII characters)|
+|Data1 –<br>Data128|The service label of the DAB station in ASCII characters.<br>The data is padded to 16 bytes with the space character (0x20)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x14|
+|Dl|0x01|
+|Data|0xF0 – Request the open menu state|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x14|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – No menu is open<br>0x02 – Set-up Menu Open<br>0x03 – Trim Menu Open<br>0x04 – Bass Menu Open<br>0x05 – Treble Menu Open<br>0x06 – Sync Menu Open<br>0x07 – Sub Menu Open<br>0x08 – Tuner Menu Open<br>0x09 – Network menu Open<br>0x0A – USB Menu Open|
+|Et|<br>0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x19|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – DAB program type|
+|Et|<br>0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x19|
+|Ac|Answer code|
+|Dl|Data length, fixed to 16 bytes (ASCII characters)|
+|Data1 –<br>Data128|The radio programme type in ASCII characters.<br>The data is padded to 16 bytes with the space character (0x20)|
+|Et|<br>0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x15|
+|Dl|0x01|
+|Data|0x01 – 0x32 (1-50) number of required preset.<br>0xF0 – Request the current preset number.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn<br>|Zone number<br>|
+|Cc|0x15|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0xFF – Currently no preset selected<br>0x01- 0x32: (1-50) the current preset number.|
+|Et|0x0D|
+
+
+
+
+
+**Request DAB station (0x18) (AVR450/750 only)**
+Request the current DAB station selected. If DAB is not selected on the given
+zone an error 0x85 is returned.
+**Example**
+
+Command/response sequence to request the DAB station selection where the
+station is called “DAB STATION 2” in zone 1:
+
+Command: 0x21 0x01 0x18 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x18 0x00 0x10 0x44 0x41 0x42 0x20 0x53 0x54 0x41
+
+0x54 0x49 0x4F 0x4E 0x20 0x32 0x20 0x20 0x20 0x0D
+
+
+**Prog. Type/Category (0x19) (AVR450/750 only)**
+Request information on the current station programme type from DAB source
+in a given zone. If DAB is not selected on the given zone an error 0x85 is
+returned.
+
+
+**Example**
+Command/response sequence to request the programme type on zone 1 where
+the programme type is “POP MUSIC”:
+
+Command: 0x21 0x01 0x19 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x19 0x00 0x10 0x50 0x4F 0x50 0x20 0x4D
+0x55 0x53 0x49 0x43 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x0D
+
+
+**DLS/PDT info. (0x1A) (AVR450/750 only)**
+Request DLS/PDT information (digital radio text) from the current radio
+station in a given zone. If DAB is not selected on the given zone an error 0x85
+is returned.
+
+
+**Example**
+Command/response sequence to request the DLS information on DAB in zone
+1, where the response is “Playing your favourite music”.
+
+Command: 0x21 0x01 0x1A 0xF0 0x0D
+Response: 0x21 0x01 0x1A 0x00 0x80 0x00 0x50 0x6C 0x61 0x79
+0x69 0x6E 0x67 0x20 0x79 0x6F 0x75 0x72 0x20 0x66
+0x61 0x76 0x6F 0x75 0x72 0x69 0x74 0x65 0x20 0x6D
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20 0x20
+0x20 0x20 0x20 0x0D
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1A|
+|Dl|0x01|
+|Data1|Request information source:<br>0xF0 – DAB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1A|
+|Ac|Answer code|
+|Dl|Data length, fixed to 128 bytes (ASCII characters)|
+|Data1 –<br>Data<n>|The radio programme type in ASCII characters.<br>The data is padded to 128 bytes with the space character (0x20)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x16|
+|Dl|0x01|
+|Data1|0x00 – Decrement tuner frequency by 1 step.<br>0x01 – Increment tuner frequency by 1 step.<br>0xF0 – Request the current tuner frequency.|
+|Et|<br>0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x16|
+|Ac|Answer code|
+|Dl|0x02 (Data length)|
+|Data1|FM: New frequency (MHz)|
+|Data2|FM: New frequency (10’s kHz)|
+|Et|0x0D|
+
+
+
+14 15
+
+
+**Request preset details (0x1B)**
+Request details of tuner presets.
+
+
+**Example**
+Command/response sequence to request preset 1 where the response is a preset
+on DAB called “DAB STATION 2”:
+
+Command: 0x21 0x01 0x1B 0x01 0x01 0x0D
+Response: 0x21 0x01 0x1B 0x00 0x0F 0x01 0x02 0x44 0x41 0x42
+0x20 0x53 0x54 0x41 0x54 0x49 0x4F 0x4E 0x20 0x32
+0x0D
+
+
+**Network Command Specifications**
+
+
+**Network playback status (0x1C)**
+Network message format.
+
+If the network is not selected on the given zone an error 0x85 is returned.
+
+
+**Example**
+Command/response sequence where the network module is playing a file “File.
+mp3” on zone 1:
+
+Command: 0x21 0x01 0x1C 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x1C 0x00 0x09 0x01 0x46 0x69 0x6C 0x65
+
+0x2e 0x6d 0x70 0x33 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x35|
+|Dl|0x01|
+|Data|0x00 — 0x0C – Set treble to 0dB — +12dB<br>0x81 — 0x8C – Set treble to -1dB — -12dB<br>0xF0 – Request current treble value<br>0xF1 – Increment treble by 1dB<br>0xF2 – Decrement treble by 1dB|
+|Et|<br>0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x35|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x0C – Treble is 0dB — +12dB<br>0x81 — 0x8C – Treble is -1dB — -12dB|
+|Et|0x0D|
+
+
+
+
+
+
+
+**Setup Adjustment Command Specifications**
+
+
+**Treble Equalisaton (0x35)**
+Adjust the amount of treble equalisation.
+
+
+**Example**
+Command/response sequence to set the treble to -2dB:
+
+Command: 0x21 0x01 0x35 0x01 0x82 0x0D
+Response: 0x21 0x01 0x35 0x00 0x01 0x82 0x0D
+
+
+**Bass Equalisation (0x36)**
+Adjust the amount of bass equalisation.
+
+
+**Example**
+Command/response sequence to increase the bass EQ by 1dB when it was 0dB:
+
+Command: 0x21 0x01 0x36 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x36 0x00 0x01 0x01 0x0D
+
+
+**Room Equalisation (0x37)**
+Turn the room equalisation system on/off.
+
+
+**Example**
+Command/response sequence to turn the room equalisation system on:
+
+Command: 0x21 0x01 0x37 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x37 0x00 0x01 0x01 0x0D
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1B|
+|Dl|0x01|
+|Data|0x01- 0x32: (1-50) The number of the required preset|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1B|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1|0x01- 0x32: (1-50) The number of the requested preset|
+|Data2|0x01 : FM frequency<br>0x02 : FM RDS name<br>0x03 : DAB (AVR450/750 only)|
+|Data3<br> <br>Data4<br>Data<n>|<br>FM: New frequency (MHz)<br>FM: New frequency (10’skHz)<br>The name (DAB,  FM if RDS)<br>in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x36|
+|Dl|0x01|
+|Data|0x00 — 0x0C – Set bass to 0dB — +12dB<br>0x81 — 0x8C – Set bass to -1dB — -12dB<br>0xF0 – Request current bass value<br>0xF1 – Increment bass by 1dB<br>0xF2 – Decrement bass by 1dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x36|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x0C – Bass is 0dB — +12dB<br>0x81 — 0x8C – Bass is -1dB — -12dB|
+|Et|0x0D|
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|<br>0x1C|
+|Dl|0x01|
+|Data|0xF0 – Request Network playback status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Ac|Answer code|
+|Dl|Data length <n>|
+|Data1|0x00 – Navigating<br>0x01 – Playing<br>0x02 – Paused<br>0xFF  - Busy/Not Playing|
+|Data2 –<br>Data<n>|<br>name of folder in ASCII if navigating<br>name of file in ASCII if playing or paused|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x37|
+|Dl|0x01|
+|Data<br>|0xF0 – Request current Room EQ state<br>0xF1 – Room EQ on<br>0xF2 – Room EQ off<br>|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x37|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Room EQ is off<br>0x01 – Room EQ is on<br>0x02 – Room EQ has not been calculated and is therefore off|
+|Et|0x0D|
+
+
+
+16 17
+
+
+**Dolby Volume (0x38)**
+Control the status of the Dolby volume system.
+
+
+**Example**
+Command/response sequence to turn the Dolby Volume system on:
+
+Command: 0x21 0x01 0x38 0x01 0x01 0x0D
+Response: 0x21 0x01 0x38 0x00 0x01 0x02 0x0D
+
+
+**Dolby Leveller (0x39)**
+Control the status of the leveller component of the Dolby volume system.
+
+
+**Example**
+Command/response sequence to set the Dolby Leveller to 5:
+
+Command: 0x21 0x01 0x39 0x01 0x05 0x0D
+Response: 0x21 0x01 0x39 0x00 0x01 0x05 0x0D
+
+
+**Dolby Volume Calibration Offset (0x3A)**
+Adjust the calibration offset of the Dolby volume system.
+
+
+**Example**
+Command/response sequence to set the calibration offset to -5dB:
+
+Command: 0x21 0x01 0x3A 0x01 0x85 0x0D
+Response: 0x21 0x01 0x3A 0x00 0x01 0x85 0x0D
+
+
+
+
+
+
+
+**Balance (0x3B)**
+Adjust the balance control.
+
+
+**Example**
+Command/response sequence to set the balance to -3:
+
+Command: 0x21 0x01 0x3B 0x01 0x83 0x0D
+Response: 0x21 0x01 0x3B 0x00 0x01 0x83 0x0D
+
+
+**Dolby PLII/x Music Dimension (0x3C)**
+Adjust the ‘Dimension’ parameter of the Dolby PLII/x Music processor.
+
+
+**Example**
+Command/response sequence to set the dimension to -1:
+
+Command: 0x21 0x01 0x3C 0x01 0x81 0x0D
+Response: 0x21 0x01 0x3C 0x00 0x01 0x81 0x0D
+
+
+**Dolby PLII/x Music Centre Width (0x3D)**
+Adjust the ‘Centre Width’ parameter of the Dolby PLII/x music processor.
+
+
+**Example**
+Command/response sequence to set the centre width to 3:
+
+Command: 0x21 0x01 0x3D 0x01 0x03 0x0D
+Response: 0x21 0x01 0x3D 0x00 0x01 0x03 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x38|
+|Dl|0x01|
+|Data|0x00 – Dolby Volume off<br>0x01 – Dolby Volume on<br>0xF0 – Request current Dolby Volume mode|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|<br>0x38|
+|Ac|Answer code|
+|Dl|<br>0x01|
+|Data1|0x00 – Dolby Volume is off<br>0x01 – Dolby Volume is on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Dl|0x01|
+|Data|0x00 — 0x06 – Set the balance to 0 — 6<br>0x81 — 0x86 – Set the balance to -1 — -6<br>0xF0 – Request current balance<br>0xF1 – Increment the balance by 1dB<br>0xF2 – Decrement the balance by 1dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x06 – Balance is 0 — 6<br>0x81 — 0x86 – Balance is -1 — -6|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x39|
+|Dl|0x01|
+|Data|0x00 — 0x0A – Set Dolby Leveller to 0 — 10<br>0xF0 – Request current Dolby Leveller setting<br>0xF1 – Increment Dolby Leveller setting<br>0xF2 – Decrement Dolby Leveller setting<br>0xFF – Turn off Dolby Leveller|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x39|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x0A – Dolby Leveller setting is 0 — 10<br>0xFF – Dolby Leveller is off|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3C|
+|Dl|0x01|
+|Data|0x00 — 0x03 – Set the Dolby PLII/x Music Dimension parameter to 0 — 3<br>0x81 — 0x83 – Set the Dolby PLII/x Music Dimension parameter to -1 — -3<br>0xF0 – Request current Dolby PLII/x Music Dimension setting<br>0xF1 – Increment the Dolby PLII/x Music Dimension<br>0xF2 – Decrement the Dolby PLII/x Music Dimension|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x03 – The Dolby PLII/x Music Dimension parameter is 0 — 3<br>0x81  — 0x83 – The Dolby PLII/x Music Dimension parameter is -1 — -3|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|<br>0x3A|
+|Dl|0x01|
+|Data|0x00 — 0x0F – Set the calibration offset to 0 — 15dB<br>0x80 — 0x8F – Set the calibration offset to -1 — -15dB<br>0xF0 – Request current calibration offset<br>0xF1 – Increment the calibration offset by 1dB<br>0xF2 – Decrement the calibration offset by 1dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3A|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x0F – Calibration offset is 0 — 15dB<br>0x80 — 0x8F – Calibration offset is -1 — -15dB|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3D|
+|Dl|0x01|
+|Data|0x00 — 0x07 – Set the Dolby PLII/x Music Centre Width parameter to 0 — 7<br>0xF0 – Request current Dolby PLII/x Music Centre Width setting<br>0xF1 – Increment the Dolby PLII/x Music Centre Width<br>0xF2 – Decrement the Dolby PLII/x Music Centre Width|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x07 – The Dolby PLII/x Music Centre Width parameter is 0 — 7|
+|Et|0x0D|
+
+
+
+18 19
+
+
+**Dolby PLII/x Music Panorama (0x3E)**
+Turn on/off the Panorama setting of the Dolby PLII/x Music processor.
+
+
+**Example**
+Command/response sequence to turn Dolby PLII/x Music Panorama on:
+
+Command: 0x21 0x01 0x3E 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x3E 0x00 0x01 0xF1 0x0D
+
+
+**Subwoofer Trim (0x3F)**
+Adjust the value of subwoofer trim.
+
+
+**Example**
+Command/response sequence to set the subwoofer trim to -1.5dB:
+
+Command: 0x21 0x01 0x3F 0x01 0x85 0x0D
+Response: 0x21 0x01 0x3F 0x00 0x01 0x85 0x0D
+
+
+**Lipsync Delay (0x40)**
+Adjust the lipsync delay value.
+
+
+**Example**
+Command/response sequence to set the lipsync delay to 50ms:
+
+Command: 0x21 0x01 0x40 0x01 0x0A 0x0D
+Response: 0x21 0x01 0x40 0x00 0x01 0x0A 0x0D
+
+
+
+
+
+
+
+**Compression (0x41)**
+Adjust the dynamic range compression setting.
+
+
+**Example**
+Command/response sequence to set compression to medium:
+
+Command: 0x21 0x01 0x41 0x01 0x01 0x0D
+Response: 0x21 0x01 0x41 0x00 0x01 0x01 0x0D
+
+
+**Request incoming video parameters (0x42)**
+Request the incoming video resolution, refresh rate and aspect ratio.
+
+
+**Example**
+Command/response sequence to request video parameters, where the video is
+1280x720 (720p) 50Hz 16:9:
+
+Command: 0x21 0x01 0x42 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x42 0x00 0x07 0x05 0x00 0x02 0xD0 0x32 0x00 0x02
+
+0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3E|
+|Dl|0x01|
+|Data|0xF0 – Request current Dolby PLII/x Music Panorama setting<br>0xF1 – Set Dolby PLII/x Music Panorama on<br>0xF2 – Set Dolby PLII/x Music Panorama off|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3E|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Dolby PLII/x Music Panorama is off<br>0x01 – Dolby PLII/x Music Panorama is on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x41|
+|Dl|0x01|
+|Data|0x00 – Compression off<br>0x01 – Set compression to medium<br>0x02 – Set compression to high<br>0xF0 – Request current compression setting|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x41|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Compression off<br>0x01 – medium<br>0x02 – high|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3F|
+|Dl|0x01|
+|Data|0x00 — 0x14 – Set positive subwoofer trim in 0.5dB steps (e.g. 0x02 = +1.0dB)<br>0x81 — 0x94 – Set negative sub. trim in 0.5dB steps (e.g. 0x82 = -1.0dB)<br>0xF0 – Request current subwoofer trim value<br>0xF1 – Increment the subwoofer trim by 1dB<br>0xF2 – Decrement the subwoofer trim by 1dB|
+|Et|<br>0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3F|
+|Ac|Answer code|
+|Dl|<br>0x01|
+|Data1|0x00 — 0x14 – Positive subwoofer trim in 0.5dB steps (e.g. 0x02 = +1.0dB)<br>0x81 — 0x94 – Negative subwoofer trim in 0.5dB steps (e.g. 0x82 = -1.0dB)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x42|
+|Dl|0x01|
+|Data|0xF0 – Request incoming video parameters|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x42|
+|Ac|Answer code|
+|Dl|0x07|
+|Data1|Horizontal resolution MSB (e.g. for 720p: 0x05 since 1280 = 0x0500)|
+|Data2|Horizontal resolution LSB (e.g. for 720p: 0x00 since 1280 = 0x0500)|
+|Data3|Vertical resolution MSB (e.g. for 720p: 0x02 since 720 = 0x02D0)|
+|Data4|Vertical resolution LSB (e.g. for 720p: 0xD0 since 720 = 0x02D0)|
+|Data5|Refresh rate for full image update (half the field rate for interlaced signals)<br>(e.g. for 50Hz progressive: 0x32)|
+|Data6|Interlaced flag:<br>0x00 – Progressive<br>0x01 – Interlaced|
+|Data7|Aspect ratio:<br>0x00 – Undefined<br>0x01 – 4:3<br>0x02 – 16:9|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x40|
+|Dl|0x01|
+|Data|0x00 — 0x32 – set the lipsync delay in 5ms steps (e.g. 0x08 = 40ms)<br>0xF0 – Request current lipsync delay value<br>0xF1 – Increment the lipsync delay by 5ms<br>0xF2 – Decrement the lipsync delay by 5ms|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x40|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x32 – the lipsync delay in 5ms steps (e.g. 0x10 = 80ms)|
+|Et|0x0D|
+
+
+
+20 21
+
+
+**Request incoming audio format (0x43)**
+Request the incoming audio format.
+
+
+**Example**
+Command/response sequence to request the incoming audio format, where the
+format is Dolby Digital 5.1:
+
+Command: 0x21 0x01 0x43 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x43 0x00 0x02 0x02 0x1A 0xD0
+
+
+
+
+
+
+
+**Request incoming audio sample rate (0x44)**
+Request the incoming audio sample rate.
+
+
+**Example**
+Command/response sequence to request the incoming audio sample rate,
+where the rate is 48kHz:
+
+Command: 0x21 0x01 0x44 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x44 0x00 0x01 0x02 0x0D
+
+
+**Set/Request Sub Stereo Trim (0x45)**
+Set/Request the subwoofer trim value for stereo mode.
+
+
+**Example**
+Command/response sequence to set the sub stereo trim to -1.5dB:
+
+Command: 0x21 0x01 0x45 0x01 0x83 0x0D
+Response: 0x21 0x01 0x45 0x00 0x01 0x83 0x0D
+
+
+**Set/Request Brightness (0x46)**
+Set/Request the brightness control value.
+
+
+**Example**
+Command/response sequence to set the brightness to -4:
+
+Command: 0x21 0x01 0x46 0x01 0x84 0x0D
+Response: 0x21 0x01 0x46 0x00 0x01 0x84 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x44|
+|Dl|0x01|
+|Data|0xF0 – Request incoming audio sample rate|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|Incoming audio sample rate:<br>0x00 – 32 KHz<br>0x01 – 44.1 KHz<br>0x02 – 48 KHz<br>0x03 – 88.2 KHz<br>0x04 – 96 KHz<br>0x05 – 176.4 KHz<br>0x06 – 192 KHz<br>0x07 – Unknown<br>0x08 – Undetected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x45|
+|Dl|0x01|
+|Data|0x00 – set the Sub Stereo Trim value to 0dB<br>0x81 — 0x94 – set the Sub Stereo Trim value to -0.5dB — -10.00dB<br>0xF0 – Request Sub Stereo Trim value<br>0xF1 – Increment Sub Stereo Trim value by 0.5dB<br>0xF2 – Decrement Sub Stereo Trim value by 0.5dB|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x45|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00, 0x81 — 0x94 – Sub Stereo Trim value in -0.5dB steps|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x43|
+|Dl|0x01|
+|Data|0xF0 – Request incoming audio format|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x43|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|Audio stream format:<br>0x00 – PCM<br>0x01 – Analogue Direct<br>0x02 – Dolby Digital<br>0x03 – Dolby Digital EX<br>0x04 – Dolby Digital Surround<br>0x05 – Dolby Digital Plus<br>0x06 – Dolby Digital True HD<br>0x07 – DTS<br>0x08 – DTS 96/24<br>0x09 – DTS ES Matrix<br>0x0A – DTS ES Discrete<br>0x0B – DTS ES Matrix 96/24<br>0x0C – DTS ES Discrete 96/24<br>0x0D – DTS HD Master Audio<br>0x0E – DTS HD High Res Audio<br>0x0F – DTS Low Bit Rate<br>0x10 – DTS Core<br>0x13 – PCM Zero<br>0x14 – Unsupported<br>0x15 – Undetected|
+|Data2|Audio channel configuration:<br>0x00 –  Dual Mono<br>0x01 –  Centre only<br>0x02 –  Stereo only<br>0x03 –  Stereo + mono surround<br>0x04 –  Stereo + Surround L & R<br>0x05 –  Stereo + Surround L & R + mono Surround Back<br>0x06 –  Stereo + Surround L & R + Surround Back L & R<br>0x07 –  Stereo + Surround L & R containing matrix information for surround<br> <br>back L&R<br>0x08 –  Stereo + Centre<br>0x09 –  Stereo + Centre + mono surround<br>0x0A –  Stereo + Centre + Surround L & R<br>0x0B –  Stereo + Centre + Surround L & R + mono Surround Back<br>0x0C –  Stereo + Centre + Surround L & R + Surround Back L & R<br>0x0D –  Stereo + Centre + Surround L & R  containing matrix information for<br> <br>surround back L&R<br>0x0E –  Stereo Downmix Lt Rt<br>0x0F –  Stereo Only (Lo Ro)<br>0x10 –  Dual Mono + LFE<br>0x11 –  Centre + LFE<br>0x12 –  Stereo + LFE<br>0x13 –  Stereo + single surround + LFE<br>0x14 –  Stereo + Surround L & R + LFE<br>0x15 –  Stereo + Surround L & R + mono Surround Back + LFE<br>0x16 –  Stereo + Surround L & R + Surround Back L & R + LFE<br>0x17 –  Stereo + Surround L & R + LFE<br>0x18 –  Stereo + Centre + LFE containing matrix information for<br> <br> <br>surround back L&R<br>0x19 –  Stereo + Centre + single surround + LFE<br>0x1A –  Stereo + Surround L & R + LFE (Standard 5.1)<br>0x1B –   Stereo + Centre + Surround L & R + mono Surround Back + LFE<br> <br>(6.1, e.g.  DTS ES Discrete)<br>0x1C – Stereo + Centre + Surround L & R + Surround Back L & R + LFE (7.1)<br>0x1D – Stereo + Centre + Surround L & R + LFE, containing matrix<br> <br> <br>information for surround back L&R (6.1 e.g. Dolby Digital EX)<br>0x1E –  Stereo Downmix (Lt Rt) + LFE<br>0x1F –  Stereo Only (Lo Ro) + LFE<br>0x20 –  Unknown<br>0x21 –  Undetected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x46|
+|Dl|0x01|
+|Data|0x00 — 0x32 – set the Brightness value to 0 — 50.<br>0x81 — 0xB2 – set the Brightness value to -1 — -50.<br>0xF0 – Request the current Brightness value.<br>0xF1 – Increment Brightness value by 1.<br>0xF2 – Decrement Brightness value by 1.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x46|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x32 – Brightness value 0 — 50<br>0x81 — 0xB2 – Brightness value -1 — -50|
+|Et|0x0D|
+
+
+
+22 23
+
+
+**Set/Request Contrast (0x47)**
+Set/Request the contrast control value.
+
+
+**Example**
+Command/response sequence to set the contrast to 4:
+
+Command: 0x21 0x01 0x47 0x01 0x04 0x0D
+Response: 0x21 0x01 0x47 0x00 0x01 0x04 0x0D
+
+
+**Set/Request Colour (0x48)**
+Set/Request the colour control value.
+
+
+**Example**
+Command/response sequence to increment the colour value, where the value
+becomes +3:
+
+Command: 0x21 0x01 0x48 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x48 0x00 0x01 0x03 0x0D
+
+
+**Set/Request Film Mode (0x49)**
+Set/Request the Film Mode.
+
+
+**Example**
+Command/response sequence to request the current fim mode, where the
+mode is auto:
+
+Command: 0x21 0x01 0x49 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x49 0x00 0x01 0x00 0x0D
+
+
+
+
+
+
+
+**Set/Request Edge Enhancement (0x4A)**
+Set/Request the Edge Enhancement value.
+
+
+**Example**
+Command/response sequence to set the Edge Enhancement value to 10:
+
+Command: 0x21 0x01 0x4A 0x01 0x0A 0x0D
+Response: 0x21 0x01 0x4A 0x00 0x01 0x0A 0x0D
+
+
+**Set/Request Noise Reduction (0x4C)**
+Set/Request the Noise Reduction value.
+
+
+**Example**
+Command/response sequence to set the Noise Reduction value to ‘Low’:
+
+Command: 0x21 0x01 0x4C 0x01 0x01 0x0D
+Response: 0x21 0x01 0x4C 0x00 0x01 0x01 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4A|
+|Dl|0x01|
+|Data|0x00 — 0x32 – Set the Edge Enhancement value to 0 — 50.<br>0xF0 – Request current Edge Enhancement value.<br>0xF1 – Increment Edge Enhancement value by 1.<br>0xF2 – Decrement Edge Enhancement value by 1.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x4A|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x32 – Edge Enhancement value to 0 — 50.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x47|
+|Dl|0x01|
+|Data|0x00 — 0x32 – set the Contrast value to 0 — 50.<br>0x81 — 0xB2 – set the Contrast value to -1 — -50.<br>0xF0 – Request the current Contrast value.<br>0xF1 – Increment Contrast value by 1.<br>0xF2 – Decrement Contrast value by 1.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x47|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x32 – Contrast value 0 — 50<br>0x81 — 0xB2 – Contrast value -1 — -50|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x48|
+|Dl|0x01|
+|Data|0x00 — 0x32 – set the Colour value to 0 — 50.<br>0x81 — 0xB2 – set the Colour value to -1 — -50.<br>0xF0 – Request the current Colour value.<br>0xF1 – Increment Colour value by 1.<br>0xF2 – Decrement Colour value by 1.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x48|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 — 0x32 – Colour value 0 — 50<br>0x81 — 0xB2 – Colour value -1 — -50|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4C|
+|Dl|0x01|
+|Data|0x00 – Set Noise Reduction to Off.<br>0x01 – Set to Noise Reduction to Low.<br>0x02 – Set Noise Reduction to Medium.<br>0x03 – Set Noise Reduction to High.<br>0xF0 – Request current Noise Reduction value.<br>0xF1 – Increment Noise Reduction value by 1.<br>0xF2 – Decrement Noise Reduction value by 1.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x4C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Noise Reduction is Off.<br>0x01 – Noise Reduction is Low.<br>0x02 – Noise Reduction is Medium.<br>0x03 - Noise Reduction is High.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x49|
+|Dl|0x01|
+|Data|0x00 – Set Film Mode to Auto.<br>0x01 – Set Film Mode to Off.<br>0xF0 – Request current FIlm Mode.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x49|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Picture Film is Auto.<br>0x01 – Picture Film is Off.|
+|Et|0x0D|
+
+
+
+24 25
+
+
+**Set/Request MPEG Noise Reduction (0x4D)**
+Set/Request the MPEG Noise Reduction value.
+
+
+**Example**
+Command/response sequence to set the MPEG Noise Reduction value to ‘Off’:
+
+Command: 0x21 0x01 0x4A 0x01 0x00 0x0D
+Response: 0x21 0x01 0x4A 0x00 0x00 0x01 0x0D
+
+
+**Set/Request Zone 1 OSD on/off (0x4E)**
+Set/Request whether the Zone 1 OSD is shown.
+
+
+**Example**
+Command/response sequence to set the Zone 1 OSD to ‘Off’:
+
+Command: 0x21 0x01 0x4A 0x01 0xF2 0x0D
+Response: 0x21 0x01 0x4A 0x00 0x00 0x01 0x0D
+
+
+**Set/Request Video Output Switching (0x4F)**
+Set/Request the HDMI video output selection.
+
+
+**Example**
+Command/response sequence to set the video output to HDMI output 1:
+
+Command: 0x21 0x01 0x4F 0x01 0x02 0x0D
+Response: 0x21 0x01 0x4F 0x00 0x01 0x02 0x0D
+
+
+
+
+
+**Set/Request Output Frame Rate (0x50)**
+Set/Request the video output frame rate.
+
+
+**Example**
+Command/response sequence to set the frame rate to Auto:
+
+Command: 0x21 0x01 0x50 0x01 0x00 0x0D
+Response: 0x21 0x01 0x50 0x00 0x01 0x00 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4D|
+|Dl|0x01|
+|Data|0x00 – Set MPEG Noise Reduction to Off.<br>0x01 – Set to MPEG Noise Reduction to Low.<br>0x02 – Set MPEG Noise Reduction to Medium.<br>0x03 – Set MPEG Noise Reduction to High.<br>0xF0 – Request current MPEG Noise Reduction value.<br>0xF1 – Increment MPEG Noise Reduction value by 1.<br>0xF2 – Decrement MPEG Noise Reduction value by 1.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x4D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – MPEG Noise Reduction is Off.<br>0x01 – MPEG Noise Reduction is Low.<br>0x02 – MPEG Noise Reduction is Medium.<br>0x03 – MPEG Noise Reducton is High.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x50|
+|Dl|0x01|
+|Data|0x00 – Set the frame rate to Auto.<br>0x01 – Set the frame rate to follow the source.<br>0x02 – Set the frame rate to 50Hz.<br>0x03 – Set the frame rate to 60Hz.<br>0xF0 – Request the current frame rate.<br>0xF1 – Increment setting.<br>0xF2 – Decrement setting.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x50|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Auto.<br>0x01 – Frame rate is set to follow the source.<br>0x02 – 50Hz.<br>0x03 – 60Hz.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4E|
+|Dl|0x01|
+|Data|0xF0 – Request current Zone 1 OSD on/off state.<br>0xF1 – Set Zone 1 OSD to On.<br>0xF2 – Set Zone 1 OSD to Off.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4E|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Zone 1 OSD is On.<br>0x01 – Zone 1 OSD is Off.|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4F|
+|Dl|0x01|
+|Data|0x02 – Set HDMI Output 1.<br>0x03 – Set HDMI Output 2.<br>0x04 – Set HDMI Output 1 & 2.<br>0xF0 – Request current video output switching setting.|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x4F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x02 – HDMI Output 1.<br>0x03 – HDMI Output 2.<br>0x04 – HDMI Output 1 & 2.|
+|Et|0x0D|
+
+
+
+26 27
+
+
+**RS232 v2.0 commands**
+
+
+**Set/request input name (0x20)**
+This command returns the name of an input if renamed by the user. It can also
+be used to set the input name.
+
+
+**Example**
+Command/response sequence for setting the current input to “BDP300”:
+
+Command: 0x21 0x01 0x20 0x06 0x42 0x44 0x50 0x33 0x30 0x30
+0x0D
+Response: 0x20 0x01 0x20 0x00 0x06 0x42 0x44 0x50 0x33 0x30
+0x30 0x0D
+
+
+**FM Scan up/down (0x23)**
+Initiates a FM scan up or down. Note: only valid if on FM input
+
+
+**Example**
+Command/response to starting a FM scan up:
+
+Command: 0x21 0x01 0x23 0x01 0x01 0x0D
+Response: 0x21 0x01 0x23 0x00 0x01 0xFF 0x0D
+
+
+**DAB Scan (0x24)**
+Initiates a DAB scan. Note: only valid if on DAB input
+
+
+**Example**
+Command/response to starting a DAB scan:
+
+Command: 0x21 0x01 0x24 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x24 0x00 0x01 0xFF 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x25|
+|Dl|0x01|
+|Data|0xF0 - Heartbeat|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x25|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 - response|
+|Et|0x0D|
+
+
+
+
+
+
+
+
+
+**Heartbeat (0x25)**
+Heartbeat command to check unit is still connected and communication - also
+resets the EuP standby timer.
+
+
+**Example**
+Command/response to sending a heartbeat command:
+
+Command: 0x21 0x01 0x25 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x25 0x00 0x01 0x00 0x0D
+
+
+**Reboot (0x26)**
+Forces a reboot of the unit.
+
+
+**Example**
+Command/response to sending a reboot command:
+
+Command: 0x21 0x01 0x26 0x06 0x52 0x45 0x42 0x4F 0x4F 0x54
+0x0D
+Response: 0x21 0x01 0x26 0x01 0x00 0x0D
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x20|
+|Dl|0x01 (query) or <n> (limited to 10 characters) for setting name|
+|Data|F0 - query<br>1-<n>|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x20|
+|Ac|Answer code|
+|Dl|Data length - <n> if setting,  0x0A if requesting the name|
+|Data1 -<br>Data <n>|Input name in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x23|
+|Dl|0x01|
+|Data|0x01 - Scan up<br>0x02 - Scan down|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|<br>0x23|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0xFF - scanning|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x26|
+|Dl|0x06|
+|Data1|0x52|
+|Data2|0x45|
+|Data3|0x42|
+|Data4|0x4F|
+|Data5|0x4F|
+|Data6|0x54|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x26|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 - response|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x24|
+|Dl|0x01|
+|Data|0xF0 - Start DAB scan|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x24|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0xFF - scanning|
+|Et|0x0D|
+
+
+
+28 29
+
+
+**AVR380/450/750 RC5 command codes**
+
+These codes are recognised as infra-red signals received by the front panel,
+RC5 electrical signals received by the remote in jacks and as control data using
+the ‘Simulate RC5 IR Command’ (0x 08).
+
+**Basic Functions**
+These RC5 codes are present on the supplied IR remote control and provide
+control over basic amplifier and video processing functions.
+
+
+
+**Advanced Functions**
+These RC5 codes are not present on the supplied remote control but have been
+created for custom install use. In order for the AVR380/450/750 to respond to
+these codes they must be transmitted from a programmable IR remote control
+or over the control link using the ‘Simulate RC5 IR Command’ (0x08).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|Function|RC5 code<br>[system-<br>command]|RC5 code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Standby|16-12*|0x10 - 0x0C*|
+|Select STB|16-1|0x10 - 0x01|
+|Select AV|16-2|0x10 - 0x02|
+|Select Tuner|16-3|0x10 - 0x03|
+|Select BD|16-4|0x10 - 0x04|
+|Select Game|16-5|0x10 - 0x05|
+|Select VCR|16-6|0x10 - 0x06|
+|Select CD|16-7|0x10 - 0x07|
+|Select Aux|16-8|0x10 - 0x08|
+|Select Audio Return Channel (Display)|16-9|0x10 - 0x09|
+|Select SAT|16-0|0x10 - 0x00|
+|Select PVR|16-34|0x10 - 0x22|
+|Select USB|16-18|0x10 - 0x12|
+|Select NET|16-11|0x10 - 0x0B|
+|Navigate Up|16-86|0x10 - 0x56|
+|Navigate Left|16-81|0x10 - 0x51|
+|OK|16-87|0x10 - 0x57|
+|Navigate Right|16-80|0x10 - 0x50|
+|Navigate Down|16-85|0x10 - 0x55|
+|Cycle between decoding modes (MODE)|16-32|0x10 - 0x20|
+|Enter system menu (MENU)|16-82|0x10 - 0x52|
+|Mute|16-13|0x10 - 0x0D|
+|Change VFD brightness (DISP)|16-59|0x10 - 0x3B|
+|Decrease volume (-)|16-17|0x10 - 0x11|
+|Increase volume (+)|16-16|0x10 - 0x10|
+|Activate DIRECT mode|16-10|0x10 - 0x0A|
+|Room EQ on/off / NET “Now Playing” screen /<br>iPod Play/Pause|16-30|0x10 - 0x1E|
+|Toggle Dolby Volume on/off<br>/ NET & iPod Play/Pause|16-70|0x10 - 0x46|
+|<br>Access Bass control|16-39|<br>0x10 - 0x27|
+|<br>Access Speaker Trim controls|16-37|<br>0x10 - 0x25|
+|<br>Access Lipsync Delay control / NET & iPod Stop|16-50|<br>0x10 - 0x32|
+|<br>Access Subwoofer Trim control|<br>16-51|<br>0x10 - 0x33|
+|<br>Access Treble control|16-14|<br>0x10 - 0x0E|
+|<br>FAV+|16-41|<br>0x10 - 0x29|
+|FAV-|<br>16-42|<br>0x10 - 0x2A|
+|HOME|16-43|0x10 - 0x2B|
+|Cycle between VFD information panels|16-55|0x10 - 0x37|
+|Change control to next zone|16-95|0x10 - 0x5F|
+|Set selected zone to Follow Zone 1|16-20|0x10 - 0x14|
+|Cycle between output resolutons|16-47|0x10 - 0x2F|
+|Power On|16-123*|0x10 - 0x7B*|
+|Power Off<br>|16-124*|0x10 - 0x7C*|
+
+
+
+- Note - commands not supported over IP control
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Frame Rate Auto|16-63|0x10 - 0x3F|
+|Frame Rate 50|16-64|0x10 - 0x40|
+|Frame Rate 60|16-65|0x10 - 0x41|
+|Frame Rate ‘Follow Input’|16-66|0x10 - 0x42|
+|Display Off|16-31|0x10 - 0x1F|
+|Display L1|16-33|0x10 - 0x21|
+|Display L2|16-35|0x10 - 0x23|
+|Balance left|16-38|0x10 - 0x26|
+|Balance right|16-40|0x10 - 0x28|
+|Bass +1|16-44|0x10 - 0x2C|
+|Bass -1|16-45|0x10 - 0x2D|
+|Treble +1|16-46|0x10 - 0x2E|
+|Treble -1|16-98|0x10 - 0x62|
+|Zone|16-95|0x10 - 0x5F|
+|Zone 2 Power On|23-123|0X17 - 0x7B|
+|Zone 2 Power Off|23-124|0x17 - 0x7C|
+|Zone 2 Vol+|23-1|0x17 - 0x01|
+|Zone 2 Vol-|23-2|0x17 - 0x02|
+|Zone 2 Mute|23-3|0x17 - 0x03|
+|Zone 2 Mute On|23-4|0x17 - 0x04|
+|Zone 2 Mute Off|23-5|0x17 - 0x05|
+|Zone 2 CD|23-6|0x17 - 0x06|
+|Zone 2 BD|23-7|0x17 - 0x07|
+|Zone 2 STB|23-8|0x17 - 0x08|
+|Zone 2 AV|23-9|0x17 - 0x09|
+|Zone 2 Game|23-11|0x17 - 0x0B|
+|Zone 2 Aux|23-13|0x17 - 0x0D|
+|Zone 2 PVR|23-15|0x17 - 0x0F|
+|Zone 2 FM<br>|23-14<br>|0x17 - 0x0E<br>|
+|Zone 2 DAB (AVR450/750 only)<br>|23-16<br>|0x17 - 0x10<br>|
+|Zone 2 USB<br>|23-18<br>|0x17 - 0x12<br>|
+|Zone 2 NET<br>|23-19<br>|0x17 - 0x13<br>|
+|Select HDMI Out 1<br>|16-73<br>|0x10 - 0x49<br>|
+|Select HDMI Out 2<br>|16-74<br>|0x10 - 0x4A<br>|
+|Select HDMI Out 1 & 2<br> <br> <br>|16-75|0x10 - 0x4B|
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|<br>Hexadecimal|
+|Random|16 - 48|0x10 - 0x30|
+|Repeat|16 - 49|0x10 - 0x31|
+|Direct mode On|16-78|0x10 - 0x4E|
+|Direct mode Off|16-79|0x10 - 0x4F|
+|Dolby PL II / IIx Game|16-102|0x10 - 0x66|
+|Dolby PL II / IIx Movie|16-103|0x10 - 0x67|
+|Dolby PL II / IIx Music|16-104|0x10 - 0x68|
+|Multi Channel|16-106|0x10 - 0x6A|
+|Stereo|16-107|0x10 - 0x6B|
+|Dolby PL|16-110|0x10 - 0x6E|
+|DTS Neo:6 Cinema|16-111|0x10 - 0x6F|
+|DTS Neo:6 Music|16-112|0x10 - 0x70|
+|5/7 Ch Stereo|16-69|0x10 - 0x45|
+|Dolby D EX|16-118|0x10 - 0x76|
+|Mute On|16-119|0x10 - 0x77|
+|Mute Off|16-120|0x10 - 0x78|
+|NET|16-53|0x10 - 0x35|
+|FM|16-54|0x10 - 0x36|
+|DAB (AVR450/750 only)|16-72|0x10 - 0x48|
+|Video STB-CVBS|16-58|0x10 - 0x3A|
+|Video PVR-CVBS|16-60|0x10 - 0x3C|
+|Video BD-CVBS|16-62|0x10 - 0x3E|
+|Video Game-CVBS|16-71|0x10 - 0x47|
+|Video AV-Component|16-83|0x10 - 0x53|
+|Video SAT-Component|16-88|0x10 - 0x58|
+|Video BD-Component|16-89|0x10 - 0x59|
+|Video VCR-HDMI|16-90|0x10 - 0x5A|
+|Video AV-HDMI|16-91|0x10 - 0x5B|
+|Video PVR-HDMI|16-92|0x10 - 0x5C|
+|Video SAT-HDMI|16-93|0x10 - 0x5D|
+|Video BD-HDMI|16-94|0x10 - 0x5E|
+|Video GAME-HDMI|16-67|0x10 - 0x43|
+|Video STB- HDMI|16-68|0x10 - 0x44|
+|Lip Sync +5ms|16-100|0x10 - 0x64|
+|Lip sync -5ms|16-101|0x10 - 0x65|
+|Sub trim +0.5dB|16-105|0x10 - 0x69|
+|Sub trim -0.5dB|16-108|0x10 - 0x6C|
+|Dolby PLII/x Music Centre +1|16-109|0x10 - 0x6D|
+|Dolby PLII/x Music Centre -1|16-113|0x10 - 0x71|
+|Dolby PLII/x Music Dim. +1|16-114|0x10 - 0x72|
+|Dolby PLII/x Music Dim. -1|16-115|0x10 - 0x73|
+|Dolby PLII/x Panorama On|16-116|0x10 - 0x74|
+|Dolby PLII/x Panorama Off|16-117|0x10 - 0x75|
+|Video out Preferred/Best|16-125|0x10 - 0x7D|
+|Video out SD Prog|16-15|0x10 - 0x0F|
+|Video out 720p|16-23|0x10 - 0x17|
+|Video out 1080i|16-26|0x10 - 0x1A|
+|Video out 1080p|16-27|0x10 - 0x1B|
+|Video out 4k|16-76|0x10 - 4C|
+|Video out Bypass|16-28|0x10 - 0x1C|
+
+
+
+30 31
+
+
+32
+
+
+## 23425
+
+**SH256E Issue 3** **WATERBEACH, CAMBRIDGE CB25 9QE, England**
+
+**+44 (0)1223 203200** **http://www.arcam.co.uk/extranet**
+
+

--- a/docs/specs/RS232_PA720_PA240_PA410_SH305E_3.md
+++ b/docs/specs/RS232_PA720_PA240_PA410_SH305E_3.md
@@ -1,0 +1,964 @@
+# Custom Installation Notes: IP/Serial programming interface for the Arcam PA720, PA240, PA410 power amplifiers
+
+
+**Contents**
+
+**Introduction...............................................................3**
+
+**Set-up..........................................................................3**
+
+**Conventions...............................................................3**
+
+**Serial Cable Specification........................................3**
+
+**Command and response formats..........................3**
+
+Zone numbers **.** ...............................................................................3
+Answer codes **.** .................................................................................4
+State changes as a result of other inputs.............................4
+Reserved Commands...................................................................4
+**AMX Duet™ Support.................................................4**
+
+**System Command Specifications..........................5**
+
+Power (0x00) **.** ...................................................................................5
+Software version (0x04) **.** .............................................................5
+Factory reset (0x05).......................................................................5
+Mute/Unmute (0x0E)....................................................................6
+Heartbeat (0x25) **.** ...........................................................................6
+Reboot (0x26)..................................................................................6
+DC offset (0x51) **.** .............................................................................7
+Short circuit status (PA720 & PA240 only) (0x52)..............7
+Friendly name (PA720 & PA240 only) (0x53).......................7
+Set/request IP address (PA720 & PA240 only) (0x54) **.** .....8
+Request timeout counter (0x55) **.** ............................................8
+Lifter temperature (PA720 & PA240 only) (0x56)...............8
+Output temperature (0x57).......................................................9
+Auto shutdown control (0x58) **.** ................................................9
+Input detect (0x5A) **.** ......................................................................9
+System status (0x5D) **.** ................................................................10
+System model (0x5E).................................................................10
+Amplifier mode (PA240 only) (0x61)...................................10
+
+
+## **Applicability**
+
+This document applies to the ArcamPA720, PA240, PA410 power amplifiers.
+
+
+**Revision history**
+
+Issue A.0: Initial revision
+
+Issue B.0 Product name change
+
+Issue 1.0 Initial Release
+
+Issue 2.0 Temperature sensor response corrected
+
+Issue 3.0 Temperature sensor data length corrected
+
+
+
+2
+
+
+## **Controlling via RS232/NET**
+
+**Introduction**
+
+This document describes the remote control protocol for controlling via the RS232/NET interface.
+
+
+**Set-up**
+
+IP control is via port 50000 of the IP address of the unit.
+
+
+**Conventions**
+
+   - All hexadecimal numbers begin 0x.
+
+   - Any character in single quotes gives the ASCII equivalent of a hex value.
+
+   - <n> represents an unknown or variable number.
+
+
+**Serial Cable Specifcation**
+
+
+The cable is wired as a null modem:
+
+|2|3|Rx  Tx|
+|---|---|---|
+|3|2|Tx Rx|
+|5|5|RS232 Ground|
+
+
+
+**Data transfer format**
+
+   - Transfer rate: 38,400bps
+
+   - Data format: 8 data bits, 1 stop bit, no parity, no flow control.
+
+
+**Command and response formats**
+
+Communication between the remote controller (RC) and the PA720, PA240, PA410 takes the form of sequences of bytes, with all commands and
+responses having the same basic format. The PA720, PA240, PA410 shall always respond to a received command, but may also send messages
+at other times.
+
+Each transmission by the RC hs the following format:
+
+<St> <Zn> <Cc> <Dl> <Data> <Et>
+
+         - St (Start transmission): 0x21 ‘!’
+
+         - Zn (Zone number): see below
+
+         - Cc (Command code): the code for the command
+
+         - Dl (Data length): the number of data items following this item,excluding the ETR
+
+         - Data: the parameters for the command
+
+         - Et (End transmission): 0x0D
+
+Each response by the PA720, PA240, PA410 has the following format:
+
+<St> <Zn> <Cc> <Ac> <Dl> <Data> <Et>
+
+         - St (Start transmission): 0x21 ‘!’
+
+         - Zn (Zone number): see below.
+
+         - Cc (Command code): the code for the command
+
+         - Ac (Answer code): see below.
+
+         - Dl (Data Length): the number of data items following this item, excluding the ETR
+
+         - Data: the parameters for the response of length n (note that n is limited to 255).
+
+         - Et (End transmission): 0x0D
+
+The PA720, PA240, PA410 responds to each command from the RC within three seconds. The RC may send further commands before a previous
+command response has been received.
+
+
+**Zone numbers**
+
+The following zone numbers are defined:
+
+         - 0x01 – Zone number 1. (Zone 1 is the master zone. Commands that appear zone-less refer to the master zone)
+
+         - 0x02 – Zone number 2.
+
+
+
+3
+
+
+**Answer codes**
+
+The following answer codes are defined:
+
+         - 0x00 – Status update.
+
+         - 0x82 – Zone Invalid.
+
+         - 0x83 – Command not recognised.
+
+         - 0x84 – Parameter not recognised.
+
+         - 0x86 – Invalid data length.
+
+
+**State changes as a result of other inputs**
+
+It is possible that the state of the PA720, PA240, PA410 may be changed as a result of user input via the rear panel switches or by external events
+(i.e. a fault). Any change resulting from these inputs is relayed to the RC using the appropriate message type.
+
+
+**Reserved Commands**
+
+Commands 0xF0 to 0xFF (inclusive) are reserved for test functions and should never be used.
+
+
+**AMX Duet™ Support**
+
+The AV shall be fully compatible with AMX Duet™ Dynamic Device Discovery Protocol (DDDP) The following description of Dynamic Device
+Discovery comes from the AMX website ( _**www.amx.com**_ ). Dynamic Device Discovery is part of AMX’s Duet™ platform, which combines the
+proven reliability and power of NetLinx with the extensive capabilities of the Java 2 Micro Edition (J2ME) platform. When integrating a serial
+or IP device from a manufacturer embedding the Dynamic Device Discovery Protocol (DDDP), Duet recognizes the device and loads the
+appropriate Duet module, which automatically installs the new device. AMX’s NetLinx Master can then find and install the Duet device module
+either from a library on the master, from AMX’s Web site, or from the manufacturer’s Web site. Duet also allows for device swapping so that
+programming changes are not required when devices with DDDP are removed or replaced – a huge benefit for end users. The Duet platform
+is an extension AMX’s InConcert® manufacturer partner program, which was developed to ensure seamless communication between partners’
+devices and the AMX control system.
+
+
+Data is specified in the ASCII format. All ASCII characters between the quotes “” should be recognised/transmitted. “\r” is a carriage return (0x0D)
+
+Command: “AMX\r”
+
+Response: “AMXB<Device-SDKClass=Amplifier><Device-Make=ARCAM><Device-Model=PA720, PA240, PA410><Device-Revision=x.y.z>\r”
+
+
+Where,
+
+x.y.z = RS232 protocol version number.
+
+
+
+4
+
+
+**System Command Specifications**
+
+**Power (0x00)**
+
+Set/request the stand-by state of a zone.
+
+
+**Example**
+
+Command/response sequence to request the power state of zone 1 where
+zone 1 has power on:
+
+Command: 0x21 0x01 0x00 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x00 0x00 0x01 0x01 0x0D
+
+
+**Software version (0x04)**
+
+Request the firmware version
+
+
+**Example**
+
+Command/response sequence, where the repsonse is version 1.2:
+
+Command: 0x21 0x01 0x04 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x04 0x00 0x02 0x01 0x02 0x0D
+
+
+**Factory reset (0x05)**
+
+This command resets the unit to factory defaults.
+
+
+**Example**
+
+Command/response sequence for resetting the unit to factory defaults:
+
+Command: 0x21 0x01 0x05 0x02 0xAA 0xAA 0x0D
+Response: 0x21 0x01 0x05 0x00 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Dl|0x01|
+|Data|0x00 – Power Off<br>0x01 – Power On<br>0xF0 – Request power state|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Zone is in standby<br>0x01 – Zone is powered on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x04|
+|Dl|0x01|
+|Data|0xF0 - request software version|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x04|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|0x?? - major version number|
+|Data2|0x?? - minor version number|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x05|
+|Dl|0x02|
+|Data1|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Data2|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x05|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+
+5
+
+
+**Mute/Unmute (0x0E)**
+
+Set/Request the mute status of the amplifier.
+
+
+**Example**
+
+Command/response sequence for requesting the mute status of the
+amplifier where the result is unmuted:
+
+Command: 0x21 0x01 0x0E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0E 0x00 0x01 0x01 0x0D
+
+
+**Heartbeat (0x25)**
+
+Heartbeat command to check unit is still connected and communicating also resets the EuP standby timer.
+
+**Example**
+
+
+Command/response to sending a heartbeat command:
+
+Command: 0x21 0x01 0x25 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x25 0x00 0x01 0x00 0x0D
+
+
+**Reboot (0x26)**
+
+Forces a reboot of the unit.
+
+**Example**
+
+
+Command/response to sending a reboot command:
+
+Command: 0x21 0x01 0x26 0x06 0x52 0x45 0x42 0x4F
+0x4F 0x54 0x0D
+Response: 0x21 0x01 0x26 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Dl|0x01|
+|Data|0x00 - Mute<br>0x01 - Unmute1<br>0xF0 – Request mute status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Muted<br>0x01 - Unmuted|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x25|
+|Dl|0x01|
+|Data|0xF0 – Heartbeat|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x25|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Response|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x26|
+|Dl|0x06|
+|Data1|0x52|
+|Data2|0x45|
+|Data3|0x42|
+|Data4|0x4F|
+|Data5|0x4F|
+|Data6|0x54|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x26|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Response|
+|Et|0x0D|
+
+
+
+6
+
+
+**DC offset (0x51)**
+
+Request the output DC offset status.
+
+
+**Example**
+
+Command/response sequence for requesting the DC offset status where
+the result is no DC offset:
+
+Command: 0x21 0x01 0x51 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x51 0x00 0x01 0x00 0x0D
+
+
+**Short circuit status (PA720 & PA240 only) (0x52)**
+
+Request the output short circuit status.
+
+
+**Example**
+
+Command/response sequence for requesting the short circuit status,
+where the result is no short circuit:
+
+Command: 0x21 0x01 0x52 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x52 0x00 0x01 0x00 0x0D
+
+
+**Friendly name (PA720 & PA240 only) (0x53)**
+
+This command returns the friendly name of the unit. It can also be used to
+set the unit name.
+
+**Example**
+
+
+Command/response sequence for setting the unit name to “AMP 1”:
+
+Command: 0x21 0x01 0x53 0x05 0x41 0x52 0x43 0x41 0x4D 0x0D
+Response: 0x21 0x01 0x53 0x00 0x05 0x41 0x4D 0x50 0x20 0x31
+0x0D
+
+**Note**
+
+
+Only upper case characters [A...Z], numbers [0...9] and space are allowed
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x51|
+|Dl|0x01|
+|Data|0xF0 – Request DC offset status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x51|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - OK<br>0x01 - DC offset detected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x52|
+|Dl|0x01|
+|Data|0xF0 – Request short circuit status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x52|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - No short circuit detected<br>0x01 - Short circuit detected|
+|Et|0x0D|
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x53|
+|Dl|0x01 (query) or <n> (limited to 10 characters) for setting name|
+|Data|0xF0 – query<br>1–<n>|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x53|
+|Ac|Answer code|
+|Dl|Data length – <n> if setting (10 characters maximum)<br>0x0A if requesting the name|
+|Data1 -<br>Data <n>|Input name in ASCII characters|
+|Et|0x0D|
+
+
+
+7
+
+
+**Set/request IP address (PA720 & PA240 only) (0x54)**
+
+This command sets or requests the IP address of the unit.
+
+
+**Example**
+
+Command/response sequence for setting an IP address of 192.168.1.4:
+
+Command: 0x21 0x01 0x54 0x04 0xC0 0xA8 0x01 0x04 0x0D
+Response: 0x21 0x01 0x54 0x00 0x04 0xC0 0xA8 0x01 0x04
+0x0D
+
+Command/response for requesting the IP address of the unit, where the IP
+address is 192.168.1.4:
+
+Command: 0x21 0x01 0x54 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x54 0x00 0x04 0xC0 0xA8 0x01 0x04
+0x0D
+
+
+**Request timeout counter (0x55)**
+
+This command requests the time left (in seconds) until unit enters auto
+standby.
+
+
+**Example**
+
+Command/response sequence for requesting the time left until timeout:
+
+Command: 0x21 0x01 0x55 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x55 0x00 0x02 0x38 0x40 0x0D
+
+In this example, the timeout value is 0x3840, which translates to 14,400
+seconds. The range of the value returned is from 0x0000 - 0x3840 (0 14,400seconds)
+
+
+**Lifter temperature (PA720 & PA240 only) (0x56)**
+
+Request the temperature of the lifter circuitry:
+
+
+**Example**
+
+Command/response sequence for requesting the temperature of lifter
+temperature sensor 1 where the result is 75degC:
+
+Command: 0x21 0x01 0x56 0x01 0xF0 0x0D
+
+Response: 0x21 0x01 0x56 0x00 0x02 0xF0 0x4B 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x54|
+|Dl|0x01 (Query) or 0x04 (Set)|
+|Data1|0xF0 (Query) or 0x?? (Set first byte of the IP address)|
+|Data2|0x?? (Set second byte of the IP address)|
+|Data3|0x?? (Set third byte of the IP address)|
+|Data4|0x?? (Set fouth byte of the IP address)|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x54|
+|Ac|Answer code|
+|Dl|0x04|
+|Data1|0x?? (First byte of the IP address)|
+|Data2|0x?? (Second byte of the IP address)|
+|Data3|0x?? (Third byte of the IP address)|
+|Data4|0x?? (Fourth byte of the IP address)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x55|
+|Dl|0x01|
+|Data|0xF0|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x55|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|0x?? (First byte of timeout counter)|
+|Data2|0x?? (Second byte timeout counter)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x56|
+|Dl|0x01|
+|Data|0xF0 – Request lifter temperature 1<br>0xF1 – Request lifter temperature 2|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x56|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|0xF0 - Lifter temperature 1<br>0xF1 - Lifter temperature 2|
+|Data2|0x?? – Temperature in deg C in hex, e.g. 75degC = 4B|
+|Et|0x0D|
+
+
+
+8
+
+
+**Output temperature (0x57)**
+
+Request the temperature of the amplifier output stages
+
+
+**Example**
+
+Command/response sequence for requesting the temperature of output
+stage temperature sensor 1 where the result is 75degC:
+
+Command: 0x21 0x01 0x57 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x57 0x00 0x02 0xF0 0x4B 0x0D
+
+
+**Auto shutdown control (0x58)**
+
+Enable or disable the signal sense auto shutdown feature
+
+**Example 1**
+
+
+Command/response sequence, the signal sense auto shutdown timeout has
+been set to 60 minutes:
+
+Command: 0x21 0x01 0x58 0x01 0x02 0x0D
+Response: 0x21 0x01 0x58 0x00 0x01 0x02 0x0D
+
+**Example 2**
+
+
+Command/response sequence, the signal sense auto shutdown has been
+disabled:
+
+Command: 0x21 0x01 0x58 0x01 0x00 0x0D
+Response: 0x21 0x01 0x58 0x00 0x01 0x00 0x0D
+
+
+**Input detect (0x5A)**
+
+Request the status of the active input.
+
+**Example**
+
+
+Command/response sequence where audio input is present.
+
+Command: 0x21 0x01 0x5A 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5A 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x57|
+|Dl|0x01|
+|Data|0xF0 – Request output stage temperature 1<br>0xF1 – Request output stage temperature 2|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x57|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|0xF0 - Output temperature 1<br>0xF1 - Output temperature 2|
+|Data2|0x?? – Temperature in deg C in hex, e.g. 75degC = 0x4B|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x58|
+|Dl|0x01|
+|Data|0x00 – Disable<br>0x01 – 20 min (default)<br>0x02 – 30 min<br>0x03 – 1 hour<br>0x04 – 2 hours<br>0x05 – 4 hours<br>0xF0 – Request timeout status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x58|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Disabled<br>0x01 – 20 min<br>0x02 – 30 min<br>0x03 – 1 hour<br>0x04 – 2 hours<br>0x05 – 4 hours|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5A|
+|Dl|0x01|
+|Data|0xF0 - Request input status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5A|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Input not present<br>0x01 - Input present|
+|Et|0x0D|
+
+
+
+9
+
+
+**System status (0x5D)**
+
+Request the system status.
+
+**Example**
+
+
+Command/response sequence to request the system status.
+
+Command: 0x21 0x01 0x5D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5D 0x00 0x01 0xF0 0x0D
+
+
+**Note:**
+
+
+This command will return the following information about the system:
+
+         - Power state
+
+         - Software version
+
+         - Mute status
+
+         - Network name (P720 & P240 only)
+
+         - Static IP address (P720 & P240 only)
+
+         - Timeout counter value
+
+         - Lifter temperature (P720 & P240 only)
+
+         - Output temperature
+
+         - Auto shutdown status
+
+         - Input detect status
+
+         - System model
+
+         - Amplifier mode (P240 only)
+
+
+**System model (0x5E)**
+
+Request the system model.
+
+**Example**
+
+
+Command/response sequence to request the system model, where the
+model is PA720
+
+Command: 0x21 0x01 0x5E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5E 0x00 0x50 0x41 0x37 0x32 0x30 0x0D
+
+
+**Amplifier mode (PA240 only) (0x61)**
+
+Request the amplifier mode - normal, bridged, dual mono
+
+
+**Example**
+
+Command/response sequence where amp mode is set to normal:
+
+Command: 0x21 0x01 0x61 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x61 0x00 0x01 0x00 0x0D
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5D|
+|Dl|0x01|
+|Data|0xF0 – Request the system status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0xF0 - System status sent|
+|Et|0x0D|
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5E|
+|Dl|0x01|
+|Data|0xF0 – Request the system model|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5E|
+|Ac|Answer code|
+|Dl|<n>, maximum 10 characters|
+|Data1 –<br>Data<n>|System model in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x61|
+|Dl|0x01|
+|Data|0xF0 - Request amplifier mode|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x61|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Normal (stereo)<br>0x01 - Bridged<br>0x02 - Dual mono|
+|Et|0x0D|
+
+
+
+10
+
+
+**www.arcam.co.uk**
+
+
+
+**THE WEST WING, STIRLING HOUSE**
+
+
+
+**SH305E Issue 3**
+
+
+
+**WATERBEACH, CAMBRIDGE, CB25 9PB, ENGLAND**
+**+44 (0)1223 203200**
+
+
+
+11
+
+

--- a/docs/specs/SH277E_RS232_SA10_SA20_B.md
+++ b/docs/specs/SH277E_RS232_SA10_SA20_B.md
@@ -1,0 +1,1550 @@
+# Custom Installation Notes IP/Serial programming interface and IR remote control commands for the SA10/SA20 integrated amplifier
+
+
+
+
+
+
+**Contents**
+
+
+Controlling via RS232/NET.............................................3
+
+Introduction.................................................................................... 3
+Set-up **.** ............................................................................................... 3
+Conventions.................................................................................... 3
+Serial cable specification **.** .......................................................... 3
+Data transfer format **.** ................................................................... 3
+Command and response formats **.** ......................................... 3
+AMX Duet™ support **.** ................................................................... 4
+System Command Specifications................................5
+
+Power (0x00) **.** .................................................................................. 5
+Display brightness (0x01).......................................................... 5
+Headphones (0x02)...................................................................... 6
+Software version (0x04) **.** ............................................................ 6
+Factory reset (0x05)...................................................................... 7
+Simulate RC5 IR command (0x08).......................................... 7
+Volume (0x0D) **.** .............................................................................. 8
+Mute/unmute (0x0E) **.** .................................................................. 8
+Current input source (0x1D)..................................................... 9
+Headphone override (0x1F) **.** .................................................... 9
+Heartbeat (0x25) **.** ........................................................................10
+Reboot (0x26)...............................................................................10
+Balance (0x3B)..............................................................................11
+Incoming audio sample rate (0x44) **.** ...................................11
+DC offset (0x51) **.** ..........................................................................12
+Short circuit status (0x52) (SA20 only) **.** ..............................12
+Friendly name (0x53).................................................................13
+IP address (0x54) **.** ........................................................................13
+Timeout counter (0x55)............................................................14
+Lifter temperature (0x56) (SA20 Only) **.** ..............................14
+Output temperature (0x57)....................................................15
+Auto shutdown control (0x58) **.** .............................................15
+Input detect (0x5A) **.** ...................................................................16
+Processor mode input (0x5B).................................................16
+Processor mode volume (0x5C)............................................17
+System status (0x5D) **.** ................................................................17
+System model (0x5E).................................................................18
+DAC Filter (0x61)..........................................................................18
+RC5 Command Codes....................................................19
+
+Basic Functions **.** ...........................................................................19
+Advanced Functions..................................................................19
+
+
+
+**Applicability**
+
+
+This document applies to the Arcam SA10/SA20 integrated amplifiers.
+
+
+**Revision history**
+
+
+Issue A.0: Initial revision
+
+Issue B.0: Correction to 0x58
+
+
+
+2
+
+
+**Controlling via RS232/NET**
+
+
+**Introduction**
+
+
+This document describes the remote control protocol for controlling via the RS232/NET interface.
+
+**Set-up**
+
+
+IP control is via port 50000 of the IP address of the unit.
+
+**Conventions**
+
+
+ -  All hexadecimal numbers begin 0x.
+
+ -  Any character in single quotes gives the ASCII equivalent of a hex value.
+
+ -  <n> represents an unknown or variable number.
+**Serial cable specification**
+
+
+The cable is wired as a null modem:
+
+|Connector 1 pin|Connector 2 pin|Function|
+|---|---|---|
+|2|3|Rx Tx|
+|3|2|Tx Rx|
+|5|5|RS232 Ground|
+
+
+
+**Data transfer format**
+
+
+ -  Transfer rate: 38,400bps
+
+ -  Data format: 8 data bits, 1 stop bit, no parity, no flow control.
+**Command and response formats**
+
+
+Communication between the remote controller (RC) and the SA10/SA20 takes the form of sequences of bytes, with all commands and responses having the
+same basic format. The SA10/SA20 shall always respond to a received command, but may also send messages at other times.
+
+Each transmission by the RC hs the following format:
+
+<St> <Zn> <Cc> <Dl> <Data> <Et>
+
+         - St (Start transmission): 0x21 ‘!’
+
+         - Zn (Zone number): see below
+
+         - Cc (Command code): the code for the command
+
+         - Dl (Data length): the number of data items following this item, excluding the Et
+
+         - Data: the parameters for the command
+
+         - Et (End transmission): 0x0D
+
+Each response by the SA10/SA20 has the following format:
+
+<St> <Zn> <Cc> <Ac> <Dl> <Data> <Et>
+
+         - St (Start transmission): 0x21 ‘!’
+
+         - Zn (Zone number): see “Zone numbers”, below
+
+         - Cc (Command code): the code for the command
+
+         - Ac (Answer code): see “Answer codes”, below
+
+         - Dl (Data Length): the number of data items following this item, excluding the Et
+
+         - Data: the parameters for the response of length n (note that n is limited to 255)
+
+         - Et (End transmission): 0x0D
+
+The SA10/SA20 responds to each command from the RC within three seconds. The RC may send further commands before a previous command response has
+been received.
+
+
+**Zone numbers**
+
+
+The following zone numbers are defined:
+
+         - 0x01 – Zone number 1. (Zone 1 is the master zone. Commands that appear zone-less refer to the master zone)
+
+         - 0x02 – Zone number 2
+
+
+
+3
+
+
+**Answer codes**
+
+
+The following answer codes are defined:
+
+         - 0x00 – Status update.
+
+         - 0x82 – Zone Invalid.
+
+         - 0x83 – Command not recognised.
+
+         - 0x84 – Parameter not recognised.
+
+         - 0x85 – Command invalid at this time (see **NOTE** below)
+
+         - 0x86 – Invalid data length.
+
+**NOTE** : Certain commands cannot be processed when the Setup Menu is being displayed. An answer code of 0x85 will be returned in these circumstances. Also,
+commands for tuner control cannot be processed when the tuner input is not selected, etc.
+
+
+**State changes as a result of other inputs**
+
+
+It is possible that the state of the SA10/SA20 may be changed as a result of user input via front panel or remote. Any change resulting from these inputs is
+relayed to the RC using the appropriate message type.
+
+
+**Reserved Commands**
+
+
+Commands 0xF0 to 0xFF (inclusive) are reserved for test functions and should never be used.
+
+
+**Example command and response sequence**
+
+
+As an example, the command to simulate the RC5 command “16-16” (increase volume):
+
+|St|Zn|Cc|Dl|Data 1|Data 2|Et|
+|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x02|0x10|0x10|0x0D|
+
+
+
+Assuming that the command was accepted by the SA10/SA20 and is being processed, the SA10/SA20 responds to this command with the following sequence:
+
+|St|Zn|Cc|Ac|Dl|Data 1|Data 2|Et|
+|---|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x00|0x02|0x10|0x10|0x0D|
+
+
+
+**AMX Duet™ support**
+
+
+The SA10/SA20 shall be fully compatible with AMX Duet™ Dynamic Device Discovery Protocol (DDDP). The following description of Dynamic Device Discovery
+comes from the AMX website ( _**www.amx.com**_ ). Dynamic Device Discovery is part of AMX’s Duet™ platform, which combines the proven reliability and power of
+NetLinx® with the extensive capabilities of the Java 2 Micro Edition (J2ME) platform. When integrating a serial or IP device from a manufacturer embedding the
+Dynamic Device Discovery Protocol (DDDP), Duet recognizes the device and loads the appropriate Duet module, which automatically installs the new device.
+AMX’s NetLinx Master can then find and install the Duet device module either from a library on the master, from AMX’s web site, or from the manufacturer’s web
+site. Duet also allows for device swapping so that programming changes are not required when devices with DDDP are removed or replaced – a huge benefit
+for end users. The Duet platform is an extension AMX’s InConcert® manufacturer partner program, which was developed to ensure seamless communication
+between partners’ devices and the AMX control system.
+
+
+Data is specified in the ASCII format. All ASCII characters between the quotes “” should be recognised/transmitted. “\r” is a carriage return (0x0D).
+
+Command: “AMX\r”
+Response: “AMXB<Device-SDKClass=Amplifier><Device-Make=ARCAM><Device-Model=SA10><Device-Revision=x.y.z>\r”
+Response: “AMXB<Device-SDKClass=Amplifier><Device-Make=ARCAM><Device-Model=SA20><Device-Revision=x.y.z>\r”
+
+Where,
+
+x.y.z = RS232 protocol version number.
+
+
+
+4
+
+
+**System Command Specifications**
+
+
+**Power (0x00)**
+
+
+Set/request the stand-by state of a zone.
+
+
+**Example**
+
+
+Command/response sequence to request the power state of the unit where
+the unit has power on:
+
+Command: 0x21 0x01 0x00 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x00 0x00 0x01 0x01 0x0D
+
+
+**Display brightness (0x01)**
+
+
+Set/request the brightness of the front panel display.
+
+
+**Example**
+
+
+Command/response sequence for requesting the brightness of the display
+where the display is off:
+
+Command: 0x21 0x01 0x01 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x01 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Dl|0x01|
+|Data|0x00 – Power off<br>0x01 – Power on<br>0x02 – Power toggle<br>0xF0 – Request power state|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Zone is in standby<br>0x01 – Zone is powered on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x01|
+|Dl|0x01|
+|Data|0x00 – Set brightness to off<br>0x01 – Set brightness to dim<br>0x02 – Set brightness to full<br>0xF0 – Request display brightness|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x01|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Display brightness is off<br>0x01 – Display brightness is dim<br>0x02 – Display brightness is full|
+|Et|0x0D|
+
+
+
+5
+
+
+**Headphones (0x02)**
+
+
+Determine whether headphones are connected.
+
+
+**Example**
+
+
+Command/response sequence to request the headphone status where the
+headphones are not connected:
+
+Command: 0x21 0x01 0x02 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x02 0x00 0x01 0x00 0x0D
+
+
+**Software version (0x04)**
+
+
+Request the firmware version
+
+
+**Example**
+
+
+Command/response sequence, where the repsonse is HOST version 1.2:
+
+Command: 0x21 0x01 0x04 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x04 0x00 0x02 0x01 0x02 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x02|
+|Dl|0x01|
+|Data|0xF0 – Request current headphone connection status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x02|
+|Ac|Answer code|
+|Dl|0x01 (Data length)|
+|Data|0x00 – Headphones are not connected.<br>0x01 – Headphones are connected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x04|
+|Dl|0x01|
+|Data|0xF0 – request software version|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x04|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|0x?? – major version number|
+|Data2|0x?? – minor version number|
+|Et|0x0D|
+
+
+
+6
+
+
+**Factory reset (0x05)**
+
+
+This command resets the unit to factory defaults.
+
+
+**Example**
+
+
+Command/response sequence for resetting the unit to factory defaults:
+
+Command: 0x21 0x01 0x05 0x02 0xAA 0xAA 0x0D
+Response: 0x21 0x01 0x05 0x00 0x00 0x0D
+
+
+**Simulate RC5 IR command (0x08)**
+
+
+Simulate an RC5 command via the RS232 port. An additional status message
+will be sent in most cases as a result of the IR command.
+
+
+**Example**
+
+
+Command/response sequence to RC5 16-17 (volume down):
+
+Command: 0x21 0x01 0x08 0x02 0x10 0x11 0x0D
+Response: 0x21 0x01 0x08 0x00 0x02 0x10 0x11 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x05|
+|Dl|0x02|
+|Data1|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Data2|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x05|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+
+
+
+7
+
+
+**Volume (0x0D)**
+
+
+Set or request the volume of a zone.
+
+This command returns the volume even if the zone requested is in mute.
+The “Request Mute status” command can be used to discover if the zone is
+muted.
+
+Response data format:
+
+e.g. for volume 45dB: Data=0x2D (45)
+
+
+**Example**
+
+
+Command/response sequence for setting the volume in Zone 1 to 45dB:
+
+Command: 0x21 0x01 0x0D 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x0D 0x00 0x01 0x2D 0x0D
+
+
+**Mute/unmute (0x0E)**
+
+
+Set/Request the mute status of the output.
+
+
+**Example**
+
+
+Command/response sequence for requesting the mute status of output
+where the result is unmuted:
+
+Command: 0x21 0x01 0x0E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0E 0x00 0x01 0x02 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the volume<br>0xF0 – Request the current volume<br>0xF1 – Increment volume by 1 step<br>0xF2 – Decrement volume by 1 step|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Zone volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Dl|0x01|
+|Data|0x00 – Mute<br>0x01 – Unmute<br>0x02 – Mute toggle<br>0xF0 – Request mute status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Muted<br>0x01 – Unmuted|
+|Et|0x0D|
+
+
+
+8
+
+
+**Current input source (0x1D)**
+
+
+Set/request the current input source.
+
+
+**Example**
+
+
+Command/response sequence to request the current source for Zone 1
+where the source is set to ‘PVR’ and set to processor mode:
+
+Command: 0x21 0x01 0x1D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x1D 0x00 0x01 0x13 0x0D
+
+
+**Headphone override (0x1F)**
+
+
+Activate/deactivate the mute relays (does not zero the volume).
+
+
+**Example**
+
+
+Command/response sequence to activate the mute relays:
+
+Command: 0x21 0x01 0x1F 0x01 0x01 0x0D
+Response: 0x21 0x01 0x1F 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Dl|0x01|
+|Data|0x01 – Phono<br>0x02 – AUX<br>0x03 – PVR<br>0x04 – AV<br>0x05 – STB<br>0x06 – CD<br>0x07 – BD<br>0x08 – SAT<br>0xF0|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Ac|Answer code|
+|Dl|0x02|
+|Data|The current source in the indicated zone:<br>0x01 – Phono<br>0x(N)2 – AUX<br>0x(N)3 – PVR<br>0x(N)4 – AV<br>0x(N)5 – STB<br>0x(N)6 – CD<br>0x(N)7 – BD<br>0x(N)8 – SAT<br>N = 0 indicates source is normal mode<br>N = 1 indicates source is set to processor (fixed gain) mode|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Dl|0x01|
+|Data|0x00 – Headphone/Over-ride Clear (speakers muted if headphones present)<br>0x01 – Headphone/Over-ride Set (speakers unmuted if headphones present)<br>0xF0 - Request Headphone/Over-ride status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Relay state|
+|Et|0x0D|
+
+
+
+9
+
+
+**Heartbeat (0x25)**
+
+
+Heartbeat command to check unit is still connected and communicating also resets the EuP standby timer.
+
+
+**Example**
+
+
+Command/response to sending a heartbeat command:
+
+Command: 0x21 0x01 0x25 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x25 0x00 0x01 0x00 0x0D
+
+
+**Reboot (0x26)**
+
+
+Forces a reboot of the unit.
+
+
+**Example**
+
+
+Command/response to sending a reboot command:
+
+Command: 0x21 0x01 0x26 0x06 0x52 0x45 0x42 0x4F
+0x4F 0x54 0x0D
+Response: 0x21 0x01 0x26 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x25|
+|Dl|0x01|
+|Data|0xF0 – Heartbeat|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x25|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Response|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x26|
+|Dl|0x06|
+|Data1|0x52|
+|Data2|0x45|
+|Data3|0x42|
+|Data4|0x4F|
+|Data5|0x4F|
+|Data6|0x54|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x26|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Response|
+|Et|0x0D|
+
+
+
+10
+
+
+**Balance (0x3B)**
+
+
+Adjust the balance control.
+
+
+**Example**
+
+
+Command/response sequence to set the balance 3dB to the left:
+
+Command: 0x21 0x01 0x3B 0x01 0x83 0x0D
+Response: 0x21 0x01 0x3B 0x00 0x01 0x83 0x0D
+
+
+**Incoming audio sample rate (0x44)**
+
+
+Request the incoming audio sample rate.
+
+
+**Example**
+
+
+Command/response sequence to request the incoming audio sample rate,
+where the rate is 48kHz:
+
+Command: 0x21 0x01 0x44 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x44 0x00 0x01 0x02 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Dl|0x01|
+|Data|0x00 – Set the balance to the centre<br>0x01 – 0x0C – Set the balance to the right 1, 2, ..., 11, 12<br>0x81 – 0x8C – Set the balance to the left 1, 2,..., 11, 12<br>0xF0 – Request current balance<br>0xF1 – Move the balance right by 1dB<br>0xF2 – Move the balance left by 1dB|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Balance is Centred<br>0x00 – 0x0C – Balance is Right 1, 2,...,11, 12<br>0x81 – 0x8C – Balance is Left 1, 2,...,11, 12|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Dl|0x01|
+|Data|0xF0 – Request incoming audio sample rate|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Incoming audio sample rate:<br>0x00 – 32 kHz<br>0x01 – 44.1 kHz<br>0x02 – 48 kHz<br>0x03 – 88.2 kHz<br>0x04 – 96 kHz<br>0x05 – 176.4 kHz<br>0x06 – 192 kHz<br>0x07 – Unknown<br>0x08 – Undetected|
+|Et|0x0D|
+
+
+
+11
+
+
+**DC offset (0x51)**
+
+
+Request the output DC offset status.
+
+
+**Example**
+
+
+Command/response sequence for requesting the DC offset status where the
+result is no DC offset:
+
+Command: 0x21 0x01 0x51 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x51 0x00 0x01 0x00 0x0D
+
+
+**Short circuit status (0x52) (SA20 only)**
+
+
+Request the output short circuit status.
+
+
+**Example**
+
+
+Command/response sequence for requesting the short circuit status, where
+the result is no short circuit:
+
+Command: 0x21 0x01 0x52 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x52 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x51|
+|Dl|0x01|
+|Data|0xF0 – Request DC offset status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x51|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - OK<br>0x01 - DC offset detected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x52|
+|Dl|0x01|
+|Data|0xF0 – Request short circuit status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x52|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - No short circuit detected<br>0x01 - One of the channels has short circuit fault|
+|Et|0x0D|
+
+
+
+12
+
+
+**Friendly name (0x53)**
+
+
+This command returns the friendly name of the unit. It can also be used to
+set the unit name.
+
+
+**Example**
+
+
+Command/response sequence for setting the unit name to “SA20”:
+
+Command: 0x21 0x01 0x53 0x04 0x53 0x41 0x33 0x30 0x0D
+Response: 0x21 0x01 0x53 0x00 0x04 0x53 0x41 0x32 0x30
+0x0D
+
+
+**Note**
+
+
+Only upper case characters [A...Z], numbers [0...9] and space are allowed
+
+
+**IP address (0x54)**
+
+
+This command sets or requests the IP address of the unit. This command will
+also set DHCP to OFF.
+
+
+**Example 1**
+
+
+Command/response sequence for setting an IP address of 192.168.1.4:
+
+Command: 0x21 0x01 0x54 0x04 0xC0 0xA8 0x01 0x04 0x0D
+Response: 0x21 0x01 0x54 0x00 0x04 0xC0 0xA8 0x01 0x04
+0x0D
+
+
+**Example 2**
+
+
+Command/response for requesting the IP address of the unit, where the IP
+address is 192.168.1.4:
+
+Command: 0x21 0x01 0x54 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x54 0x00 0x04 0xC0 0xA8 0x01 0x04
+0x0D
+
+
+**NOTE:**
+
+
+To set DHCP to ON, set the unit’s IP address to 0.0.0.0
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x53|
+|Dl|0x01 (query) or <n> (limited to 10 characters) for setting name|
+|Data|0xF0 – query<br><n> Name in ASCII characters|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x53|
+|Ac|Answer code|
+|Dl|Data length – <n> if setting (10 characters maximum)<br>0x0A if requesting the name|
+|Data1 -<br>Data <n>|Name in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x54|
+|Dl|0x01 (Query) or 0x04 (Set)|
+|Data1|0xF0 (Query) or 0x?? (Set first byte of the IP address)|
+|Data2|0x?? (Set second byte of the IP address)|
+|Data3|0x?? (Set third byte of the IP address)|
+|Data4|0x?? (Set fouth byte of the IP address)|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x54|
+|Ac|Answer code|
+|Dl|0x04|
+|Data1|0x?? (First byte of the IP address)|
+|Data2|0x?? (Second byte of the IP address)|
+|Data3|0x?? (Third byte of the IP address)|
+|Data4|0x?? (Fourth byte of the IP address)|
+|Et|0x0D|
+
+
+
+13
+
+
+**Timeout counter (0x55)**
+
+
+This command requests the time left (in minutes) until unit enters auto
+standby.
+
+
+**Example**
+
+
+Command/response sequence for requesting the time left until timeout:
+
+Command: 0x21 0x01 0x55 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x55 0x00 0x02 0x00 0xF0 0x0D
+
+In this example, the timeout value is 0x00B4, which translates to 180 minutes
+(i.e. 3 hours). The range of the value returned is from 0x0000 - 0x00F0 (0 - 240
+minutes)
+
+
+**Lifter temperature (0x56) (SA20 Only)**
+
+
+Request the temperature of the lifter.
+
+
+**Example**
+
+
+Command/response sequence for requesting the temperature of the lifter
+where the result is 75degC:
+
+Command: 0x21 0x01 0x56 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x56 0x00 0x01 0x4B 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x55|
+|Dl|0x01|
+|Data|0xF0|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x55|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|0x00 (First byte of timeout counter, value is fixed)|
+|Data2|0x00 – 0xF0 (Second byte timeout counter)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x56|
+|Dl|0x01|
+|Data|0xF0 – Request lifter temperature|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x56|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x?? – Temperature in deg C in hex, e.g. 75degC = 4B|
+|Et|0x0D|
+
+
+
+14
+
+
+**Output temperature (0x57)**
+
+
+Request the temperature of the output stage.
+
+
+**Example**
+
+
+Command/response sequence for requesting the temperature of the output
+where the result is 75 degC:
+
+Command: 0x21 0x01 0x57 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x57 0x00 0x01 0x4B 0x0D
+
+
+**Auto shutdown control (0x58)**
+
+
+Enable or disable the signal sense auto shutdown feature
+
+
+**Example 1**
+
+
+Command/response sequence, the signal sense auto shutdown timeout has
+been set to 60 minutes:
+
+Command: 0x21 0x01 0x58 0x01 0x02 0x0D
+Response: 0x21 0x01 0x58 0x00 0x01 0x02 0x0D
+
+
+**Example 2**
+
+
+Command/response sequence, the signal sense auto shutdown has been
+disabled:
+
+Command: 0x21 0x01 0x58 0x01 0x00 0x0D
+Response: 0x21 0x01 0x58 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x57|
+|Dl|0x01|
+|Data|0xF0 – Request output temperature|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x57|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x?? – Temperature in deg C in hex, e.g. 75degC = 4B|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x58|
+|Dl|0x01|
+|Data|0x00 – Disable (Default)<br>0x01 – 30 min<br>0x02 – 1 hour<br>0x03 – 2 hours<br>0x04 – 4 hours<br>0xF0 – Request timeout status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x58|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x01 – 30 min<br>0x02 – 1 hour<br>0x03 – 2 hours<br>0x04 – 4 hours|
+|Et|0x0D|
+
+
+
+15
+
+
+**Input detect (0x5A)**
+
+
+Request the status of the active input.
+
+
+**Example**
+
+
+Command/response sequence where audio input is present.
+
+Command: 0x21 0x01 0x5A 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5A 0x00 0x01 0x01 0x0D
+
+
+**Processor mode input (0x5B)**
+
+
+Enable processor mode on a certain input or disable processor mode.
+
+
+**Example**
+
+
+Enable processor mode on the CD input:
+
+Command: 0x21 0x01 0x5B 0x01 0x06 0x0D
+Response: 0x21 0x01 0x5B 0x00 0x01 0x06 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5A|
+|Dl|0x01|
+|Data|0xF0 - Request input status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5A|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Input not present<br>0x01 - Input present|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5B|
+|Dl|0x01|
+|Data|0x00 - Disable (Default)<br>0x02 - Aux<br>0x03 - PVR<br>0x04 - AV<br>0x05 - STB<br>0x06 - CD<br>0x07 - BD<br>0x08 - SAT<br>0xF0 - Query processor mode status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Disabled<br>0x01 - Phono<br>0x02 - Aux<br>0x03 - PVR<br>0x04 - AV<br>0x05 - STB<br>0x06 - CD<br>0x07 - BD<br>0x08 - SAT|
+|Et|0x0D|
+
+
+
+16
+
+
+**Processor mode volume (0x5C)**
+
+
+Set the processor mode volume
+
+
+**Example**
+
+
+Command/response sequence to set the processor mode volume to 45
+(0x2D).
+
+Command: 0x21 0x01 0x5C 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x5C 0x00 0x01 0x2D 0x0D
+
+
+**System status (0x5D)**
+
+
+Request the system status.
+
+
+**Example**
+
+
+Command/response sequence to request the system status.
+
+Command: 0x21 0x01 0x5D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5D 0x00 0x01 0xF0 0x0D
+
+
+**Note:**
+
+
+This command will return the following information about the system:
+
+         - Power state
+
+         - Brightness level
+
+         - Headphone status
+
+         - Software version
+
+         - Model Number
+
+         - Volume setting
+
+         - Mute status
+
+         - Current input source
+
+         - Headphone override status
+
+         - Balance setting
+
+         - Sample rate
+
+         - Network name
+
+         - IP address
+
+         - Timeout counter value
+
+         - Lifter temperature (SA20 only)
+
+         - Output temperature
+
+         - Auto shutdown status
+
+         - Input detect status
+
+         - Processor mode input
+
+         - Processor mode volume
+
+         - DC offset status
+
+         - Short circuit status (SA20 only)
+
+         - DAC Filter
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5C|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the volume<br>0xF0 – Request the current volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 (0)– 0x63 (99)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5D|
+|Dl|0x01|
+|Data|0xF0 – Request the system|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0xF0 - System status sent|
+|Et|0x0D|
+
+
+
+17
+
+
+**System model (0x5E)**
+
+
+Request the system model.
+
+
+**Example**
+
+
+Command/response sequence to request the system model, where the
+model is SA10.
+
+Command: 0x21 0x01 0x5E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5E 0x00 0x04 0x53 0x41 0x31 0x30 0x0D
+
+
+**DAC Filter (0x61)**
+
+
+Sets or requests the DAC filter
+
+
+**Example**
+
+
+Command/response sequence to request the DAC filter where response is
+Linear Phase Fast Roll Off
+
+Command: 0x21 0x01 0x61 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x61 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5E|
+|Dl|0x01|
+|Data|0xF0 – Request the system model|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5E|
+|Ac|Answer code|
+|Dl|0x04|
+|Data|System model in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x61|
+|Dl|0x01|
+|Data|0x00 - Linear Phase Fast Roll Off<br>0x01 - Linear Phase Slow Roll Off<br>0x02 - Minimum Phase Fast Roll Off<br>0x03 - Minimum Phase Slow Roll Off**(SA20 only)**<br>0x04 - Brick Wall**(SA20 only)**<br>0x05 - Corrected Phase Fast Roll Off**(SA20 only)**<br>0x06 - Apodizing**(SA20 only)**<br>0xF0 - Request the current filter|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x61|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Linear Phase Fast Roll Off<br>0x01 - Linear Phase Slow Roll Off<br>0x02 - Minimum Phase Fast Roll Off<br>0x03 - Minimum Phase Slow Roll Off**(SA20 only)**<br>0x04 - Brick Wall**(SA20 only)**<br>0x05 - Corrected Phase Fast Roll Off**(SA20 only)**<br>0x06 - Apodizing**(SA20 only)**|
+|Et|0x0D|
+
+
+
+18
+
+
+**RC5 Command Codes**
+
+
+These codes are recognised as infra-red signals received by the front panel and as control data using the “Simulate RC5 IR command (0x08)” on page 7.
+
+
+
+**Basic Functions**
+
+
+These RC5 codes are present on the supplied IR remote control and provide
+control over basic amplifier functions.
+
+
+**Advanced Functions**
+
+
+These RC5 codes are not present on the supplied remote control but have
+been created for custom install use. In order for the amp to respond to these
+codes they must be transmitted from a programmable IR remote control or
+over the control link using the ‘Simulate RC5 IR Command’ (0x08).
+
+
+|Function|RC5 code<br>[system-command]|RC5 code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|**Decimal**|**Hexadecimal**|
+|Standby|16-12|0x10 - 0x0C|
+|Disp|16-59|0x10 - 0x3B|
+|Mute|16-13|0x10 - 0x0D|
+|Increase volume (+)|16-16|0x10 - 0x10|
+|Decrease volume (-)|16-17|0x10 - 0x11|
+|Balance left|16-38|0x10 - 0x26|
+|Balance right|16-40|0x10 - 0x28|
+|PHONO|16-117|0x10 - 0x75|
+|CD|16-118|0x10 - 0x76|
+|BD|16-98|0x10 - 0x62|
+|SAT|16-27|0x10 - 0x1B|
+|PVR|16-96|0x10 - 0x60|
+|AV|16-94|0x10 - 0x5E|
+|AUX|16-99|0x10 - 0x63|
+|STB|16-100|0x10 - 0x64|
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|**Decimal**|**Hexadecimal**|
+|Power On|16-123|0x10 - 0x7B|
+|Power Off|16-124|0x10 - 0x7C|
+|Mute On|16-26|0x10 - 0x1A|
+|Mute Off|16-120|0x10 - 0x78|
+|Display Off|16-31|0x10 - 0x1F|
+|Display L1|16-34|0x10 - 0x22|
+|Display L2|16-35|0x10 - 0x23|
+|Back (return)|16-51|0x10 - 0x33|
+|Home|16-43|0x10 - 0x2B|
+|Menu (Enter system menu)|16-82|0x10 - 0x52|
+|Navigate Up|16-86|0x10 - 0x56|
+|Navigate Left|16-81|0x10 - 0x51|
+|OK|16-87|0x10 - 0x57|
+|Navigate Right|16-80|0x10 - 0x50|
+|Navigate Down|16-85|0x10 - 0x55|
+
+
+
+19
+
+
+SH277E Issue B
+
+
+
+www.arcam.co.uk
+
+THE WEST WING, STIRLING HOUSE
+
+WATERBEACH, CAMBRIDGE, CB25 9PB, ENGLAND
++44 (0)1223 203200
+
+

--- a/docs/specs/SH306E_RS232_SA30_4.md
+++ b/docs/specs/SH306E_RS232_SA30_4.md
@@ -1,0 +1,1908 @@
+# Custom Installation Notes IP/Serial programming interface and IR remote control commands for the SA30 integrated amplifier
+
+
+
+
+
+
+
+
+**Contents**
+
+
+Controlling via RS232/NET.............................................3
+
+Introduction.................................................................................... 3
+Set-up **.** ............................................................................................... 3
+Conventions.................................................................................... 3
+Serial cable specification **.** .......................................................... 3
+Data transfer format **.** ................................................................... 3
+Command and response formats **.** ......................................... 3
+AMX Duet™ support **.** ................................................................... 4
+System Command Specifications................................5
+
+Power (0x00) **.** .................................................................................. 5
+Display brightness (0x01).......................................................... 5
+Headphones (0x02)...................................................................... 6
+Software version (0x04) **.** ............................................................ 6
+Factory reset (0x05)...................................................................... 7
+Simulate RC5 IR command (0x08).......................................... 7
+Volume (0x0D) **.** .............................................................................. 8
+Mute/unmute (0x0E) **.** .................................................................. 8
+Direct mode status (0x0F) **.** ........................................................ 9
+Network playback status (0x1C) ............................................ 9
+Current input source (0x1D)...................................................10
+Headphone override (0x1F) **.** ..................................................11
+Heartbeat (0x25) **.** ........................................................................11
+Reboot (0x26)...............................................................................12
+Network (0x30) **.** ...........................................................................13
+Room EQ names (0x34)............................................................14
+Room Equalisation (0x37) **.** ......................................................14
+Balance (0x3B)..............................................................................15
+Incoming audio sample rate (0x44) **.** ...................................15
+DC offset (0x51) **.** ..........................................................................16
+Short circuit status (0x52)........................................................16
+Timeout counter (0x55)............................................................17
+Lifter temperature (0x56) **.** ......................................................17
+Output temperature (0x57)....................................................18
+Auto shutdown control (0x58) **.** .............................................18
+PHONO input type (0x59) **.** ......................................................19
+Input detect (0x5A) **.** ...................................................................19
+Processor mode input (0x5B).................................................20
+Processor mode volume (0x5C)............................................20
+System status (0x5D) **.** ................................................................21
+System model (0x5E).................................................................22
+DAC Filter (0x61)..........................................................................22
+Now Playing information (0x64)...........................................23
+Maximum Turn On Volume (0x65).......................................24
+Maximum Volume (0x66) **.** .......................................................24
+Maximum Streaming Volume (0x67)..................................25
+RC5 Command Codes....................................................26
+
+Basic Functions **.** ...........................................................................26
+Advanced Functions..................................................................26
+
+
+
+**Applicability**
+
+
+This document applies to the Arcam SA30 integrated amplifier.
+
+
+**Revision history**
+
+
+Issue A.0: Initial revision
+
+Issue B.0: Additional network commands
+
+Issue 1.0: First release version
+
+Issue 2.0: Added max streaming volume, correcrted max vol
+examples
+
+Added ARC version
+
+Add NET as selectable input
+
+Issue 3.0 Combine USB and NET inputs (0x1D)
+
+Issue 4.0 Add ARC iR input
+
+
+
+2
+
+
+**Controlling via RS232/NET**
+
+
+**Introduction**
+
+
+This document describes the remote control protocol for controlling via the RS232/NET interface.
+
+**Set-up**
+
+
+IP control is via port 50000 of the IP address of the unit.
+
+**Conventions**
+
+
+ - All hexadecimal numbers begin 0x.
+
+ - Any character in single quotes gives the ASCII equivalent of a hex value.
+
+ - <n> represents an unknown or variable number.
+**Serial cable specification**
+
+
+The cable is wired as a null modem:
+
+|Connector 1 pin|Connector 2 pin|Function|
+|---|---|---|
+|2|3|Rx Tx|
+|3|2|Tx Rx|
+|5|5|RS232 Ground|
+
+
+
+**Data transfer format**
+
+
+ - Transfer rate: 38,400bps
+
+ - Data format: 8 data bits, 1 stop bit, no parity, no flow control.
+**Command and response formats**
+
+
+Communication between the remote controller (RC) and the SA30 takes the form of sequences of bytes, with all commands and responses having the same
+basic format. The SA30 shall always respond to a received command, but may also send messages at other times.
+
+Each transmission by the RC hs the following format:
+
+<St> <Zn> <Cc> <Dl> <Data> <Et>
+
+         - St (Start transmission): 0x21 ‘!’
+
+         - Zn (Zone number): see below
+
+         - Cc (Command code): the code for the command
+
+         - Dl (Data length): the number of data items following this item, excluding the Et
+
+         - Data: the parameters for the command
+
+         - Et (End transmission): 0x0D
+
+Each response by the SA30 has the following format:
+
+<St> <Zn> <Cc> <Ac> <Dl> <Data> <Et>
+
+         - St (Start transmission): 0x21 ‘!’
+
+         - Zn (Zone number): see “Zone numbers”, below
+
+         - Cc (Command code): the code for the command
+
+         - Ac (Answer code): see “Answer codes”, below
+
+         - Dl (Data Length): the number of data items following this item, excluding the Et
+
+         - Data: the parameters for the response of length n (note that n is limited to 255)
+
+         - Et (End transmission): 0x0D
+
+The SA30 responds to each command from the RC within three seconds. The RC may send further commands before a previous command response has been
+received.
+
+**Zone numbers**
+
+
+The following zone numbers are defined:
+
+         - 0x01 – Zone number 1. (Zone 1 is the master zone. Commands that appear zone-less refer to the master zone)
+
+         - 0x02 – Zone number 2
+
+
+
+3
+
+
+**Answer codes**
+
+
+The following answer codes are defined:
+
+         - 0x00 – Status update.
+
+         - 0x82 – Zone Invalid.
+
+         - 0x83 – Command not recognised.
+
+         - 0x84 – Parameter not recognised.
+
+         - 0x85 – Command invalid at this time (see **NOTE** below)
+
+         - 0x86 – Invalid data length.
+
+**NOTE** : Certain commands cannot be processed when the Setup Menu is being displayed. An answer code of 0x85 will be returned in these circumstances. Also,
+commands for tuner control cannot be processed when the tuner input is not selected, etc.
+
+**State changes as a result of other inputs**
+
+
+It is possible that the state of the SA30 may be changed as a result of user input via front panel or remote. Any change resulting from these inputs is relayed to
+the RC using the appropriate message type.
+
+**Reserved Commands**
+
+
+Commands 0xF0 to 0xFF (inclusive) are reserved for test functions and should never be used.
+
+**Example command and response sequence**
+
+
+As an example, the command to simulate the RC5 command “16-16” (increase volume):
+
+|St|Zn|Cc|Dl|Data 1|Data 2|Et|
+|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x02|0x10|0x10|0x0D|
+
+
+
+Assuming that the command was accepted by the SA30 and is being processed, the SA30 responds to this command with the following sequence:
+
+|St|Zn|Cc|Ac|Dl|Data 1|Data 2|Et|
+|---|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x00|0x02|0x10|0x10|0x0D|
+
+
+
+**AMX Duet™ support**
+
+
+The SA30 shall be fully compatible with AMX Duet™ Dynamic Device Discovery Protocol (DDDP). The following description of Dynamic Device Discovery
+comes from the AMX website ( _**www.amx.com**_ ). Dynamic Device Discovery is part of AMX’s Duet™ platform, which combines the proven reliability and power of
+NetLinx® with the extensive capabilities of the Java 2 Micro Edition (J2ME) platform. When integrating a serial or IP device from a manufacturer embedding the
+Dynamic Device Discovery Protocol (DDDP), Duet recognizes the device and loads the appropriate Duet module, which automatically installs the new device.
+AMX’s NetLinx Master can then find and install the Duet device module either from a library on the master, from AMX’s web site, or from the manufacturer’s web
+site. Duet also allows for device swapping so that programming changes are not required when devices with DDDP are removed or replaced – a huge benefit
+for end users. The Duet platform is an extension AMX’s InConcert® manufacturer partner program, which was developed to ensure seamless communication
+between partners’ devices and the AMX control system.
+
+
+Data is specified in the ASCII format. All ASCII characters between the quotes “” should be recognised/transmitted. “\r” is a carriage return (0x0D).
+
+Command: “AMX\r”
+Response: “AMXB<Device-SDKClass=Amplifier><Device-Make=ARCAM><Device-Model=SA30><Device-Revision=x.y.z>\r”
+
+Where,
+
+x.y.z = RS232 protocol version number.
+
+
+
+4
+
+
+**System Command Specifications**
+
+
+**Power (0x00)**
+
+
+Set/request the stand-by state of a zone.
+
+**Example**
+
+
+Command/response sequence to request the power state of the unit where
+the unit has power on:
+
+Command: 0x21 0x01 0x00 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x00 0x00 0x01 0x01 0x0D
+
+
+**Display brightness (0x01)**
+
+
+Set/request the brightness of the front panel display.
+
+**Example**
+
+
+Command/response sequence for requesting the brightness of the display
+where the display is off:
+
+Command: 0x21 0x01 0x01 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x01 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Dl|0x01|
+|Data|0x00 – Power off<br>0x01 – Power on<br>0x02 – Power toggle<br>0xF0 – Request power state|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Zone is in standby<br>0x01 – Zone is powered on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x01|
+|Dl|0x01|
+|Data|0x00 – Set brightness to off<br>0x01 – Set brightness to dim<br>0x02 – Set brightness to full<br>0xF0 – Request display brightness|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x01|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Display brightness is off<br>0x01 – Display brightness is dim<br>0x02 – Display brightness is full|
+|Et|0x0D|
+
+
+
+5
+
+
+**Headphones (0x02)**
+
+
+Determine whether headphones are connected.
+
+**Example**
+
+
+Command/response sequence to request the headphone status where the
+headphones are not connected:
+
+Command: 0x21 0x01 0x02 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x02 0x00 0x01 0x00 0x0D
+
+
+**Software version (0x04)**
+
+
+Request the firmware version
+
+**Example**
+
+
+Command/response sequence, where the repsonse is HOST version 1.2:
+
+Command: 0x21 0x01 0x04 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x04 0x00 0x02 0xF0 0x01 0x02 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x02|
+|Dl|0x01|
+|Data|0xF0 – Request current headphone connection status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x02|
+|Ac|Answer code|
+|Dl|0x01 (Data length)|
+|Data|0x00 – Headphones are not connected.<br>0x01 – Headphones are connected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x04|
+|Dl|0x01|
+|Data|0xF0 – request software version<br>0xF2 - request ARC version<br>0xF3 - request ARC Rx version|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x04|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|Echo data from command|
+|Data2|0x?? – major version number|
+|Data3|0x?? – minor version number|
+|Et|0x0D|
+
+
+
+6
+
+
+**Factory reset (0x05)**
+
+
+This command resets the unit to factory defaults.
+
+**Example**
+
+
+Command/response sequence for resetting the unit to factory defaults:
+
+Command: 0x21 0x01 0x05 0x02 0xAA 0xAA 0x0D
+Response: 0x21 0x01 0x05 0x00 0x00 0x0D
+
+
+**Simulate RC5 IR command (0x08)**
+
+
+Simulate an RC5 command via the RS232 port. An additional status message
+will be sent in most cases as a result of the IR command.
+
+**Example**
+
+
+Command/response sequence to RC5 16-17 (volume down):
+
+Command: 0x21 0x01 0x08 0x02 0x10 0x11 0x0D
+Response: 0x21 0x01 0x08 0x00 0x02 0x10 0x11 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x05|
+|Dl|0x02|
+|Data1|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Data2|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x05|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+
+
+
+7
+
+
+**Volume (0x0D)**
+
+
+Set or request the volume of a zone.
+
+This command returns the volume even if the zone requested is in mute.
+The “Request Mute status” command can be used to discover if the zone is
+muted.
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+**Example**
+
+
+Command/response sequence for setting the volume in Zone 1 to 45:
+
+Command: 0x21 0x01 0x0D 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x0D 0x00 0x01 0x2D 0x0D
+
+
+**Mute/unmute (0x0E)**
+
+
+Set/Request the mute status of the output.
+
+**Example**
+
+
+Command/response sequence for requesting the mute status of output
+where the result is unmuted:
+
+Command: 0x21 0x01 0x0E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0E 0x00 0x01 0x02 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the volume<br>0xF0 – Request the current volume<br>0xF1 – Increment volume by 1 step<br>0xF2 – Decrement volume by 1 step|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Zone volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Dl|0x01|
+|Data|0x00 – Mute<br>0x01 – Unmute<br>0x02 – Mute toggle<br>0xF0 – Request mute status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Muted<br>0x01 – Unmuted|
+|Et|0x0D|
+
+
+
+8
+
+
+**Direct mode status (0x0F)**
+
+
+Set or request the analogue input direct mode of an input
+
+**Example**
+
+
+Command/response sequence to request the direct mode status where the
+mode is direct and input is CD:
+
+Command: 0x21 0x01 0x0F 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0F 0x00 0x02 0x06 0x01 0x0D
+
+
+**Network playback status (0x1C)**
+
+
+Network message format.
+
+If the network is not selected on the given zone an error 0x85 is returned.
+
+**Example**
+
+
+Command/response sequence where the network module is playing.
+
+Command: 0x21 0x01 0x1C 0x01 0xF0 0x0D
+
+
+Response: 0x21 0x01 0x1C 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0F|
+|Dl|0x01 (Query), 0x02 for setting|
+|Data 1|0x01 – Phono<br>0x02 – AUX<br>0x03 – PVR<br>0x05 – STB<br>0x06 – CD<br>0xF0 – Request mode setting of current input|
+|Data 2|0x00 – Turn ‘Direct mode’ off<br>0x01 – Turn‘Direct mode’ on|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data 1|0x01 – Phono<br>0x02 – AUX<br>0x03 – PVR<br>0x05 – STB<br>0x06 – CD|
+|Data 2|0x00 – ‘Direct mode’ is off<br>0x01 – ‘Direct mode’ is on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Dl|0x01|
+|Data|0xF0 – Request Network playback status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Stopped<br>0x01 – Transitioning<br>0x02 – Playing<br>0x03  - Paused|
+|Et|0x0D|
+
+
+
+9
+
+
+**Current input source (0x1D)**
+
+
+Set/request the current input source.
+
+**Example**
+
+
+Command/response sequence to request the current source for Zone 1
+where the source is set to ‘PVR’ and set to processor mode:
+
+Command: 0x21 0x01 0x1D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x1D 0x00 0x01 0x13 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Dl|0x01|
+|Data|0x01 – Phono<br>0x02 – AUX<br>0x03 – PVR<br>0x04 – AV<br>0x05 – STB<br>0x06 – CD<br>0x07 – BD<br>0x08 – SAT<br>0x09 - GAME<br>0x0B - NET/USB<br>0x0D - ARC<br>0xF0 - Request input|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Ac|Answer code|
+|Dl|0x02|
+|Data|The current source in the indicated zone:<br>0x01 – Phono<br>0x(N)2 – AUX<br>0x(N)3 – PVR<br>0x(N)4 – AV<br>0x(N)5 – STB<br>0x(N)6 – CD<br>0x(N)7 – BD<br>0x(N)8 – SAT<br>0x(N)9 - GAME<br>0x0B - NET/USB<br>0x0D - ARC<br>N = 0 indicates source is normal mode<br>N = 1 indicates source is set to processor (fixed gain) mode|
+|Et|0x0D|
+
+
+
+10
+
+
+**Headphone override (0x1F)**
+
+
+Activate/deactivate the mute relays (does not zero the volume).
+
+**Example**
+
+
+Command/response sequence to activate the mute relays:
+
+Command: 0x21 0x01 0x1F 0x01 0x01 0x0D
+Response: 0x21 0x01 0x1F 0x00 0x01 0x01 0x0D
+
+
+**Heartbeat (0x25)**
+
+
+Heartbeat command to check unit is still connected and communicating also resets the EuP standby timer.
+
+**Example**
+
+
+Command/response to sending a heartbeat command:
+
+Command: 0x21 0x01 0x25 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x25 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Dl|0x01|
+|Data|0x00 – Headphone/Over-ride Clear (speakers muted if headphones present)<br>0x01 – Headphone/Over-ride Set (speakers unmuted if headphones present)<br>0xF0 - Request Headphone/Over-ride status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Relay state|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x25|
+|Dl|0x01|
+|Data|0xF0 – Heartbeat|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x25|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Response|
+|Et|0x0D|
+
+
+
+11
+
+
+**Reboot (0x26)**
+
+
+Forces a reboot of the unit.
+
+**Example**
+
+
+Command/response to sending a reboot command:
+
+Command: 0x21 0x01 0x26 0x06 0x52 0x45 0x42 0x4F
+0x4F 0x54 0x0D
+Response: 0x21 0x01 0x26 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x26|
+|Dl|0x06|
+|Data1|0x52|
+|Data2|0x45|
+|Data3|0x42|
+|Data4|0x4F|
+|Data5|0x4F|
+|Data6|0x54|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x26|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Response|
+|Et|0x0D|
+
+
+
+12
+
+
+**Network (0x30)**
+
+
+Request network info.
+
+**Example**
+
+
+Command/response sequence for requesting the IP address, where the
+address is 192 168 1 1
+
+Command: 0x21 0x01 0x30 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x30 0x00 0x04 0xC0 0xA8 0x01 0x010x0D
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x30|
+|Dl|0x01|
+|Data1|0xF0 - Request IP address<br>0xF1 - Request Wired MAC address<br>0xF2 - Request WiFi MAC address<br>0xF3 - Request  Friendly name<br>0xF4 - Request Host Name<br>0xF5 - Request  SSID|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x30|
+|Ac|Answer code|
+|Dl|0x04 (IP), 0x06 (MAC), <n> (Name)|
+|||
+||IP Address|
+|Data1|0x?? First byte of IP address|
+|Data2|0x?? Second byte of IP address|
+|Data3|0x?? Third byte of IP address|
+|Data4|0x?? Forth byte of IP address|
+|||
+||Wired/WiFi MAC Address|
+|Data1|0x?? First byte of MAC address|
+|Data2|0x?? Second byte of MAC address|
+|Data3|0x?? Third byte of MAC address|
+|Data4|0x?? Forth byte of MAC address|
+|Data5|0x?? Fifth byte of MAC address|
+|Data6|0x?? Sixth byte of MAC address|
+|||
+||Friendly/Host name|
+|Data1 -<br>Data <n-1>|Friendly name in ASCII characters|
+|||
+||SSID|
+|Data1 -<br>Data <n-1>|SSID in ASCII characters|
+|Et|0x0D|
+
+
+
+13
+
+
+**Room EQ names (0x34)**
+
+
+Request Room EQ name(s).
+
+
+**Room Equalisation (0x37)**
+
+
+Turn the room equalisation system on/off.
+
+**Example**
+
+
+Command/response sequence to turn the room equalisation 1 on:
+
+Command: 0x21 0x01 0x37 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x37 0x00 0x01 0x01 0x0D
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x34|
+|Dl|0x01|
+|Data1|0xF0 - request EQ names|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x34|
+|Ac|Answer code|
+|Dl|0xn - dependant on number of EQ slots filled, 20, 40, 60, 80,100, 120|
+|Data1-20<br>Data21-40<br>Data41-60<br>Data61-80<br>Data81-100<br>Data101-<br>120|EQ1 name (read only / 20 characters)<br>name in ASCII characters<br>EQ2 name (read only / 20 characters)<br>name in ASCII characters<br>EQ3 name (read only / 20 characters)<br>name in ASCII characters<br>EQ4 name (read only / 20 characters)<br>name in ASCII characters<br>EQ5 name (read only / 20 characters)<br>name in ASCII characters<br>EQ6 name (read only / 20 characters)<br>name in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x37|
+|Dl|0x01|
+|Data|0xF0 – Request current Room EQ state<br>0x00 - Room EQ off<br>0x01 – Room EQ 1 on<br>0x02 - Room EQ 2 on<br>0x03 -Room EQ 3 on<br>0x04 -Room EQ 4 on<br>0x05 -Room EQ 5 on<br>0x06 -Room EQ 6 on|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x37|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Room EQ is off<br>0x01 – Room EQ 1 is on<br>0x02 – Room EQ 2 is on<br>0x03 – Room EQ 3 is on<br>0x04 – Room EQ 4 is on<br>0x05 – Room EQ 5 is on<br>0x06 – Room EQ 6 is on<br>0x0A – Room EQ has not been calculated and is therefore off|
+|Et|0x0D|
+
+
+
+14
+
+
+**Balance (0x3B)**
+
+
+Adjust the balance control.
+
+**Example**
+
+
+Command/response sequence to set the balance 3dB to the left:
+
+Command: 0x21 0x01 0x3B 0x01 0x83 0x0D
+Response: 0x21 0x01 0x3B 0x00 0x01 0x83 0x0D
+
+
+**Incoming audio sample rate (0x44)**
+
+
+Request the incoming audio sample rate.
+
+**Example**
+
+
+Command/response sequence to request the incoming audio sample rate,
+where the rate is 48kHz:
+
+Command: 0x21 0x01 0x44 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x44 0x00 0x01 0x02 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Dl|0x01|
+|Data|0x00 – Set the balance to the centre<br>0x01 – 0x0C – Set the balance to the right 1, 2, ..., 11, 12<br>0x81 – 0x8C – Set the balance to the left 1, 2,..., 11, 12<br>0xF0 – Request current balance<br>0xF1 – Move the balance right by 1dB<br>0xF2 – Move the balance left by 1dB|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Balance is Centred<br>0x00 – 0x0C – Balance is Right 1, 2,...,11, 12<br>0x81 – 0x8C – Balance is Left 1, 2,...,11, 12|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Dl|0x01|
+|Data|0xF0 – Request incoming audio sample rate|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Incoming audio sample rate:<br>0x00 – 32 kHz<br>0x01 – 44.1 kHz<br>0x02 – 48 kHz<br>0x03 – 88.2 kHz<br>0x04 – 96 kHz<br>0x05 – 176.4 kHz<br>0x06 – 192 kHz<br>0x07 – Unknown<br>0x08 – Undetected|
+|Et|0x0D|
+
+
+
+15
+
+
+**DC offset (0x51)**
+
+
+Request the output DC offset status.
+
+**Example**
+
+
+Command/response sequence for requesting the DC offset status where the
+result is no DC offset:
+
+Command: 0x21 0x01 0x51 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x51 0x00 0x01 0x00 0x0D
+
+
+**Short circuit status (0x52)**
+
+
+Request the output short circuit status.
+
+**Example**
+
+
+Command/response sequence for requesting the short circuit status, where
+the result is no short circuit:
+
+Command: 0x21 0x01 0x52 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x52 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x51|
+|Dl|0x01|
+|Data|0xF0 – Request DC offset status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x51|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - OK<br>0x01 - DC offset detected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x52|
+|Dl|0x01|
+|Data|0xF0 – Request short circuit status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x52|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - No short circuit detected<br>0x01 - One of the channels has short circuit fault|
+|Et|0x0D|
+
+
+
+16
+
+
+**Timeout counter (0x55)**
+
+
+This command requests the time left (in minutes) until unit enters auto
+standby.
+
+**Example**
+
+
+Command/response sequence for requesting the time left until timeout:
+
+Command: 0x21 0x01 0x55 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x55 0x00 0x02 0x00 0xF0 0x0D
+
+In this example, the timeout value is 0x00B4, which translates to 180 minutes
+(i.e. 3 hours). The range of the value returned is from 0x0000 - 0x00F0 (0 - 240
+minutes)
+
+
+**Lifter temperature (0x56)**
+
+
+Request the temperature of the lifter.
+
+**Example**
+
+
+Command/response sequence for requesting the temperature of the lifter
+where the result is 75degC:
+
+Command: 0x21 0x01 0x56 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x56 0x00 0x01 0x4B 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x55|
+|Dl|0x01|
+|Data|0xF0|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x55|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|0x00 (First byte of timeout counter, value is fixed)|
+|Data2|0x00 – 0xF0 (Second byte timeout counter)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x56|
+|Dl|0x01|
+|Data|0xF0 – Request lifter temperature|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x56|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x?? – Temperature in deg C in hex, e.g. 75degC = 4B|
+|Et|0x0D|
+
+
+
+17
+
+
+**Output temperature (0x57)**
+
+
+Request the temperature of the output stage.
+
+**Example**
+
+
+Command/response sequence for requesting the temperature of the output
+where the result is 75 degC:
+
+Command: 0x21 0x01 0x57 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x57 0x00 0x01 0x4B 0x0D
+
+
+**Auto shutdown control (0x58)**
+
+
+Set time for when unit will go into standby state die to no signal being
+present
+
+**Example 1**
+
+
+Command/response sequence, the signal sense auto shutdown timeout has
+been set to 60 minutes:
+
+Command: 0x21 0x01 0x58 0x01 0x03 0x0D
+Response: 0x21 0x01 0x58 0x00 0x01 0x03 0x0D
+
+**Example 2**
+
+
+Command/response sequence, the signal sense auto shutdown has been
+disabled:
+
+Command: 0x21 0x01 0x58 0x01 0x00 0x0D
+Response: 0x21 0x01 0x58 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x57|
+|Dl|0x01|
+|Data|0xF0 – Request output temperature|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x57|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x?? – Temperature in deg C in hex, e.g. 75degC = 4B|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x58|
+|Dl|0x01|
+|Data|0x00 – Disable (Default)<br>0x01 – 20 min<br>0x02 – 30 min<br>0x03 – 1 hour<br>0x04 – 2 hours<br>0x05 – 4 hours<br>0xF0 – Request timeout status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x58|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Disabled<br>0x01 – 20 min<br>0x02 – 30 min<br>0x03 – 1 hour<br>0x04 – 2 hours<br>0x05 – 4 hours|
+|Et|0x0D|
+
+
+
+18
+
+
+**PHONO input type (0x59)**
+
+
+Set or request Phono input type.
+
+**Example**
+
+
+Command/response sequence where PHONO input is set to Moving Magnet
+type
+
+Command: 0x21 0x01 0x59 0x01 0x00 0x0D
+Response: 0x21 0x01 0x59 0x00 0x01 0x00 0x0D
+
+
+**Input detect (0x5A)**
+
+
+Request the status of the active input.
+
+**Example**
+
+
+Command/response sequence where audio input is present.
+
+Command: 0x21 0x01 0x5A 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5A 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x59|
+|Dl|0x01|
+|Data|0x00 - Set PHONO input to Moving Magnet type<br>0x01 - Set PHONO input to Moving Coil type<br>0xF0 - Request PHONO input type|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x59|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - PHONO input set to Moving Magnet type<br>0x01 - PHONO input set to Moving Coil type|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5A|
+|Dl|0x01|
+|Data|0xF0 - Request input status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5A|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Input not present<br>0x01 - Input present|
+|Et|0x0D|
+
+
+
+19
+
+
+**Processor mode input (0x5B)**
+
+
+Enable processor mode on a certain input or disable processor mode.
+
+**Example**
+
+
+Enable processor mode on the CD input:
+
+Command: 0x21 0x01 0x5B 0x01 0x06 0x0D
+Response: 0x21 0x01 0x5B 0x00 0x01 0x06 0x0D
+
+
+**Processor mode volume (0x5C)**
+
+
+Set the processor mode volume
+
+**Example**
+
+
+Command/response sequence to set the processor mode volume to 45
+(0x2D).
+
+Command: 0x21 0x01 0x5C 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x5C 0x00 0x01 0x2D 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5B|
+|Dl|0x01|
+|Data|0x00 - Disable<br>0x02 - Aux<br>0x03 - PVR<br>0x04 - AV<br>0x05 - STB<br>0x06 - CD<br>0x07 - BD<br>0x08 - SAT<br>0x09 - GAME<br>0xF0 - Query processor mode status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Disabled<br>0x02 - Aux<br>0x03 - PVR<br>0x04 - AV<br>0x05 - STB<br>0x06 - CD<br>0x07 - BD<br>0x08 - SAT<br>0x09 - GAME|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5C|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the volume<br>0xF0 – Request the current volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 (0)– 0x63 (99)|
+|Et|0x0D|
+
+
+
+20
+
+
+**System status (0x5D)**
+
+
+Request the system status.
+
+**Example**
+
+
+Command/response sequence to request the system status.
+
+Command: 0x21 0x01 0x5D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5D 0x00 0x01 0xF0 0x0D
+
+
+**Note:**
+
+
+This command will return the following information about the system:
+
+         - Power state
+
+         - Brightness level
+
+         - Headphone status
+
+         - Software version
+
+         - Model Number
+
+         - Volume setting
+
+         - Mute status
+
+         - Current input source
+
+         - Headphone override status
+
+         - Balance setting
+
+         - Sample rate
+
+         - Network name
+
+         - IP address
+
+         - Timeout counter value
+
+         - Lifter temperature
+
+         - Output temperature
+
+         - Auto shutdown status
+
+         - Input detect status
+
+         - Processor mode input
+
+         - Processor mode volume
+
+         - DC offset status
+
+         - Short circuit status
+
+         - DAC Filter
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5D|
+|Dl|0x01|
+|Data|0xF0 – Request the system|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0xF0 - System status sent|
+|Et|0x0D|
+
+
+
+21
+
+
+**System model (0x5E)**
+
+
+Request the system model.
+
+**Example**
+
+
+Command/response sequence to request the system model, where the
+model is SA30.
+
+Command: 0x21 0x01 0x5E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5E 0x00 0x04 0x53 0x41 0x33 0x30 0x0D
+
+
+**DAC Filter (0x61)**
+
+
+Sets or requests the DAC filter
+
+**Example**
+
+
+Command/response sequence to request the DAC filter where response is
+Linear Phase Fast Roll Off
+
+Command: 0x21 0x01 0x61 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x61 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5E|
+|Dl|0x01|
+|Data|0xF0 – Request the system model|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5E|
+|Ac|Answer code|
+|Dl|0x04|
+|Data|System model in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x61|
+|Dl|0x01|
+|Data|0x00 - Linear Phase Fast Roll Off<br>0x01 - Linear Phase Slow Roll Off<br>0x02 - Minimum Phase Fast Roll Off<br>0x03 - Minimum Phase Slow Roll Off<br>0x04 - Brick Wall<br>0x05 - Corrected Phase Fast Roll Off<br>0x06 - Apodizing<br>0xF0 - Request the current filter|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x61|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Linear Phase Fast Roll Off<br>0x01 - Linear Phase Slow Roll Off<br>0x02 - Minimum Phase Fast Roll Off<br>0x03 - Minimum Phase Slow Roll Off<br>0x04 - Brick Wall<br>0x05 - Corrected Phase Fast Roll Off<br>0x06 - Apodizing|
+|Et|0x0D|
+
+
+
+22
+
+
+**Now Playing information (0x64)**
+
+
+Request the various now playing track details. If the unit is currently playing
+from a source other than a streaming input the track name etc will returned
+as NULL.
+
+**Example**
+
+
+Command/response sequence to request the currently playing artist where
+the response is A
+
+Command: 0x21 0x01 0x64 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x64 0x00 0x02 0x41 0x0D
+
+**Note**
+
+
+Response length is limited to 100 characters
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x64|
+|Dl|0x01|
+|Data|0xF0 – Request the currently playing track title<br>0xF1 - Request the currently playing artist<br>0xF2 - Request the currently playing album<br>0xF3 - Request the currently playing application (GoogleCast only)<br>0xF4 - Request the currently playing sample rate<br>0xF5 - Request the currently playing track encoder|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x64|
+|Ac|Answer code|
+|Dl|<n>|
+|Data|Track:<br>Track title in ASCII characters<br>Album:<br>Album name in ASCII characters<br>Artist:<br>Artist name in ASCII characters<br>Application:<br>GoogleCast source application in ASCII characters<br>Sample rate:<br>0x00 – 32 kHz<br>0x01 – 44.1 kHz<br>0x02 – 48 kHz<br>0x03 – 88.2 kHz<br>0x04 – 96 kHz<br>0x05 – 176.4 kHz<br>0x06 – 192 kHz<br>0x07 – Unknown<br>0x08 – Undetected<br>Audio encoder:<br>0x00 – Uknown<br>0x01 – MP3<br>0x02 – WMA<br>0x03 – Ogg Vorbis<br>0x04 - FLAC<br>0x05 – WAV<br>0x06 - AIFF<br>0x07 - RealAudio<br>0x08 - MPEG URL<br>0x09 - SCPLS<br>0x0A - WPL<br>0x0B - MP4<br>0x0C - DSD<br>0x0D - Opus<br>0x0E - Sirius<br>0x0F - MQA|
+|Et|0x0D|
+
+
+
+23
+
+
+**Maximum Turn On Volume (0x65)**
+
+
+Set or request the maximum volume level at power up of the SA30.
+
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+**Example**
+
+
+Command/response sequence for setting the maximum turn on volume in
+Zone 1 to 45:
+
+Command: 0x21 0x01 0x65 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x65 0x00 0x01 0x2D 0x0D
+
+
+**Maximum Volume (0x66)**
+
+
+Set or request the maximum volume level of the SA30. Used to prevent
+volume being accidently set to full when using app volume sliders.
+
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+**Example**
+
+
+Command/response sequence for setting the maximum volume in Zone 1
+to 45:
+
+Command: 0x21 0x01 0x66 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x66 0x00 0x01 0x2D 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x65|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the maximum turn on volume<br>0xF0 – Request the maximum turn on volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x65|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Maximum turn on volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x66|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the maximum volume<br>0xF0 – Request the maximum volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x66|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Maximum volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+
+24
+
+
+**Maximum Streaming Volume (0x67)**
+
+
+Set or request the maximum volume level of the SA30 when playing back
+streamed content. Used to prevent volume being accidently set to full when
+using app volume sliders and increase the resolution of the app volume
+sliders
+
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+**Example**
+
+
+Command/response sequence for setting the maximum volume in Zone 1
+to 45:
+
+Command: 0x21 0x01 0x67 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x67 0x00 0x01 0x2D 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x67|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the maximum volume<br>0xF0 – Request the maximum volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x67|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Maximum volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+
+25
+
+
+**RC5 Command Codes**
+
+
+These codes are recognised as infra-red signals received by the front panel and as control data using the “Simulate RC5 IR command (0x08)” on page 7.
+
+
+
+**Basic Functions**
+
+
+These RC5 codes are present on the supplied IR remote control and provide
+control over basic amplifier functions.
+
+
+
+**Advanced Functions**
+
+
+These RC5 codes are not present on the supplied remote control but have
+been created for custom install use. In order for the amp to respond to these
+codes they must be transmitted from a programmable IR remote control or
+over the control link using the ‘Simulate RC5 IR Command’ (0x08).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Power On|16-123|0x10 - 0x7B|
+|Power Off|16-124|0x10 - 0x7C|
+|Random|16-76|0x10 - 0x4C|
+|Repeat|16-49|0x10 - 0x31|
+|Direct mode On|16-78|0x10 - 0x4E|
+|Direct mode Off|16-79|0x10 - 0x4F|
+|Mute On|16-26|0x10 - 0x1A|
+|Mute Off|16-120|0x10 - 0x78|
+|Display Off|16-31|0x10 - 0x1F|
+|Display L1|16-34|0x10 - 0x22|
+|Display L2|16-35|0x10 - 0x23|
+|Balance left|16-38|0x10 - 0x26|
+|Balance right|16-40|0x10 - 0x28|
+
+
+|Function|RC5 code<br>[system-<br>command]|RC5 code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Standby|16-12|0x10 - 0x0C|
+|1|16-1|0x10 - 0x01|
+|2|16-2|0x10 - 0x02|
+|3|16-3|0x10 - 0x03|
+|4|16-4|0x10 - 0x04|
+|5|16-5|0x10 - 0x05|
+|6|16-6|0x10 - 0x06|
+|7|16-7|0x10 - 0x07|
+|8|16-8|0x10 - 0x08|
+|9|16-9|0x10 - 0x09|
+|Access Balance Control|16-37|0x10 - 0x25|
+|0|16-0|0x10 - 0x00|
+|Cycle between VFD information panels|16-55|0x10 - 0x37|
+|Rewind|16-121|0x10 - 0x79|
+|Fast Forward|16-52|0x10 - 0x34|
+|Skip Back|16-33|0x10 - 0x21|
+|Skip Forward|16-11|0x10 - 0x0B|
+|Stop|16-54|0x10 - 0x36|
+|Play|16-53|0x10 - 0x35|
+|Pause|16-48|0x10 - 0x30|
+|MENU (Enter system menu)|16-82|0x10 - 0x52|
+|Navigate Up|16-86|0x10 - 0x56|
+|Navigate Left|16-81|0x10 - 0x51|
+|OK|16-87|0x10 - 0x57|
+|Navigate Right|16-80|0x10 - 0x50|
+|Audio (Room EQ on/off)|16-30|0x10 - 0x1E|
+|Navigate Down|16-85|0x10 - 0x55|
+|RTN (Back in menu)|16-51|0x10 - 0x33|
+|HOME|16-43|0x10 - 0x2B|
+|Mute|16-13|0x10 - 0x0D|
+|Increase volume (+)|16-16|0x10 - 0x10|
+|DISP (Change VFD brightness)|16-59|0x10 - 0x3B|
+|Analogue DIRECT mode|16-10|0x10 - 0x0A|
+|Decrease volume (-)|16-17|0x10 - 0x11|
+|PHONO|16-117|0x10 - 0x75|
+|AUX|16-99|0x10 - 0x63|
+|NET|16-92|0x10 - 0x5C|
+|USB|16-93|0x10 - 0x5D|
+|AV|16-94|0x10 - 0x5E|
+|SAT|16-27|0x10 - 0x1B|
+|PVR|16-96|0x10 - 0x60|
+|GAME|16-97|0x10 - 0x61|
+|BD|16-98|0x10 - 0x62|
+|CD|16-118|0x10 - 0x76|
+|STB|16-100|0x10 - 0x64|
+|ARC/eARC|16-125|0x10 - 0x7D|
+
+
+
+26
+
+
+SH306E Issue 4
+
+
+
+www.arcam.co.uk
+
+THE WEST WING, STIRLING HOUSE
+
+WATERBEACH, CAMBRIDGE, CB25 9PB, ENGLAND
++44 (0)1223 203200
+
+

--- a/docs/specs/SH309_RS232_ST60_C.md
+++ b/docs/specs/SH309_RS232_ST60_C.md
@@ -1,0 +1,1387 @@
+# Custom Installation Notes IP/Serial programming interface and IR remote control commands for the ST60 audio streamer
+
+
+
+
+
+
+**Contents**
+
+
+Controlling via RS232/NET.............................................3
+Introduction.................................................................................... 3
+Set-up **.** ............................................................................................... 3
+Conventions.................................................................................... 3
+Serial cable specification **.** .......................................................... 3
+Data transfer format **.** ................................................................... 3
+Command and response formats **.** ......................................... 3
+AMX Duet™ support **.** ................................................................... 4
+System Command Specifications................................5
+Power (0x00) **.** .................................................................................. 5
+Display brightness (0x01).......................................................... 5
+Software version (0x04) **.** ............................................................ 6
+Factory reset (0x05)...................................................................... 6
+Simulate RC5 IR command (0x08).......................................... 7
+Volume (0x0D) **.** .............................................................................. 7
+Mute/unmute (0x0E) **.** .................................................................. 8
+Network playback status (0x1C) ............................................ 8
+Current input source (0x1D)..................................................... 9
+Heartbeat (0x25) **.** .......................................................................... 9
+Reboot (0x26)...............................................................................10
+Network (0x30) **.** ...........................................................................11
+Incoming audio sample rate (0x44) **.** ...................................12
+Timeout counter (0x55)............................................................12
+Auto shutdown control (0x58) **.** .............................................13
+Input detect (0x5A) **.** ...................................................................13
+Fixed Volume (0x5C)..................................................................14
+System status (0x5D) **.** ................................................................14
+System model (0x5E).................................................................15
+DAC Filter (0x61)..........................................................................15
+Now Playing information (0x64)...........................................16
+Maximum Turn On Volume (0x65).......................................17
+Maximum Volume (0x66) **.** .......................................................17
+Maximum Streaming Volume (0x67)..................................18
+Dark mode (0x68) **.** ......................................................................18
+RC5 Command Codes....................................................19
+Basic Functions **.** ...........................................................................19
+Advanced Functions..................................................................19
+
+
+
+**Applicability**
+
+
+This document applies to the Arcam ST60 audio streamer
+
+
+**Revision history**
+
+
+Issue A.0: Initial revision
+
+Issue B.0: Correct Baud rate, remove unused
+commands.
+
+Issue C.0: Friendly name and now playing info encoding
+changed to UTF-8.
+
+
+
+2
+
+
+**Controlling via RS232/NET**
+
+
+**Introduction**
+
+
+This document describes the remote control protocol for controlling via the RS232/NET interface.
+
+**Set-up**
+
+
+IP control is via port 50000 of the IP address of the unit.
+
+**Conventions**
+
+
+ - All hexadecimal numbers begin 0x.
+
+ - Any character in single quotes gives the ASCII equivalent of a hex value.
+
+ - <n> represents an unknown or variable number.
+**Serial cable specification**
+
+
+The cable is wired as a null modem:
+
+|Connector 1 pin|Connector 2 pin|Function|
+|---|---|---|
+|2|3|Rx Tx|
+|3|2|Tx Rx|
+|5|5|RS232 Ground|
+
+
+
+**Data transfer format**
+
+
+ - Transfer rate: 115,200bps
+
+ - Data format: 8 data bits, 1 stop bit, no parity, no flow control.
+**Command and response formats**
+
+
+Communication between the remote controller (RC) and the ST60 takes the form of sequences of bytes, with all commands and responses having the same
+basic format. The ST60 shall always respond to a received command, but may also send messages at other times.
+
+Each transmission by the RC hs the following format:
+
+<St> <Zn> <Cc> <Dl> <Data> <Et>
+
+         - St (Start transmission): 0x21 ‘!’
+
+         - Zn (Zone number): see below
+
+         - Cc (Command code): the code for the command
+
+         - Dl (Data length): the number of data items following this item, excluding the Et
+
+         - Data: the parameters for the command
+
+         - Et (End transmission): 0x0D
+
+Each response by the ST60 has the following format:
+
+<St> <Zn> <Cc> <Ac> <Dl> <Data> <Et>
+
+         - St (Start transmission): 0x21 ‘!’
+
+         - Zn (Zone number): see “Zone numbers”, below
+
+         - Cc (Command code): the code for the command
+
+         - Ac (Answer code): see “Answer codes”, below
+
+         - Dl (Data Length): the number of data items following this item, excluding the Et
+
+         - Data: the parameters for the response of length n (note that n is limited to 255)
+
+         - Et (End transmission): 0x0D
+
+The ST60 responds to each command from the RC within three seconds. The RC may send further commands before a previous command response has been
+received.
+
+**Zone numbers**
+
+
+The following zone numbers are defined:
+
+         - 0x01 – Zone number 1. (Zone 1 is the master zone. Commands that appear zone-less refer to the master zone)
+
+         - 0x02 – Zone number 2
+
+
+
+3
+
+
+**Answer codes**
+
+
+The following answer codes are defined:
+
+         - 0x00 – Status update.
+
+         - 0x82 – Zone Invalid.
+
+         - 0x83 – Command not recognised.
+
+         - 0x84 – Parameter not recognised.
+
+         - 0x85 – Command invalid at this time (see **NOTE** below)
+
+         - 0x86 – Invalid data length.
+
+**NOTE** : Certain commands cannot be processed when the Setup Menu is being displayed. An answer code of 0x85 will be returned in these circumstances. Also,
+commands for tuner control cannot be processed when the tuner input is not selected, etc.
+
+**State changes as a result of other inputs**
+
+
+It is possible that the state of the ST60 may be changed as a result of user input via front panel or remote. Any change resulting from these inputs is relayed to
+the RC using the appropriate message type.
+
+**Reserved Commands**
+
+
+Commands 0xF0 to 0xFF (inclusive) are reserved for test functions and should never be used.
+
+**Example command and response sequence**
+
+
+As an example, the command to simulate the RC5 command “16-16” (increase volume):
+
+|St|Zn|Cc|Dl|Data 1|Data 2|Et|
+|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x02|0x10|0x10|0x0D|
+
+
+
+Assuming that the command was accepted by the ST60 and is being processed, the ST60 responds to this command with the following sequence:
+
+|St|Zn|Cc|Ac|Dl|Data 1|Data 2|Et|
+|---|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x00|0x02|0x10|0x10|0x0D|
+
+
+
+**AMX Duet™ support**
+
+
+The ST60 shall be fully compatible with AMX Duet™ Dynamic Device Discovery Protocol (DDDP). The following description of Dynamic Device Discovery comes
+from the AMX website ( _**www.amx.com**_ ). Dynamic Device Discovery is part of AMX’s Duet™ platform, which combines the proven reliability and power of
+NetLinx® with the extensive capabilities of the Java 2 Micro Edition (J2ME) platform. When integrating a serial or IP device from a manufacturer embedding the
+Dynamic Device Discovery Protocol (DDDP), Duet recognizes the device and loads the appropriate Duet module, which automatically installs the new device.
+AMX’s NetLinx Master can then find and install the Duet device module either from a library on the master, from AMX’s web site, or from the manufacturer’s web
+site. Duet also allows for device swapping so that programming changes are not required when devices with DDDP are removed or replaced – a huge benefit
+for end users. The Duet platform is an extension AMX’s InConcert® manufacturer partner program, which was developed to ensure seamless communication
+between partners’ devices and the AMX control system.
+
+
+Data is specified in the ASCII format. All ASCII characters between the quotes “” should be recognised/transmitted. “\r” is a carriage return (0x0D).
+Command: “AMX\r”
+Response: “AMXB<Device-SDKClass=Amplifier><Device-Make=ARCAM><Device-Model=ST60><Device-Revision=x.y.z>\r”
+
+Where,
+
+x.y.z = RS232 protocol version number.
+
+
+
+4
+
+
+**System Command Specifications**
+
+
+**Power (0x00)**
+
+
+Set/request the stand-by state of a zone.
+
+**Example**
+
+
+Command/response sequence to request the power state of the unit where
+the unit has power on:
+Command: 0x21 0x01 0x00 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x00 0x00 0x01 0x01 0x0D
+
+
+**Display brightness (0x01)**
+
+
+Set/request the brightness of the front panel display.
+
+**Example**
+
+
+Command/response sequence for requesting the brightness of the display
+where the display is off:
+Command: 0x21 0x01 0x01 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x01 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Dl|0x01|
+|Data|0x00 – Power off<br>0x01 – Power on<br>0x02 – Power toggle<br>0xF0 – Request power state|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Zone is in standby<br>0x01 – Zone is powered on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x01|
+|Dl|0x01|
+|Data|0x00 – Set brightness to off<br>0x01 – Set brightness to dim<br>0x02 – Set brightness to full<br>0xF0 – Request display brightness|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x01|
+|Ac|Answer code|
+|Dl|0x0|
+|Data|For Display brightness:<br>0x00 – Display brightness is off<br>0x01 – Display brightness is dim<br>0x02 – Display brightness is full<br>0x03 – Dark mode is on|
+|Et|0x0D|
+
+
+
+5
+
+
+**Software version (0x04)**
+
+
+Request the firmware version
+
+**Example**
+
+
+Command/response sequence, where the repsonse is HOST version 1.2:
+Command: 0x21 0x01 0x04 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x04 0x00 0x02 0xF0 0x01 0x02 0x0D
+
+
+**Factory reset (0x05)**
+
+
+This command resets the unit to factory defaults.
+
+**Example**
+
+
+Command/response sequence for resetting the unit to factory defaults:
+Command: 0x21 0x01 0x05 0x02 0xAA 0xAA 0x0D
+Response: 0x21 0x01 0x05 0x00 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x04|
+|Dl|0x01|
+|Data|0xF0 – request software version|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x04|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|Echo data from command|
+|Data2|0x?? – major version number|
+|Data3|0x?? – minor version number|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x05|
+|Dl|0x02|
+|Data1|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Data2|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x05|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+
+6
+
+
+**Simulate RC5 IR command (0x08)**
+
+
+Simulate an RC5 command via the RS232 port. An additional status message
+will be sent in most cases as a result of the IR command.
+
+**Example**
+
+
+Command/response sequence to RC5 16-17 (volume down):
+Command: 0x21 0x01 0x08 0x02 0x10 0x11 0x0D
+Response: 0x21 0x01 0x08 0x00 0x02 0x10 0x11 0x0D
+
+
+**Volume (0x0D)**
+
+
+Set or request the volume of a zone.
+
+This command returns the volume even if the zone requested is in mute.
+The “Request Mute status” command can be used to discover if the zone is
+muted.
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+**Example**
+
+
+Command/response sequence for setting the volume in Zone 1 to 45:
+Command: 0x21 0x01 0x0D 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x0D 0x00 0x01 0x2D 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the volume<br>0xF0 – Request the current volume<br>0xF1 – Increment volume by 1 step<br>0xF2 – Decrement volume by 1 step|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Zone volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+
+7
+
+
+**Mute/unmute (0x0E)**
+
+
+Set/Request the mute status of the output.
+
+**Example**
+
+
+Command/response sequence for requesting the mute status of output
+where the result is unmuted:
+Command: 0x21 0x01 0x0E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0E 0x00 0x01 0x02 0x0D
+
+
+**Network playback status (0x1C)**
+
+
+Network message format.
+
+If the network is not selected on the given zone an error 0x85 is returned.
+
+**Example**
+
+
+Command/response sequence where the network module is playing.
+Command: 0x21 0x01 0x1C 0x01 0xF0 0x0D
+
+
+Response: 0x21 0x01 0x1C 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Dl|0x01|
+|Data|0x00 – Mute<br>0x01 – Unmute<br>0x02 – Mute toggle<br>0xF0 – Request mute status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Muted<br>0x01 – Unmuted|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Dl|0x01|
+|Data|0xF0 – Request Network playback status|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Stopped<br>0x01 – Transitioning<br>0x02 – Playing<br>0x03  - Paused|
+|Et|0x0D|
+
+
+
+8
+
+
+**Current input source (0x1D)**
+
+
+Set/request the current input source.
+
+**Example**
+
+
+Command/response sequence to request the current source for Zone 1
+where the source is set to ‘DIG2’:
+Command: 0x21 0x01 0x1D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x1D 0x00 0x01 0x02 0x0D
+
+
+**Heartbeat (0x25)**
+
+
+Heartbeat command to check unit is still connected and communicating also resets the EuP standby timer.
+
+**Example**
+
+
+Command/response to sending a heartbeat command:
+Command: 0x21 0x01 0x25 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x25 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Dl|0x01|
+|Data|0x01 – DIG1<br>0x02 – DIG2<br>0x03 – DIG3<br>0x04 – DIG4<br>0x05 - NET/USB<br>0xF0 - Request input|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Ac|Answer code|
+|Dl|0x02|
+|Data|The current source in the indicated zone:<br>0x01 – DIG1<br>0x02 – DIG2<br>0x03 – DIG3<br>0x04 – DIG4<br>0x05 - NET/USB|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x25|
+|Dl|0x01|
+|Data|0xF0 – Heartbeat|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x25|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Response|
+|Et|0x0D|
+
+
+
+9
+
+
+**Reboot (0x26)**
+
+
+Forces a reboot of the unit.
+
+**Example**
+
+
+Command/response to sending a reboot command:
+Command: 0x21 0x01 0x26 0x06 0x52 0x45 0x42 0x4F
+0x4F 0x54 0x0D
+Response: 0x21 0x01 0x26 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x26|
+|Dl|0x06|
+|Data1|0x52|
+|Data2|0x45|
+|Data3|0x42|
+|Data4|0x4F|
+|Data5|0x4F|
+|Data6|0x54|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x26|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Response|
+|Et|0x0D|
+
+
+
+10
+
+
+**Network (0x30)**
+
+
+Request network info.
+
+**Example**
+
+
+Command/response sequence for requesting the IP address, where the
+address is 192 168 1 1
+Command: 0x21 0x01 0x30 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x30 0x00 0x04 0xC0 0xA8 0x01 0x010x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x30|
+|Dl|0x01|
+|Data1|0xF0 - Request IP address<br>0xF1 - Request Wired MAC address<br>0xF2 - Request WiFi MAC address<br>0xF3 - Request  Friendly name<br>0xF4 - Request Host Name<br>0xF5 - Request  SSID|
+|Et|0x0D|
+|RESPONSE:|RESPONSE:|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x30|
+|Ac|Answer code|
+|Dl|0x04 (IP), 0x06 (MAC), <n> (Name)|
+|||
+||IP Address|
+|Data1|0x?? First byte of IP address|
+|Data2|0x?? Second byte of IP address|
+|Data3|0x?? Third byte of IP address|
+|Data4|0x?? Forth byte of IP address|
+|||
+||Wired/WiFi MAC Address|
+|Data1|0x?? First byte of MAC address|
+|Data2|0x?? Second byte of MAC address|
+|Data3|0x?? Third byte of MAC address|
+|Data4|0x?? Forth byte of MAC address|
+|Data5|0x?? Fifth byte of MAC address|
+|Data6|0x?? Sixth byte of MAC address|
+|||
+||Friendly/Host name|
+|Data1 -<br>Data <n-1>|Friendly name in UTF-8 characters|
+|||
+||SSID|
+|Data1 -<br>Data <n-1>|SSID in UTF-8 characters|
+|Et|0x0D|
+
+
+
+11
+
+
+**Incoming audio sample rate (0x44)**
+
+
+Request the incoming audio sample rate.
+
+**Example**
+
+
+Command/response sequence to request the incoming audio sample rate,
+where the rate is 48kHz:
+Command: 0x21 0x01 0x44 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x44 0x00 0x01 0x02 0x0D
+
+
+**Timeout counter (0x55)**
+
+
+This command requests the time left (in minutes) until unit enters auto
+standby.
+
+**Example**
+
+
+Command/response sequence for requesting the time left until timeout:
+Command: 0x21 0x01 0x55 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x55 0x00 0x02 0x00 0xB4 0x0D
+
+In this example, the timeout value is 0x00B4, which translates to 180 minutes
+(i.e. 3 hours). The range of the value returned is from 0x0000 - 0x00F0 (0 - 240
+minutes)
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Dl|0x01|
+|Data|0xF0 – Request incoming audio sample rate|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Incoming audio sample rate:<br>0x00 – 32 kHz<br>0x01 – 44.1 kHz<br>0x02 – 48 kHz<br>0x03 – 88.2 kHz<br>0x04 – 96 kHz<br>0x05 – 176.4 kHz<br>0x06 – 192 kHz<br>0x07 – Unknown<br>0x08 – Undetected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x55|
+|Dl|0x01|
+|Data|0xF0|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x55|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|0x00 (First byte of timeout counter, value is fixed)|
+|Data2|0x00 – 0xF0 (Second byte timeout counter)|
+|Et|0x0D|
+
+
+
+12
+
+
+**Auto shutdown control (0x58)**
+
+
+Set time for when unit will go into standby state due to no signal being
+present
+
+**Example 1**
+
+
+Command/response sequence, the signal sense auto shutdown timeout has
+been set to 60 minutes:
+Command: 0x21 0x01 0x58 0x01 0x03 0x0D
+Response: 0x21 0x01 0x58 0x00 0x01 0x03 0x0D
+
+**Example 2**
+
+
+Command/response sequence, the signal sense auto shutdown has been
+disabled:
+Command: 0x21 0x01 0x58 0x01 0x00 0x0D
+Response: 0x21 0x01 0x58 0x00 0x01 0x00 0x0D
+
+
+**Input detect (0x5A)**
+
+
+Request the status of the active input.
+
+**Example**
+
+
+Command/response sequence where audio input is present.
+Command: 0x21 0x01 0x5A 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5A 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x58|
+|Dl|0x01|
+|Data|0x00 – Disable (Default)<br>0x01 – 20 min<br>0x02 – 30 min<br>0x03 – 1 hour<br>0x04 – 2 hours<br>0x05 – 4 hours<br>0xF0 – Request timeout status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x58|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Disabled<br>0x01 – 20 min<br>0x02 – 30 min<br>0x03 – 1 hour<br>0x04 – 2 hours<br>0x05 – 4 hours|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5A|
+|Dl|0x01|
+|Data|0xF0 - Request input status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5A|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Input not present<br>0x01 - Input present|
+|Et|0x0D|
+
+
+
+13
+
+
+**Fixed Volume (0x5C)**
+
+
+Set/request the status of the fixed volume mode.
+
+**Example**
+
+
+Command/response sequence where volume is fixed
+Command: 0x21 0x01 0x5C 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5C 0x00 0x01 0x01 0x0D
+
+
+**System status (0x5D)**
+
+
+Request the system status.
+
+**Example**
+
+
+Command/response sequence to request the system status.
+Command: 0x21 0x01 0x5D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5D 0x00 0x01 0xF0 0x0D
+
+
+**Note:**
+
+
+This command will return the following information about the system:
+
+         - Power state
+
+         - Brightness level
+
+         - Software version
+
+         - Model Number
+
+         - Volume setting
+
+         - Mute status
+
+         - Current input source
+
+         - Sample rate
+
+         - IP address
+
+         - Wired MAC address
+
+         - Wireless MAC address
+
+         - Friendly Name
+
+         - Host Name
+
+         - SSID
+
+         - Timeout counter value
+
+         - Auto shutdown status
+
+         - Input detect status
+
+         - DAC Filter
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5C|
+|Dl|0x01|
+|Data|0x00 - Variable volume mode<br>0x01 - Fixed volume mode<br>0xF0 - Request fixed volume mode|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Variable volume mode<br>0x01 - Fixed volume mode|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5D|
+|Dl|0x01|
+|Data|0xF0 – Request the system|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0xF0 - System status sent|
+|Et|0x0D|
+
+
+
+14
+
+
+**System model (0x5E)**
+
+
+Request the system model.
+
+**Example**
+
+
+Command/response sequence to request the system model, where the
+model is ST60.
+Command: 0x21 0x01 0x5E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5E 0x00 0x04 0x53 0x41 0x33 0x30 0x0D
+
+
+**DAC Filter (0x61)**
+
+
+Sets or requests the DAC filter
+
+**Example**
+
+
+Command/response sequence to request the DAC filter where response is
+Linear Phase Fast Roll Off
+Command: 0x21 0x01 0x61 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x61 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5E|
+|Dl|0x01|
+|Data|0xF0 – Request the system model|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5E|
+|Ac|Answer code|
+|Dl|0x04|
+|Data|System model in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x61|
+|Dl|0x01|
+|Data|0x00 - Linear Phase Fast Roll Off<br>0x01 - Linear Phase Slow Roll Off<br>0x02 - Minimum Phase Fast Roll Off<br>0x03 - Minimum Phase Slow Roll Off<br>0x04 - Brick Wall<br>0x05 - Corrected Phase Fast Roll Off<br>0x06 - Apodizing<br>0xF0 - Request the current filter|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x61|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Linear Phase Fast Roll Off<br>0x01 - Linear Phase Slow Roll Off<br>0x02 - Minimum Phase Fast Roll Off<br>0x03 - Minimum Phase Slow Roll Off<br>0x04 - Brick Wall<br>0x05 - Corrected Phase Fast Roll Off<br>0x06 - Apodizing|
+|Et|0x0D|
+
+
+
+15
+
+
+**Now Playing information (0x64)**
+
+
+Request the various now playing track details. If the unit is currently playing
+from a source other than a streaming input the track name etc will returned
+as NULL.
+
+**Example**
+
+
+Command/response sequence to request the currently playing artist where
+the response is A
+Command: 0x21 0x01 0x64 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x64 0x00 0x02 0x41 0x0D
+
+**Note**
+
+
+Response length is limited to 100 characters
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x64|
+|Dl|0x01|
+|Data|0xF0 – Request the currently playing track title<br>0xF1 - Request the currently playing artist<br>0xF2 - Request the currently playing album<br>0xF3 - Request the currently playing application (GoogleCast only)<br>0xF4 - Request the currently playing sample rate<br>0xF5 - Request the currently playing track encoder|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x64|
+|Ac|Answer code|
+|Dl|<n>|
+|Data|Track:<br>Track title in UTF-8 characters<br>Album:<br>Album name in UTF-8 characters<br>Artist:<br>Artist name in UTF-8 characters<br>Application:<br>GoogleCast source application in UTF-8 characters<br>Sample rate:<br>0x00 – 32 kHz<br>0x01 – 44.1 kHz<br>0x02 – 48 kHz<br>0x03 – 88.2 kHz<br>0x04 – 96 kHz<br>0x05 – 176.4 kHz<br>0x06 – 192 kHz<br>0x07 – Unknown<br>0x08 – Undetected<br>Audio encoder:<br>0x00 – Uknown<br>0x01 – MP3<br>0x02 – WMA<br>0x03 – Ogg Vorbis<br>0x04 - FLAC<br>0x05 – WAV<br>0x06 - AIFF<br>0x07 - RealAudio<br>0x08 - MPEG URL<br>0x09 - SCPLS<br>0x0A - WPL<br>0x0B - MP4<br>0x0C - DSD<br>0x0D - Opus<br>0x0E - Sirius<br>0x0F - MQA|
+|Et|0x0D|
+
+
+
+16
+
+
+**Maximum Turn On Volume (0x65)**
+
+
+Set or request the maximum volume level at power up of the ST60.
+
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+**Example**
+
+
+Command/response sequence for setting the maximum turn on volume in
+Zone 1 to 45:
+Command: 0x21 0x01 0x65 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x65 0x00 0x01 0x2D 0x0D
+
+
+**Maximum Volume (0x66)**
+
+
+Set or request the maximum volume level of the ST60. Used to prevent
+volume being accidently set to full when using app volume sliders.
+
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+**Example**
+
+
+Command/response sequence for setting the maximum volume in Zone 1
+to 45:
+Command: 0x21 0x01 0x66 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x66 0x00 0x01 0x2D 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x65|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the maximum turn on volume<br>0xF0 – Request the maximum turn on volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x65|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Maximum turn on volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x66|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the maximum volume<br>0xF0 – Request the maximum volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x66|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Maximum volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+
+17
+
+
+**Maximum Streaming Volume (0x67)**
+
+
+Set or request the maximum volume level of the ST60 when playing back
+streamed content. Used to prevent volume being accidently set to full when
+using app volume sliders and increase the resolution of the app volume
+sliders
+
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+**Example**
+
+
+Command/response sequence for setting the maximum volume in Zone 1
+to 45:
+Command: 0x21 0x01 0x67 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x67 0x00 0x01 0x2D 0x0D
+
+
+**Dark mode (0x68)**
+
+
+Set or request the status of the dark mode function.
+
+**Example**
+
+
+Command/response sequence where dark mode is on.
+Command: 0x21 0x01 0x68 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5A 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x67|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the maximum volume<br>0xF0 – Request the maximum volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x67|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Maximum volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x68|
+|Dl|0x01|
+|Data|0x00 - Dark mode off<br>0x01 - Dark mode on<br>0xF0 - Request dark mode status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x68|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Dark mode off<br>0x01 - Dark mode on|
+|Et|0x0D|
+
+
+
+18
+
+
+**RC5 Command Codes**
+
+
+These codes are recognised as infra-red signals received by the front panel and as control data using the “Simulate RC5 IR command (0x08)” on page 7.
+
+
+
+**Basic Functions**
+
+
+These RC5 codes are present on the supplied IR remote control and provide
+control over basic functions.
+
+
+
+**Advanced Functions**
+
+
+These RC5 codes are not present on the supplied remote control but have
+been created for custom install use. In order for the amp to respond to these
+codes they must be transmitted from a programmable IR remote control or
+over the control link using the ‘Simulate RC5 IR Command’ (0x08).
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Power On|21-123|0x15 - 0x7B|
+|Power Off|21-124|0x15 - 0x7C|
+|Mute On|21-26|0x15 - 0x1A|
+|Mute Off|21-120|0x15 - 0x78|
+|Display brightness off|21-31|0x15 - 0x1F|
+|Display brightness dim|21-34|0x15 - 0x22|
+|Display brightness full<br>|21-35|0x15 - 0x23|
+
+
+|Function|RC5 code<br>[system-<br>command]|RC5 code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Standby|21-12|0x15 - 0x0C|
+|1|21-1|0x15 - 0x01|
+|2|21-2|0x15 - 0x02|
+|3|21-3|0x15 - 0x03|
+|4|21-4|0x15 - 0x04|
+|5|21-5|0x15 - 0x05|
+|6|21-6|0x15 - 0x06|
+|7|21-7|0x15 - 0x07|
+|8|21-8|0x15 - 0x08|
+|9|21-9|0x15 - 0x09|
+|0|21-0|0x15 - 0x00|
+|Mute|21-13|0x15 - 0x0D|
+|Rewind|21-50|0x15 - 0x32|
+|Fast Forward|21-52|0x15 - 0x34|
+|Skip Back|21-33|0x15 - 0x21|
+|Skip Forward|21-32|0x15 - 0x20|
+|Play|21-53|0x15 - 0x35|
+|Pause|21-48|0x15 - 0x30|
+|Shuffle|21-64|0x15 - 0x40|
+|Repeat|21-29|0x15 - 0x1D|
+|Navigate Up|21-86|0x15 - 0x56|
+|Navigate Left|21-81|0x15 - 0x51|
+|OK|21-87|0x15 - 0x57|
+|Navigate Right|21-80|0x15 - 0x50|
+|Navigate Down|21-85|0x15 - 0x55|
+|HOME|21-74|0x15 - 0x4A|
+|Back|21-72|0x15 - 0x48|
+|Menu|21-66|0x15 - 0x42|
+|DISP|21-59|0x15 - 0x3B|
+|Info|21-55|0x15 - 0x37|
+|Digital Input 1|21-94|0x15 - 0x5E|
+|Digital Input 2|21-98|0x15 - 0x62|
+|Digital Input 3|21-27|0x15 - 0x1B|
+|Digital Input 4|21-97|0x15 - 0x61|
+|USB|21-93|0x15 - 0x5D|
+|NET|21-92|0x15 - 0x5C|
+
+
+
+19
+
+
+SH309 Issue C
+
+
+
+www.arcam.co.uk
+THE WEST WING, STIRLING HOUSE
+
+WATERBEACH, CAMBRIDGE, CB25 9PB, ENGLAND
++44 (0)1223 203200
+
+

--- a/docs/specs/SH320E_RS232_SA750_iss1.md
+++ b/docs/specs/SH320E_RS232_SA750_iss1.md
@@ -1,0 +1,1839 @@
+# Custom Installation Notes IP/Serial programming interface and IR remote control commands for the SA750 integrated amplifier
+
+
+Contents
+
+
+
+Controlling via RS232/NET............................. 3
+
+Introduction..............................................................3
+Set-up......................................................................3
+Conventions **.** ...........................................................3
+Serial cable specification.........................................3
+Data transfer format **.** ...............................................3
+Command and response formats............................3
+AMX Duet™ support **.** ..............................................4
+System Command Specifications **.** .................. 5
+
+Power (0x00)...........................................................5
+Display brightness (0x01)........................................5
+Headphones (0x02).................................................6
+Software version (0x04) **.** .........................................6
+Factory reset (0x05) **.** ...............................................7
+Simulate RC5 IR command (0x08).........................7
+Volume (0x0D).........................................................8
+Mute/unmute (0x0E)................................................8
+Direct mode status (0x0F).......................................9
+Network playback status (0x1C) **.** ...........................9
+Current input source (0x1D)..................................10
+Headphone override (0x1F).................................. 11
+Heartbeat (0x25) **.** .................................................. 11
+Reboot (0x26)........................................................12
+Network (0x30)......................................................13
+Room EQ names (0x34) **.** ......................................14
+Room Equalisation (0x37).....................................14
+Balance (0x3B)......................................................15
+Incoming audio sample rate (0x44).......................15
+DC offset (0x51) **.** ...................................................16
+Short circuit status (0x52)......................................16
+Timeout counter (0x55) **.** ........................................17
+Lifter temperature (0x56) ......................................17
+Output temperature (0x57)....................................18
+Auto shutdown control (0x58) **.** ..............................18
+PHONO input type (0x59) **.** ....................................19
+Input detect (0x5A)................................................19
+Processor mode input (0x5B) **.** ..............................20
+Processor mode volume (0x5C) **.** ..........................20
+System status (0x5D)............................................21
+System model (0x5E)............................................22
+DAC Filter (0x61)...................................................22
+Now Playing information (0x64)............................23
+Maximum Turn On Volume (0x65)........................24
+Maximum Volume (0x66) **.** .....................................24
+Maximum Streaming Volume (0x67).....................25
+RC5 Command Codes.................................. 26
+
+Basic Functions.....................................................26
+Advanced Functions..............................................26
+
+
+
+Applicability
+
+This document applies to the JBL SA750 integrated amplifier.
+
+
+Revision history
+
+
+Issue 1.0: Initial revision
+
+
+
+2
+
+
+**Controlling via RS232/NET**
+
+
+**Introduction**
+
+This document describes the remote control protocol for controlling via the RS232/NET interface.
+
+**Set-up**
+
+IP control is via port 50000 of the IP address of the unit.
+
+**Conventions**
+
+ - All hexadecimal numbers begin 0x.
+
+ - Any character in single quotes gives the ASCII equivalent of a hex value.
+
+ - <n> represents an unknown or variable number.
+**Serial cable specification**
+
+
+The cable is wired as a null modem:
+
+
+
+
+
+
+
+
+
+|Connector<br>1 pin|Connector<br>2 pin|Function|
+|---|---|---|
+|2|3|Rx Tx|
+|3|2|Tx Rx|
+|5|5|RS232 Ground|
+
+
+**Data transfer format**
+
+ - Transfer rate: 38,400bps
+
+ - Data format: 8 data bits, 1 stop bit, no parity, no flow control.
+**Command and response formats**
+
+Communication between the remote controller (RC) and the SA750 takes the form of sequences of bytes, with all commands and responses having
+the same basic format. The SA750 shall always respond to a received command, but may also send messages at other times.
+
+Each transmission by the RC hs the following format:
+
+<St> <Zn> <Cc> <Dl> <Data> <Et>
+
+       - St (Start transmission): 0x21 ‘!’
+
+       - Zn (Zone number): see below
+
+       - Cc (Command code): the code for the command
+
+       - Dl (Data length): the number of data items following this item, excluding the Et
+
+       - Data: the parameters for the command
+
+       - Et (End transmission): 0x0D
+
+Each response by the SA750 has the following format:
+
+<St> <Zn> <Cc> <Ac> <Dl> <Data> <Et>
+
+       - St (Start transmission): 0x21 ‘!’
+
+       - Zn (Zone number): see “Zone numbers”, below
+
+       - Cc (Command code): the code for the command
+
+       - Ac (Answer code): see “Answer codes”, below
+
+       - Dl (Data Length): the number of data items following this item, excluding the Et
+
+       - Data: the parameters for the response of length n (note that n is limited to 255)
+
+       - Et (End transmission): 0x0D
+
+The SA750 responds to each command from the RC within three seconds. The RC may send further commands before a previous command
+response has been received.
+
+**Zone numbers**
+
+The following zone numbers are defined:
+
+       - 0x01 – Zone number 1. (Zone 1 is the master zone. Commands that appear zone-less refer to the master zone)
+
+       - 0x02 – Zone number 2
+
+
+
+3
+
+
+**Answer codes**
+
+The following answer codes are defined:
+
+       - 0x00 – Status update.
+
+       - 0x82 – Zone Invalid.
+
+       - 0x83 – Command not recognised.
+
+       - 0x84 – Parameter not recognised.
+
+       - 0x85 – Command invalid at this time (see **NOTE** below)
+
+       - 0x86 – Invalid data length.
+
+**NOTE** : Certain commands cannot be processed when the Setup Menu is being displayed. An answer code of 0x85 will be returned in these
+circumstances. Also, commands for tuner control cannot be processed when the tuner input is not selected, etc.
+
+**State changes as a result of other inputs**
+
+It is possible that the state of the SA750 may be changed as a result of user input via front panel or remote. Any change resulting from these inputs is
+relayed to the RC using the appropriate message type.
+
+**Reserved Commands**
+
+Commands 0xF0 to 0xFF (inclusive) are reserved for test functions and should never be used.
+
+**Example command and response sequence**
+
+As an example, the command to simulate the RC5 command “16-16” (increase volume):
+
+|St|Zn|Cc|Dl|Data 1|Data 2|Et|
+|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x02|0x10|0x10|0x0D|
+
+
+
+Assuming that the command was accepted by the SA750 and is being processed, the SA750 responds to this command with the following sequence:
+
+|St|Zn|Cc|Ac|Dl|Data 1|Data 2|Et|
+|---|---|---|---|---|---|---|---|
+|0x21|0x01|0x08|0x00|0x02|0x10|0x10|0x0D|
+
+
+
+**AMX Duet™ support**
+
+The SA750 shall be fully compatible with AMX Duet™ Dynamic Device Discovery Protocol (DDDP). The following description of Dynamic Device
+Discovery comes from the AMX website ( _**www.amx.com**_ ). Dynamic Device Discovery is part of AMX’s Duet™ platform, which combines the proven
+reliability and power of NetLinx® with the extensive capabilities of the Java 2 Micro Edition (J2ME) platform. When integrating a serial or IP device
+from a manufacturer embedding the Dynamic Device Discovery Protocol (DDDP), Duet recognizes the device and loads the appropriate Duet module,
+which automatically installs the new device. AMX’s NetLinx Master can then find and install the Duet device module either from a library on the master,
+from AMX’s web site, or from the manufacturer’s web site. Duet also allows for device swapping so that programming changes are not required when
+devices with DDDP are removed or replaced – a huge benefit for end users. The Duet platform is an extension AMX’s InConcert® manufacturer
+partner program, which was developed to ensure seamless communication between partners’ devices and the AMX control system.
+
+
+Data is specified in the ASCII format. All ASCII characters between the quotes “” should be recognised/transmitted. “\r” is a carriage return (0x0D).
+
+Command: “AMX\r”
+Response: “AMXB<Device-SDKClass=Amplifier><Device-Make=JBL><Device-Model=SA750><Device-Revision=x.y.z>\r”
+
+Where,
+
+x.y.z = RS232 protocol version number.
+
+
+
+4
+
+
+**System Command Specifications**
+
+
+**Power (0x00)**
+
+Set/request the stand-by state of a zone.
+
+Example
+
+
+Command/response sequence to request the power state of the unit
+where the unit has power on:
+
+Command: 0x21 0x01 0x00 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x00 0x00 0x01 0x01 0x0D
+
+
+**Display brightness (0x01)**
+
+Set/request the brightness of the front panel display.
+
+Example
+
+
+Command/response sequence for requesting the brightness of the
+display where the display is off:
+
+Command: 0x21 0x01 0x01 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x01 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Dl|0x01|
+|Data|0x00 – Power off<br>0x01 – Power on<br>0x02 – Power toggle<br>0xF0 – Request power state|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x00|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Zone is in standby<br>0x01 – Zone is powered on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x01|
+|Dl|0x01|
+|Data|0x00 – Set brightness to off<br>0x01 – Set brightness to dim<br>0x02 – Set brightness to full<br>0xF0 – Request display brightness|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x01|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Display brightness is off<br>0x01 – Display brightness is dim<br>0x02 – Display brightness is full|
+|Et|0x0D|
+
+
+
+5
+
+
+**Headphones (0x02)**
+
+Determine whether headphones are connected.
+
+Example
+
+
+Command/response sequence to request the headphone status where
+the headphones are not connected:
+
+Command: 0x21 0x01 0x02 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x02 0x00 0x01 0x00 0x0D
+
+
+**Software version (0x04)**
+
+Request the firmware version
+
+Example
+
+
+Command/response sequence, where the repsonse is version 1.2:
+
+Command: 0x21 0x01 0x04 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x04 0x00 0x02 0xF0 0x01 0x02 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x02|
+|Dl|0x01|
+|Data|0xF0 – Request current headphone connection status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x02|
+|Ac|Answer code|
+|Dl|0x01 (Data length)|
+|Data|0x00 – Headphones are not connected.<br>0x01 – Headphones are connected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x04|
+|Dl|0x01|
+|Data|0xF0 – request software version|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x04|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|Echo data from command|
+|Data2|0x?? – major version number|
+|Data3|0x?? – minor version number|
+|Et|0x0D|
+
+
+
+6
+
+
+**Factory reset (0x05)**
+
+This command resets the unit to factory defaults.
+
+Example
+
+
+Command/response sequence for resetting the unit to factory defaults:
+
+Command: 0x21 0x01 0x05 0x02 0xAA 0xAA 0x0D
+Response: 0x21 0x01 0x05 0x00 0x00 0x0D
+
+
+**Simulate RC5 IR command (0x08)**
+
+Simulate an RC5 command via the RS232 port. An additional status
+message will be sent in most cases as a result of the IR command.
+
+Example
+
+
+Command/response sequence to RC5 16-17 (volume down):
+
+Command: 0x21 0x01 0x08 0x02 0x10 0x11 0x0D
+Response: 0x21 0x01 0x08 0x00 0x02 0x10 0x11 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x05|
+|Dl|0x02|
+|Data1|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Data2|0xAA (Confirmation data pattern to avoid accidental restore)|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x05|
+|Ac|Answer code|
+|Dl|0x00|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x08|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|RC5 System code|
+|Data2|RC5 Command code|
+|Et|0x0D|
+
+
+
+7
+
+
+**Volume (0x0D)**
+
+Set or request the volume of a zone.
+
+This command returns the volume even if the zone requested is in
+mute. The “Request Mute status” command can be used to discover if
+the zone is muted.
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+Example
+
+
+Command/response sequence for setting the volume in Zone 1 to 45:
+
+Command: 0x21 0x01 0x0D 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x0D 0x00 0x01 0x2D 0x0D
+
+
+**Mute/unmute (0x0E)**
+
+Set/Request the mute status of the output.
+
+Example
+
+
+Command/response sequence for requesting the mute status of output
+where the result is unmuted:
+
+Command: 0x21 0x01 0x0E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0E 0x00 0x01 0x02 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the volume<br>0xF0 – Request the current volume<br>0xF1 – Increment volume by 1 step<br>0xF2 – Decrement volume by 1 step|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Zone volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Dl|0x01|
+|Data|0x00 – Mute<br>0x01 – Unmute<br>0x02 – Mute toggle<br>0xF0 – Request mute status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x0E|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Muted<br>0x01 – Unmuted|
+|Et|0x0D|
+
+
+
+8
+
+
+**Direct mode status (0x0F)**
+
+Set or request the analogue input direct mode of an input
+
+Example
+
+
+Command/response sequence to request the direct mode status where
+the mode is direct and input is CD:
+
+Command: 0x21 0x01 0x0F 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x0F 0x00 0x02 0x06 0x01 0x0D
+
+
+**Network playback status (0x1C)**
+
+Network message format.
+
+If the network is not selected on the given zone an error 0x85 is returned.
+
+Example
+
+
+Command/response sequence where the network module is playing.
+
+Command: 0x21 0x01 0x1C 0x01 0xF0 0x0D
+
+
+Response: 0x21 0x01 0x1C 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0F|
+|Dl|0x01 (Query), 0x02 for setting|
+|Data 1|0x01 – Phono<br>0x02 – AUX<br>0x03 – PVR<br>0x05 – STB<br>0x06 – CD<br>0xF0 – Request mode setting of current input|
+|Data 2|0x00 – Turn ‘Direct mode’ off<br>0x01 – Turn‘Direct mode’ on|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x0F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data 1|0x01 – Phono<br>0x02 – AUX<br>0x03 – PVR<br>0x05 – STB<br>0x06 – CD|
+|Data 2|0x00 – ‘Direct mode’ is off<br>0x01 – ‘Direct mode’ is on|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Dl|0x01|
+|Data|0xF0 – Request Network playback status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Stopped<br>0x01 – Transitioning<br>0x02 – Playing<br>0x03  - Paused|
+|Et|0x0D|
+
+
+
+9
+
+
+**Current input source (0x1D)**
+
+Set/request the current input source.
+
+Example
+
+
+Command/response sequence to request the current source for Zone 1
+where the source is set to ‘PVR’ and set to processor mode:
+
+Command: 0x21 0x01 0x1D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x1D 0x00 0x01 0x13 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Dl|0x01|
+|Data|0x01 – Phono<br>0x02 – AUX<br>0x03 – PVR<br>0x04 – AV<br>0x05 – STB<br>0x06 – CD<br>0x07 – BD<br>0x08 – SAT<br>0x09 - GAME<br>0x0B - NET/USB<br>0xF0 - Request input|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1D|
+|Ac|Answer code|
+|Dl|0x02|
+|Data|The current source in the indicated zone:<br>0x01 – Phono<br>0x(N)2 – AUX<br>0x(N)3 – PVR<br>0x(N)4 – AV<br>0x(N)5 – STB<br>0x(N)6 – CD<br>0x(N)7 – BD<br>0x(N)8 – SAT<br>0x(N)9 - GAME<br>0x0B - NET/USB<br>N = 0 indicates source is normal mode<br>N = 1 indicates source is set to processor (fixed gain) mode|
+|Et|0x0D|
+
+
+
+10
+
+
+**Headphone override (0x1F)**
+
+Activate/deactivate the mute relays (does not zero the volume).
+
+Example
+
+
+Command/response sequence to activate the mute relays:
+
+Command: 0x21 0x01 0x1F 0x01 0x01 0x0D
+Response: 0x21 0x01 0x1F 0x00 0x01 0x01 0x0D
+
+
+**Heartbeat (0x25)**
+
+Heartbeat command to check unit is still connected and communicating
+
+- also resets the EuP standby timer.
+
+Example
+
+
+Command/response to sending a heartbeat command:
+
+Command: 0x21 0x01 0x25 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x25 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Dl|0x01|
+|Data|0x00 – Headphone/Over-ride Clear (speakers muted if headphones<br>present)<br>0x01 – Headphone/Over-ride Set (speakers unmuted if headphones<br>present)<br>0xF0 - Request Headphone/Over-ride status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x1F|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Relay state|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x25|
+|Dl|0x01|
+|Data|0xF0 – Heartbeat|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x25|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Response|
+|Et|0x0D|
+
+
+
+11
+
+
+**Reboot (0x26)**
+
+Forces a reboot of the unit.
+
+Example
+
+
+Command/response to sending a reboot command:
+
+Command: 0x21 0x01 0x26 0x06 0x52 0x45 0x42 0x4F
+0x4F 0x54 0x0D
+Response: 0x21 0x01 0x26 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x26|
+|Dl|0x06|
+|Data1|0x52|
+|Data2|0x45|
+|Data3|0x42|
+|Data4|0x4F|
+|Data5|0x4F|
+|Data6|0x54|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x26|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Response|
+|Et|0x0D|
+
+
+
+12
+
+
+**Network (0x30)**
+
+Request network info.
+
+Example
+
+
+Command/response sequence for requesting the IP address, where
+the address is 192 168 1 1
+
+Command: 0x21 0x01 0x30 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x30 0x00 0x04 0xC0 0xA8 0x01
+0x010x0D
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x30|
+|Dl|0x01|
+|Data1|0xF0 - Request IP address<br>0xF1 - Request Wired MAC address<br>0xF2 - Request WiFi MAC address<br>0xF3 - Request  Friendly name<br>0xF4 - Request Host Name<br>0xF5 - Request  SSID|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x30|
+|Ac|Answer code|
+|Dl|0x04 (IP), 0x06 (MAC), <n> (Name)|
+|||
+||IP Address|
+|Data1|0x?? First byte of IP address|
+|Data2|0x?? Second byte of IP address|
+|Data3|0x?? Third byte of IP address|
+|Data4|0x?? Forth byte of IP address|
+|||
+||Wired/WiFi MAC Address|
+|Data1|0x?? First byte of MAC address|
+|Data2|0x?? Second byte of MAC address|
+|Data3|0x?? Third byte of MAC address|
+|Data4|0x?? Forth byte of MAC address|
+|Data5|0x?? Fifth byte of MAC address|
+|Data6|0x?? Sixth byte of MAC address|
+|||
+||Friendly/Host name|
+|Data1<br>- Data<br><n-1>|Friendly name in ASCII characters|
+|||
+||SSID|
+|Data1<br>- Data<br><n-1>|SSID in ASCII characters|
+|Et|0x0D|
+
+
+
+13
+
+
+**Room EQ names (0x34)**
+
+Request Room EQ name(s).
+
+
+**Room Equalisation (0x37)**
+
+
+Turn the room equalisation system on/off.
+
+Example
+
+
+Command/response sequence to turn the room equalisation 1 on:
+
+Command: 0x21 0x01 0x37 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x37 0x00 0x01 0x01 0x0D
+
+
+
+
+
+
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|0x01|
+|Cc|0x34|
+|Dl|0x01|
+|Data1|0xF0 - request EQ names|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone Number|
+|Cc|0x34|
+|Ac|Answer code|
+|Dl|0xn - dependant on number of EQ slots filled, 20, 40, 60, 80,100, 120|
+|Data1-20<br>Data21-40<br>Data41-60<br>Data61-80<br>Data81-<br>100<br>Data101-<br>120|EQ1 name (read only / 20 characters)<br>name in ASCII characters<br>EQ2 name (read only / 20 characters)<br>name in ASCII characters<br>EQ3 name (read only / 20 characters)<br>name in ASCII characters<br>EQ4 name (read only / 20 characters)<br>name in ASCII characters<br>EQ5 name (read only / 20 characters)<br>name in ASCII characters<br>EQ6 name (read only / 20 characters)<br>name in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x37|
+|Dl|0x01|
+|Data|0xF0 – Request current Room EQ state<br>0x00 - Room EQ off<br>0x01 – Room EQ 1 on<br>0x02 - Room EQ 2 on<br>0x03 -Room EQ 3 on<br>0x04 -Room EQ 4 on<br>0x05 -Room EQ 5 on<br>0x06 -Room EQ 6 on|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x37|
+|Ac|Answer code|
+|Dl|0x01|
+|Data1|0x00 – Room EQ is off<br>0x01 – Room EQ 1 is on<br>0x02 – Room EQ 2 is on<br>0x03 – Room EQ 3 is on<br>0x04 – Room EQ 4 is on<br>0x05 – Room EQ 5 is on<br>0x06 – Room EQ 6 is on<br>0x0A – Room EQ has not been calculated and is therefore off|
+|Et|0x0D|
+
+
+
+14
+
+
+**Balance (0x3B)**
+
+Adjust the balance control.
+
+Example
+
+
+Command/response sequence to request the balance where the
+response is left 3
+
+Command: 0x21 0x01 0x3B 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x3B 0x00 0x01 0x83 0x0D
+
+
+**Incoming audio sample rate (0x44)**
+
+Request the incoming audio sample rate.
+
+Example
+
+
+Command/response sequence to request the incoming audio sample
+rate, where the rate is 48kHz:
+
+Command: 0x21 0x01 0x44 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x44 0x00 0x01 0x02 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Dl|0x01|
+|Data|0xF0 – Request current balance|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x3B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Balance is Centred<br>0x00 – 0x0C – Balance is Right 1, 2,...,5, 6<br>0x81 – 0x8C – Balance is Left 1, 2,...,5, 6|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Dl|0x01|
+|Data|0xF0 – Request incoming audio sample rate|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x44|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Incoming audio sample rate:<br>0x00 – 32 kHz<br>0x01 – 44.1 kHz<br>0x02 – 48 kHz<br>0x03 – 88.2 kHz<br>0x04 – 96 kHz<br>0x05 – 176.4 kHz<br>0x06 – 192 kHz<br>0x07 – Not supported<br>0x08 – Undetected<br>0x09 - 325.8kHz<br>0x0A - 384kHz|
+|Et|0x0D|
+
+
+
+15
+
+
+**DC offset (0x51)**
+
+Request the output DC offset status.
+
+Example
+
+
+Command/response sequence for requesting the DC offset status
+where the result is no DC offset:
+
+Command: 0x21 0x01 0x51 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x51 0x00 0x01 0x00 0x0D
+
+
+**Short circuit status (0x52)**
+
+Request the output short circuit status.
+
+Example
+
+
+Command/response sequence for requesting the short circuit status,
+where the result is no short circuit:
+
+Command: 0x21 0x01 0x52 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x52 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x51|
+|Dl|0x01|
+|Data|0xF0 – Request DC offset status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x51|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - OK<br>0x01 - DC offset detected|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x52|
+|Dl|0x01|
+|Data|0xF0 – Request short circuit status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x52|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - No short circuit detected<br>0x01 - One of the channels has short circuit fault|
+|Et|0x0D|
+
+
+
+16
+
+
+**Timeout counter (0x55)**
+
+This command requests the time left (in minutes) until unit enters auto
+standby.
+
+Example
+
+
+Command/response sequence for requesting the time left until timeout:
+
+Command: 0x21 0x01 0x55 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x55 0x00 0x02 0x00 0xF0 0x0D
+
+In this example, the timeout value is 0x00B4, which translates to 180
+minutes (i.e. 3 hours). The range of the value returned is from 0x0000
+
+- 0x00F0 (0 - 240 minutes)
+
+
+**Lifter temperature (0x56)**
+
+Request the temperature of the lifter.
+
+Example
+
+
+Command/response sequence for requesting the temperature of the
+lifter where the result is 75degC:
+
+Command: 0x21 0x01 0x56 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x56 0x00 0x01 0x4B 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x55|
+|Dl|0x01|
+|Data|0xF0|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x55|
+|Ac|Answer code|
+|Dl|0x02|
+|Data1|0x00 (First byte of timeout counter, value is fixed)|
+|Data2|0x00 – 0xF0 (Second byte timeout counter)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x56|
+|Dl|0x01|
+|Data|0xF0 – Request lifter temperature|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x56|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x?? – Temperature in deg C in hex, e.g. 75degC = 4B|
+|Et|0x0D|
+
+
+
+17
+
+
+**Output temperature (0x57)**
+
+Request the temperature of the output stage.
+
+Example
+
+
+Command/response sequence for requesting the temperature of the
+output where the result is 75 degC:
+
+Command: 0x21 0x01 0x57 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x57 0x00 0x01 0x4B 0x0D
+
+
+**Auto shutdown control (0x58)**
+
+Set time for when unit will go into standby state die to no signal being
+present
+
+Example 1
+
+
+Command/response sequence, the signal sense auto shutdown
+timeout has been set to 60 minutes:
+
+Command: 0x21 0x01 0x58 0x01 0x03 0x0D
+Response: 0x21 0x01 0x58 0x00 0x01 0x03 0x0D
+
+Example 2
+
+
+Command/response sequence, the signal sense auto shutdown has
+been disabled:
+
+Command: 0x21 0x01 0x58 0x01 0x00 0x0D
+Response: 0x21 0x01 0x58 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x57|
+|Dl|0x01|
+|Data|0xF0 – Request output temperature|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x57|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x?? – Temperature in deg C in hex, e.g. 75degC = 4B|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x58|
+|Dl|0x01|
+|Data|0x00 – Disable (Default)<br>0x01 – 20 min<br>0x02 – 30 min<br>0x03 – 1 hour<br>0x04 – 2 hours<br>0x05 – 4 hours<br>0xF0 – Request timeout status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x58|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 – Disabled<br>0x01 – 20 min<br>0x02 – 30 min<br>0x03 – 1 hour<br>0x04 – 2 hours<br>0x05 – 4 hours|
+|Et|0x0D|
+
+
+
+18
+
+
+**PHONO input type (0x59)**
+
+Set or request Phono input type.
+
+Example
+
+
+Command/response sequence where PHONO input is set to Moving
+Magnet type
+
+Command: 0x21 0x01 0x59 0x01 0x00 0x0D
+Response: 0x21 0x01 0x59 0x00 0x01 0x00 0x0D
+
+
+**Input detect (0x5A)**
+
+Request the status of the active input.
+
+Example
+
+
+Command/response sequence where audio input is present.
+
+Command: 0x21 0x01 0x5A 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5A 0x00 0x01 0x01 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x59|
+|Dl|0x01|
+|Data|0x00 - Set PHONO input to Moving Magnet type<br>0x01 - Set PHONO input to Moving Coil type<br>0xF0 - Request PHONO input type|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x59|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - PHONO input set to Moving Magnet type<br>0x01 - PHONO input set to Moving Coil type|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5A|
+|Dl|0x01|
+|Data|0xF0 - Request input status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5A|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Input not present<br>0x01 - Input present|
+|Et|0x0D|
+
+
+
+19
+
+
+**Processor mode input (0x5B)**
+
+Enable processor mode on a certain input or disable processor mode.
+
+Example
+
+
+Enable processor mode on the CD input:
+
+Command: 0x21 0x01 0x5B 0x01 0x06 0x0D
+Response: 0x21 0x01 0x5B 0x00 0x01 0x06 0x0D
+
+
+**Processor mode volume (0x5C)**
+
+Set the processor mode volume
+
+Example
+
+
+Command/response sequence to set the processor mode volume to
+45 (0x2D).
+
+Command: 0x21 0x01 0x5C 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x5C 0x00 0x01 0x2D 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5B|
+|Dl|0x01|
+|Data|0x00 - Disable<br>0x02 - Aux<br>0x03 - PVR<br>0x04 - AV<br>0x05 - STB<br>0x06 - CD<br>0x07 - BD<br>0x08 - SAT<br>0x09 - GAME<br>0xF0 - Query processor mode status|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5B|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Disabled<br>0x02 - Aux<br>0x03 - PVR<br>0x04 - AV<br>0x05 - STB<br>0x06 - CD<br>0x07 - BD<br>0x08 - SAT<br>0x09 - GAME|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5C|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the volume<br>0xF0 – Request the current volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5C|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 (0)– 0x63 (99)|
+|Et|0x0D|
+
+
+
+20
+
+
+**System status (0x5D)**
+
+Request the system status.
+
+Example
+
+
+Command/response sequence to request the system status.
+
+Command: 0x21 0x01 0x5D 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5D 0x00 0x01 0xF0 0x0D
+
+
+Note:
+
+
+This command will return the following information about the system:
+
+       - Power state
+
+       - Brightness level
+
+       - Headphone status
+
+       - Software version
+
+       - Model Number
+
+       - Volume setting
+
+       - Mute status
+
+       - Current input source
+
+       - Headphone override status
+
+       - Balance setting
+
+       - Sample rate
+
+       - Network name
+
+       - IP address
+
+       - Timeout counter value
+
+       - Lifter temperature
+
+       - Output temperature
+
+       - Auto shutdown status
+
+       - Input detect status
+
+       - Processor mode input
+
+       - Processor mode volume
+
+       - DC offset status
+
+       - Short circuit status
+
+       - DAC Filter
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5D|
+|Dl|0x01|
+|Data|0xF0 – Request the system|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5D|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0xF0 - System status sent|
+|Et|0x0D|
+
+
+
+21
+
+
+**System model (0x5E)**
+
+Request the system model.
+
+Example
+
+
+Command/response sequence to request the system model, where the
+model is SA750.
+
+Command: 0x21 0x01 0x5E 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x5E 0x00 0x04 0x53 0x41 0x33 0x30
+0x0D
+
+
+**DAC Filter (0x61)**
+
+Sets or requests the DAC filter
+
+Example
+
+
+Command/response sequence to request the DAC filter where
+response is Linear Phase Fast Roll Off
+
+Command: 0x21 0x01 0x61 0x01 0xF0 0x0D
+Response: 0x21 0x01 0x61 0x00 0x01 0x00 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5E|
+|Dl|0x01|
+|Data|0xF0 – Request the system model|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x5E|
+|Ac|Answer code|
+|Dl|0x04|
+|Data|System model in ASCII characters|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x61|
+|Dl|0x01|
+|Data|0x00 - Linear Phase Fast Roll Off<br>0x01 - Linear Phase Slow Roll Off<br>0x02 - Minimum Phase Fast Roll Off<br>0x03 - Minimum Phase Slow Roll Off<br>0x04 - Brick Wall<br>0x05 - Corrected Phase Fast Roll Off<br>0x06 - Apodizing<br>0xF0 - Request the current filter|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x61|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|0x00 - Linear Phase Fast Roll Off<br>0x01 - Linear Phase Slow Roll Off<br>0x02 - Minimum Phase Fast Roll Off<br>0x03 - Minimum Phase Slow Roll Off<br>0x04 - Brick Wall<br>0x05 - Corrected Phase Fast Roll Off<br>0x06 - Apodizing|
+|Et|0x0D|
+
+
+
+22
+
+
+**Now Playing information (0x64)**
+
+Request the various now playing track details. If the unit is currently
+playing from a source other than a streaming input the track name etc
+will returned as NULL.
+
+Example
+
+
+Command/response sequence to request the currently playing artist
+where the response is A
+
+Command: 0x21 0x01 0x64 0x01 0xF1 0x0D
+Response: 0x21 0x01 0x64 0x00 0x02 0x41 0x0D
+
+Note
+
+
+Response length is limited to 100 characters
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x64|
+|Dl|0x01|
+|Data|0xF0 – Request the currently playing track title<br>0xF1 - Request the currently playing artist<br>0xF2 - Request the currently playing album<br>0xF3 - Request the currently playing application (GoogleCast only)<br>0xF4 - Request the currently playing sample rate<br>0xF5 - Request the currently playing track encoder|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x64|
+|Ac|Answer code|
+|Dl|<n>|
+|Data|Track:<br>Track title in ASCII characters<br>Album:<br>Album name in ASCII characters<br>Artist:<br>Artist name in ASCII characters<br>Application:<br>GoogleCast source application in ASCII characters<br>Sample rate:<br>0x00 – 32 kHz<br>0x01 – 44.1 kHz<br>0x02 – 48 kHz<br>0x03 – 88.2 kHz<br>0x04 – 96 kHz<br>0x05 – 176.4 kHz<br>0x06 – 192 kHz<br>0x07 – Unknown<br>0x08 – Undetected<br>0x09 - 352.8kHz<br>0x0A - 384kHz<br>Audio encoder:<br>0x00 – Uknown<br>0x01 – MP3<br>0x02 – WMA<br>0x03 – Ogg Vorbis<br>0x04 - FLAC<br>0x05 – WAV<br>0x06 - AIFF<br>0x07 - RealAudio<br>0x08 - MPEG URL<br>0x09 - SCPLS<br>0x0A - WPL<br>0x0B - MP4<br>0x0C - DSD<br>0x0D - Opus<br>0x0E - Sirius<br>0x0F - MQA|
+|Et|0x0D|
+
+
+
+23
+
+
+**Maximum Turn On Volume (0x65)**
+
+Set or request the maximum volume level at power up of the SA750.
+
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+Example
+
+
+Command/response sequence for setting the maximum turn on volume
+in Zone 1 to 45:
+
+Command: 0x21 0x01 0x65 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x65 0x00 0x01 0x2D 0x0D
+
+
+**Maximum Volume (0x66)**
+
+Set or request the maximum volume level of the SA750. Used to prevent
+volume being accidently set to full when using app volume sliders.
+
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+Example
+
+
+Command/response sequence for setting the maximum volume in
+Zone 1 to 45:
+
+Command: 0x21 0x01 0x66 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x66 0x00 0x01 0x2D 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x65|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the maximum turn on volume<br>0xF0 – Request the maximum turn on volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x65|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Maximum turn on volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x66|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the maximum volume<br>0xF0 – Request the maximum volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x66|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Maximum volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+
+24
+
+
+**Maximum Streaming Volume (0x67)**
+
+Set or request the maximum volume level of the SA750 when playing
+back streamed content. Used to prevent volume being accidently set to
+full when using app volume sliders and increase the resolution of the
+app volume sliders
+
+
+Response data format:
+
+e.g. for volume 45: Data=0x2D (45)
+
+Example
+
+
+Command/response sequence for setting the maximum volume in
+Zone 1 to 45:
+
+Command: 0x21 0x01 0x67 0x01 0x2D 0x0D
+Response: 0x21 0x01 0x67 0x00 0x01 0x2D 0x0D
+
+
+
+
+|COMMAND:|Col2|
+|---|---|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x67|
+|Dl|0x01|
+|Data|0x00 (0) – 0x63 (99) – Set the maximum volume<br>0xF0 – Request the maximum volume|
+|Et|0x0D|
+|**RESPONSE:**|**RESPONSE:**|
+|Byte:|Description:|
+|St|0x21|
+|Zn|Zone number|
+|Cc|0x67|
+|Ac|Answer code|
+|Dl|0x01|
+|Data|Maximum volume, integer value:<br>0x00 (0) – 0x63 (99)|
+|Et|0x0D|
+
+
+
+25
+
+
+**RC5 Command Codes**
+
+
+These codes are recognised as infra-red signals received by the front panel and as control data using the “Simulate RC5 IR command (0x08)” on
+page 7.
+
+
+
+**Basic Functions**
+
+These RC5 codes are present on the supplied IR remote control and
+provide control over basic amplifier functions.
+
+
+
+**Advanced Functions**
+
+These RC5 codes are not present on the supplied remote control
+but have been created for custom install use. In order for the amp to
+respond to these codes they must be transmitted from a programmable
+IR remote control or over the control link using the ‘Simulate RC5 IR
+Command’ (0x08).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+|Function|RC5 Code<br>[system-command]|RC5 Code<br>(Data1 - Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Power On|16-123|0x10 - 0x7B|
+|Power Off|16-124|0x10 - 0x7C|
+|Random|16-76|0x10 - 0x4C|
+|Repeat|16-49|0x10 - 0x31|
+|Direct mode On|16-78|0x10 - 0x4E|
+|Direct mode Off|16-79|0x10 - 0x4F|
+|Mute On|16-26|0x10 - 0x1A|
+|Mute Off|16-120|0x10 - 0x78|
+|Display Off|16-31|0x10 - 0x1F|
+|Display L1|16-34|0x10 - 0x22|
+|Display L2|16-35|0x10 - 0x23|
+
+
+|Function|RC5 code<br>[system-<br>command]|RC5 code<br>(Data1 -<br>Data2)|
+|---|---|---|
+|**Function**|Decimal|Hexadecimal|
+|Standby|16-12|0x10 - 0x0C|
+|Cycle between VFD information panels|16-55|0x10 - 0x37|
+|Rewind|16-121|0x10 - 0x79|
+|Fast Forward|16-52|0x10 - 0x34|
+|Skip Back|16-33|0x10 - 0x21|
+|Skip Forward|16-11|0x10 - 0x0B|
+|Stop|16-54|0x10 - 0x36|
+|Play|16-53|0x10 - 0x35|
+|Pause|16-48|0x10 - 0x30|
+|MENU (Enter system menu)|16-82|0x10 - 0x52|
+|Navigate Up|16-86|0x10 - 0x56|
+|Navigate Left|16-81|0x10 - 0x51|
+|OK|16-87|0x10 - 0x57|
+|Navigate Right|16-80|0x10 - 0x50|
+|Audio (Room EQ on/off)|16-30|0x10 - 0x1E|
+|Navigate Down|16-85|0x10 - 0x55|
+|RTN (Back in menu)|16-51|0x10 - 0x33|
+|HOME|16-43|0x10 - 0x2B|
+|Mute|16-13|0x10 - 0x0D|
+|Increase volume (+)|16-16|0x10 - 0x10|
+|DISP (Change VFD brightness)|16-59|0x10 - 0x3B|
+|Analogue DIRECT mode|16-10|0x10 - 0x0A|
+|Decrease volume (-)|16-17|0x10 - 0x11|
+|PHONO|16-117|0x10 - 0x75|
+|AUX|16-99|0x10 - 0x63|
+|NET|16-92|0x10 - 0x5C|
+|USB|16-93|0x10 - 0x5D|
+|AV|16-94|0x10 - 0x5E|
+|SAT|16-27|0x10 - 0x1B|
+|PVR|16-96|0x10 - 0x60|
+|GAME|16-97|0x10 - 0x61|
+|BD|16-98|0x10 - 0x62|
+|CD|16-118|0x10 - 0x76|
+|STB|16-100|0x10 - 0x64|
+
+
+
+26
+
+
+SH320E Issue 1
+
+
+
+www.jblsynthesis.com
+
+Harman International Industries
+
+8500 Balboa Avenue,Northridge, CA, 91329, USA
+
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,399 @@
+{
+  description = "Arcam FMJ receiver control library";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        inherit (pkgs) lib;
+
+        # Each entry: { models, url, hash }
+        #   models — human-readable list of receiver/amp models the spec covers, used in the generated README.
+        specSources = [
+          {
+            models = "AVR5/AVR10/AVR20/AVR30/AV40/AVR11/AVR21/AVR31/AV41";
+            url = "https://www.arcam.co.uk/ugc/tor/AVR11/Custom%20Installation%20Notes/RS232_5_10_20_30_40_11_21_31_41__SH289E_F_07Oct21.pdf";
+            hash = "sha256-SJZpSAMAuDe2soJAqB8djlnags1QLnEpxIvi4OYNkOI=";
+          }
+          {
+            models = "SA30";
+            url = "https://www.arcam.co.uk/ugc/tor/SA30/Custom%20Installation%20Notes/SH306E_RS232_SA30_4.pdf";
+            hash = "sha256-o6YJ1N0v914DQEAtS6ibbDJQDsUFE0VzZmbqYLk7AZo=";
+          }
+          {
+            models = "SA750";
+            url = "https://www.jbl.com/on/demandware.static/-/Sites-masterCatalog_Harman/default/dwabc088c9/pdfs/SH320E_RS232_SA750_iss1.pdf";
+            hash = "sha256-cAvTiaRVf0L8GeAGwXwa811fjD9ySrOl8lu6s5u8WPY=";
+          }
+          {
+            models = "PA720/PA240/PA410";
+            url = "https://www.arcam.co.uk/ugc/tor/PA240/Custom%20Installation%20Notes/RS232_PA720_PA240_PA410_SH305E_3.pdf";
+            hash = "sha256-EM/u8ECteRMIRTf2By4SmCaVUkR+sfQjI/xzS+ZtP74=";
+          }
+          {
+            models = "ST60";
+            url = "https://www.arcam.co.uk/ugc/tor/ST60/Custom%20Installation%20Notes/SH309_RS232_ST60_C.pdf";
+            hash = "sha256-4BJFb/EoFsQqwxQfWKWXZMuwuhT97k7jA53uxPAJ3Dw=";
+          }
+          {
+            models = "AV860/AVR850/AVR550/AVR390/SR250";
+            url = "https://www.arcam.co.uk/ugc/tor/avr390/RS232/RS232_860_850_550_390_250_SH274E_D_181018.pdf";
+            hash = "sha256-rmOBTVZS/kBkNtqEkc0ecstK+cEvL7qtV9nmNAwMwp8=";
+          }
+          {
+            models = "SA10/SA20";
+            url = "https://www.arcam.co.uk/ugc/tor/SA20/Custom%20Installation%20Notes/SH277E_RS232_SA10_SA20_B.pdf";
+            hash = "sha256-KNlltjQnG/htrCTTm2x1aRo8fESCU+O3jYGlEYTZdnc=";
+          }
+          {
+            models = "AVR750/AVR450/AVR380";
+            url = "https://www.arcam.co.uk/ugc/tor/avr380/RS232/RS232_AVR750450380_SH256E_3.pdf";
+            hash = "sha256-9VS6BDNTWwzVzRYGZGbyoALiT4mZMSV/DThmOldV3aE=";
+          }
+        ];
+
+        specs =
+          let
+            withPdf = src: src // { pdf = pkgs.fetchurl { inherit (src) url hash; }; };
+            withMarkdown =
+              src:
+              src
+              // {
+                markdown =
+                  let
+                    baseName = lib.removeSuffix ".pdf" src.pdf.name;
+                  in
+                  pkgs.runCommand "${baseName}.md"
+                    {
+                      nativeBuildInputs = [
+                        (pkgs.python3.withPackages (ps: [ ps.pymupdf4llm ]))
+                      ];
+                      inherit (src) pdf;
+                    }
+                    ''
+                      python3 <<'EOF'
+                      import os
+                      import pymupdf4llm
+                      md = pymupdf4llm.to_markdown(os.environ["pdf"])
+                      with open(os.environ["out"], "w") as f:
+                          f.write(md)
+                      EOF
+                    '';
+              };
+            entries = map (src: withMarkdown (withPdf src)) specSources;
+            readme = pkgs.writeText "README.md" ''
+              # Protocol specifications
+
+              Arcam's official RS-232 / IP control protocol PDFs, converted to Markdown by `nix run '.#fetch-specs'`. The spec PDFs are the first source of ground truth for the library implemention (modulo errors discovered in the specs.) These markdown versions are easier for LLM agents to consume than the original PDFs. Please regenerate them whenever the upstream PDFs change.
+
+              Caveat: `pymupdf4llm` does not always preserve table ordering — command-reference tables may appear separated from the prose that describes them. When in doubt, consult the original PDF.
+
+              ## Documents
+
+              ${lib.concatMapStringsSep "\n" (e: "- ${e.models} — [${e.markdown.name}](${e.markdown.name}) ([original PDF](${e.url}))") entries}
+            '';
+          in
+          pkgs.runCommand "arcam-specs" { } ''
+            mkdir -p $out
+            ln -s ${readme} $out/README.md
+            ${lib.concatMapStringsSep "\n" (e: "ln -s ${e.markdown} $out/${e.markdown.name}") entries}
+          '';
+
+        fetch-specs = pkgs.writeShellApplication {
+          name = "fetch-specs";
+          runtimeInputs = [ pkgs.coreutils ];
+          # Replace existing *.md and README.md in docs/specs; leave any other
+          # files (e.g. hand-written notes) alone.
+          text = ''
+            dest=docs/specs
+            mkdir -p "$dest"
+            rm -f "$dest"/*.md
+            cp -L --no-preserve=mode ${specs}/*.md "$dest"/
+          '';
+        };
+
+        firmwareZip = pkgs.fetchurl {
+          url = "https://www.arcam.co.uk/ugc/tor/AV41/v1.62%202148%20Unit%20Software/AVRx1_1v62_2148.zip";
+          hash = "sha256-5wCU0N4mKYd9/Bl4/JAX5Qk2QBYWzf6koOPgNZrmq/E=";
+        };
+
+        firmwareUnzipped =
+          pkgs.runCommand "AVRx1_1v62_2148"
+            {
+              nativeBuildInputs = [ pkgs.unzip ];
+            }
+            ''
+              unzip ${firmwareZip} -d $out
+            '';
+
+        # SWUpdate payload for the Amlogic A113D Linux SoC (network/streaming side).
+        firmwareNetRaw =
+          pkgs.runCommand "AVRx1_1v62_2148-net-raw"
+            {
+              nativeBuildInputs = [ pkgs.cpio ];
+            }
+            ''
+              mkdir -p $out
+              cd $out
+              cpio -idv < ${firmwareUnzipped}/image.swu
+            '';
+
+        # Yocto rootfs — the .ubifs blob is XZ-compressed (see sw-description).
+        firmwareNetRootfs =
+          pkgs.runCommand "AVRx1_1v62_2148-net-rootfs"
+            {
+              nativeBuildInputs = [
+                pkgs.xz
+                pkgs.ubi_reader
+              ];
+            }
+            ''
+              xz -dc ${firmwareNetRaw}/yocto-nsdk-ip-image-swu-a113d-arcam.ubifs > rootfs.ubifs
+              ubireader_extract_files -o "$out" rootfs.ubifs
+            '';
+
+        # Split a signed FIT image into its sub-images. Kernel/ramdisk are gzip-compressed
+        # inside the FIT, so decompress them after extraction.
+        extractFit =
+          name: fit: subimages:
+          pkgs.runCommand name
+            {
+              nativeBuildInputs = [
+                pkgs.ubootTools
+                pkgs.gzip
+                pkgs.cpio
+              ];
+            }
+            ''
+              mkdir -p $out
+              ${lib.concatMapStringsSep "\n" (s: ''
+                dumpimage -T flat_dt -p ${toString s.index} -o "$out/${s.name}${s.ext or ""}" ${fit}
+                ${lib.optionalString (s.gunzip or false) ''
+                  gunzip "$out/${s.name}${s.ext or ""}"
+                ''}
+                ${lib.optionalString (s.cpio or false) ''
+                  mkdir -p "$out/${s.name}.d"
+                  ( cd "$out/${s.name}.d" && cpio -idmv < "$out/${s.name}" )
+                ''}
+              '') subimages}
+            '';
+
+        firmwareNetFit =
+          extractFit "AVRx1_1v62_2148-net-fit" "${firmwareNetRaw}/fitImage-a113d-arcam-signed"
+            [
+              {
+                index = 0;
+                name = "kernel";
+                ext = ".gz";
+                gunzip = true;
+              }
+              {
+                index = 1;
+                name = "fdt.dtb";
+              }
+            ];
+
+        firmwareNetFitSwu =
+          extractFit "AVRx1_1v62_2148-net-fit-swu" "${firmwareNetRaw}/fitImage-swu-a113d-arcam-signed"
+            [
+              {
+                index = 0;
+                name = "kernel";
+                ext = ".gz";
+                gunzip = true;
+              }
+              {
+                index = 1;
+                name = "fdt.dtb";
+              }
+              {
+                index = 2;
+                name = "ramdisk.cpio";
+                ext = ".gz";
+                gunzip = true;
+                cpio = true;
+              }
+            ];
+
+        firmwareNetUboot =
+          pkgs.runCommand "AVRx1_1v62_2148-net-uboot"
+            {
+              nativeBuildInputs = [
+                pkgs.gnutar
+                pkgs.gzip
+              ];
+            }
+            ''
+              mkdir -p $out
+              tar -xzf ${firmwareNetRaw}/u-boot.tar.gz -C $out
+            '';
+
+        # Full demangled aarch64 disassembly of binaries plausibly involved in the TCP-bridge data path. See CLAUDE.md "TCP-serial bridge" for context.
+        firmwareNetAnalysis =
+          let
+            disasmTargets = [
+              # Binaries
+              "usr/share/nsdk/nSDK"
+              "usr/bin/hostlink_cli"
+              "usr/bin/nsdk_cli"
+              # Directly involved
+              "usr/lib64/libnsdk_hostLink.so"
+              "usr/lib64/libnsdk_hostLinkLib.so"
+              "usr/lib64/libnsdk_serialComm.so"
+              "usr/lib64/libnsdk_thrift_api.so"
+              "usr/lib64/libnsdk_api.so"
+              # Could intercept / wrap the data path or hold relevant state
+              "usr/lib64/libnsdk_networking.so"
+              "usr/lib64/libnsdk_services.so"
+              "usr/lib64/libnsdk_simple_ipc.so"
+              "usr/lib64/libnsdk_webserver.so"
+              "usr/lib64/libnsdk_machine.so"
+              "usr/lib64/libnsdk_systemManager.so"
+              "usr/lib64/libnsdk_processhandler.so"
+              "usr/lib64/libnsdk_powerHandler.so"
+              "usr/lib64/libnsdk_powerManager.so"
+              # Settings/infra used by hostlink
+              "usr/lib64/libnsdk_constpartition.so"
+              "usr/lib64/libnsdk_sysfs.so"
+              "usr/lib64/libnsdk_mLib.so"
+              "usr/lib64/libnsdk_miscUtils.so"
+              # mDNS — registers the port-50000 advert; may surface session lifecycle
+              "usr/lib64/libnsdk_mdnsHelpers.so"
+              "usr/lib64/libnsdk_mdnsSystemMembers.so"
+            ];
+          in
+          pkgs.runCommand "AVRx1_1v62_2148-net-analysis"
+            {
+              nativeBuildInputs = [ pkgs.llvm ];
+            }
+            ''
+              mkdir -p $out/disasm
+              ${lib.concatMapStringsSep "\n" (t: ''
+                llvm-objdump --disassemble --demangle ${firmwareNetRootfs}/${t} \
+                  > $out/disasm/${baseNameOf t}.S
+              '') disasmTargets}
+            '';
+
+        firmwareNet = pkgs.runCommand "AVRx1_1v62_2148-net" { } ''
+          mkdir -p $out
+          cp -r --no-preserve=mode ${firmwareNetRootfs}   $out/rootfs
+          cp -r --no-preserve=mode ${firmwareNetFit}      $out/fit
+          cp -r --no-preserve=mode ${firmwareNetFitSwu}   $out/fit-swu
+          cp -r --no-preserve=mode ${firmwareNetUboot}    $out/u-boot
+          cp -r --no-preserve=mode ${firmwareNetAnalysis} $out/analysis
+          for f in ${firmwareNetRaw}/*; do
+            cp -L --no-preserve=mode "$f" "$out/$(basename "$f")"
+          done
+        '';
+
+        # Extract the two STM32 code regions from the host firmware bundle and
+        # disassemble each in Thumb-2. Section boundaries inside the 90 MB .fw blob
+        # (mostly 0xFF padding) were determined by inspecting the vector-table
+        # patterns at the start of each contiguous run of non-0xFF bytes.
+        #
+        #   file offset  flash addr   contents
+        #   0x000000     0x08000000   STM32 update bootloader (~60 KB)
+        #   0x010000     0x08010000   STM32 main app (~872 KB)
+        #
+        # The remainder of the .fw is TI Performance Audio DSP firmware + the
+        # "Bach" audio sub-component, which are not relevant to the protocol
+        # path we analyse and so are not disassembled here.
+        firmwareHostAnalysis =
+          let
+            # (region name, file-offset start, file-offset end exclusive, flash load addr)
+            regions = [
+              { name = "stm32_bootloader"; src = "0x0"; dst = "0x10000"; vma = "0x08000000"; }
+              { name = "stm32_app"; src = "0x10000"; dst = "0xea020"; vma = "0x08010000"; }
+            ];
+          in
+          pkgs.runCommand "AVRx1_1v62_2148-host-analysis"
+            {
+              nativeBuildInputs = [
+                pkgs.coreutils
+                pkgs.gcc-arm-embedded
+              ];
+            }
+            ''
+              mkdir -p $out/extracted $out/disasm
+              FW=$(echo ${firmwareUnzipped}/*.fw)
+              ${lib.concatMapStringsSep "\n" (r: ''
+                dd if=$FW of=$out/extracted/${r.name}.bin bs=1 \
+                   skip=$(( ${r.src} )) count=$(( ${r.dst} - ${r.src} )) status=none
+                arm-none-eabi-objdump -D -b binary -m armv7e-m -M force-thumb \
+                  --adjust-vma=${r.vma} $out/extracted/${r.name}.bin \
+                  > $out/disasm/${r.name}.S
+              '') regions}
+            '';
+
+        # Core MCU firmware for the AVR receiver itself, plus extracted/disassembled
+        # STM32 code regions for analysis.
+        firmwareHost = pkgs.runCommand "AVRx1_1v62_2148-host" { } ''
+          mkdir -p $out
+          for f in ${firmwareUnzipped}/*.fw; do
+            ln -s "$f" "$out/$(basename "$f")"
+          done
+          cp -r --no-preserve=mode ${firmwareHostAnalysis} $out/analysis
+        '';
+
+        firmware = pkgs.runCommand "arcam-firmware" { } ''
+          mkdir -p $out
+          cp -r --no-preserve=mode ${firmwareHost} $out/host
+          cp -r --no-preserve=mode ${firmwareNet}  $out/net
+          for f in ${firmwareUnzipped}/*; do
+            name=$(basename "$f")
+            case "$name" in
+              image.swu|*.fw) ;;
+              *) cp -L --no-preserve=mode "$f" "$out/$name" ;;
+            esac
+          done
+        '';
+
+        fetch-firmware = pkgs.writeShellApplication {
+          name = "fetch-firmware";
+          runtimeInputs = [ pkgs.coreutils ];
+          # Plain `cp -r` (no -L) so absolute symlinks inside extracted filesystems
+          # (e.g. /usr/sbin/...) are preserved rather than dereferenced against the host.
+          text = ''
+            rm -rf .firmware
+            cp -r --no-preserve=mode ${firmware} .firmware
+          '';
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            uv
+            python3
+            nixfmt
+          ];
+
+          shellHook = ''
+            export UV_PYTHON_PREFERENCE=only-system
+          '';
+        };
+
+        packages.specs = specs;
+        packages.firmware = firmware;
+
+        apps.fetch-specs = {
+          type = "app";
+          program = "${fetch-specs}/bin/fetch-specs";
+        };
+        apps.fetch-firmware = {
+          type = "app";
+          program = "${fetch-firmware}/bin/fetch-firmware";
+        };
+      }
+    );
+}


### PR DESCRIPTION
You asked how I got as far as I did in the FW RE - here you go. This adds:

- A nix flake & direnv. If you have direnv & nix installed, then you get an environment that automatically pulls in the tools needed for building & testing & etc.
- Claude support files
- Script for pulling specs & converting them to markdown for LLMs; check those in for reference
- Script for pulling in the FW, extracting and disassembling interesting parts - suitable for analysis from there. _Not_ checked in - it's huge, and easy to re-grab when needed.
- There's also a doc with the disassembly analysis. One notable refinement from my earlier notes: There _is_ a state machine in the TCP handler, but that's not what's responsible for the dropped packets. What actually _is_ responsible is the fact that the stream handler drains _everything_ in the buffer, sends it along, and then down in the MCU, it treats it as a single packet and ignores the tail. So not _quite_ as horrible as I initially thought, but definitely a significant design bug.

Anyway, take this if you're interested, reject if you're not.