### PR TITLE
chore: No SEND_ONLY

### DIFF
--- a/src/arcam/fmj/client.py
+++ b/src/arcam/fmj/client.py
@@ -144,19 +144,6 @@ class ClientBase:
                             return await asyncio.shield(future)
                     await stack.aclose()
                     return await future
-                    
-    async def send(self, zn: int, cc: CommandCodes, data: bytes, priority: int = 0) -> None:
-        if not self._writer:
-            raise NotConnectedException()
-
-        if not (cc.flags & CommandFlags.ZONE_SUPPORT) and zn != 1:
-            raise UnsupportedZone()
-
-        writer = self._writer
-        request = CommandPacket(zn, cc, data)
-        async with self._request_lock(priority):
-            await write_packet(writer, request)
-            await asyncio.sleep(_REQUEST_THROTTLE)
 
     async def request(self, zn: int, cc: CommandCodes, data: bytes, priority: int = 0):
         if not self._writer:
@@ -164,10 +151,6 @@ class ClientBase:
 
         if not (cc.flags & CommandFlags.ZONE_SUPPORT) and zn != 1:
             raise UnsupportedZone()
-
-        if cc.flags & CommandFlags.SEND_ONLY:
-            await self.send(zn, cc, data, priority)
-            return
 
         response = await self.request_raw(CommandPacket(zn, cc, data), priority)
 

--- a/src/arcam/fmj/commands.py
+++ b/src/arcam/fmj/commands.py
@@ -49,7 +49,6 @@ class CommandFlags(enum.IntFlag):
         return obj
 
     ZONE_SUPPORT = enum.auto()
-    SEND_ONLY = enum.auto()
     POLL_REQUIRED = (enum.auto(), 20)
     FULL_UPDATE = (enum.auto(), 10)
 
@@ -75,7 +74,6 @@ VOLUME_STEP_SUPPORTED = {
 
 # Short aliases for the table below.
 _Z = CommandFlags.ZONE_SUPPORT
-_S = CommandFlags.SEND_ONLY
 _P = CommandFlags.POLL_REQUIRED
 _F = CommandFlags.FULL_UPDATE
 
@@ -143,7 +141,7 @@ class CommandCodes(IntOrTypeEnum):
     SOFTWARE_VERSION                = 0x04, None
     RESTORE_FACTORY_DEFAULT         = 0x05, None
     SAVE_RESTORE_COPY_OF_SETTINGS   = 0x06, _AVR
-    SIMULATE_RC5_IR_COMMAND         = 0x08, _AVR_SA_ST, _Z | _S
+    SIMULATE_RC5_IR_COMMAND         = 0x08, _AVR_SA_ST, _Z
     DISPLAY_INFORMATION_TYPE        = 0x09, _AVR,       _Z | _F
 
     # --- Input ---

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -384,7 +384,7 @@ class State:
                 # assume we succeded until response come
                 # back.
                 self._state[CommandCodes.POWER] = bytes([0])
-                await self._client.send(
+                await self._client.request(
                     self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command
                 )
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -103,7 +103,7 @@ async def test_power_off(zn, api_model):
     else:
         # zn, api_model, power
         code = PARAMS_TO_RC5COMMAND[zn, api_model, False]
-        client.send.assert_called_with(zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code)
+        client.request.assert_called_with(zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code)
     assert state.get_power() is False
 
 


### PR DESCRIPTION
SEND_ONLY is for commands where the device doesn't ACK the command - which is none, actually. Per spec, _everything_ returns a response. Experimentation confirms this. The only command we have marked with this today is the RC5 send, and that's not true. We don't get a new _value_ back or anything, but we _do_ get an ACK.

This matters for two reasons:
- It's another code path an extra complexity to handle
- Efficient comms utilization (over TCP anyway) requires waiting for the response to the last send command. If we can't (or don't) listen for a response, the only safe thing we can do is wait very conservatively, wasting line bandwidth and increasing command latency.

This removes the flag and cleans up the extraneous code paths.

Note this is built on https://github.com/elupus/arcam_fmj/pull/93