### PR TITLE
chore: Update Task

### DIFF
--- a/src/arcam/fmj/client.py
+++ b/src/arcam/fmj/client.py
@@ -5,7 +5,6 @@ from asyncio.streams import StreamReader, StreamWriter
 import logging
 from collections.abc import Callable
 from contextlib import contextmanager
-from copy import copy
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import overload
@@ -29,7 +28,7 @@ from .packets import (
     read_response,
     write_packet,
 )
-from .utils import async_retry
+from .utils import async_retry, run_tasks
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,10 +36,13 @@ _REQUEST_TIMEOUT = timedelta(milliseconds=500)
 _REQUEST_RETRY_COUNT = 2
 _REQUEST_SETTLE_TIME = timedelta(milliseconds=5)
 
+_UPDATE_IDLE_INTERVAL = timedelta(milliseconds=200)
+
 _HEARTBEAT_INTERVAL = timedelta(seconds=5)
 _HEARTBEAT_TIMEOUT = _HEARTBEAT_INTERVAL + _HEARTBEAT_INTERVAL
 
 _USER_PRIORITY = 0
+_UPDATE_PRIORITY = 10
 _HEARTBEAT_PRIORITY = 100
 
 
@@ -57,6 +59,7 @@ class ClientBase:
         self._reader: StreamReader | None = None
         self._writer: StreamWriter | None = None
         self._listen: set[Callable] = set()
+        self._update_providers: set[Callable] = set()
         self._queue: asyncio.PriorityQueue[_QueueItem] | None = None
         self._seq: int = 0
 
@@ -82,6 +85,12 @@ class ClientBase:
             yield self
         finally:
             self._listen.remove(listener)
+
+    def register_update_provider(self, provider: Callable) -> None:
+        self._update_providers.add(provider)
+
+    def unregister_update_provider(self, provider: Callable) -> None:
+        self._update_providers.discard(provider)
 
     async def start(self) -> None:
         if self._writer:
@@ -204,6 +213,16 @@ class ClientBase:
                         NotConnectedException("Connection closed")
                     )
 
+    async def _process_updates(self) -> None:
+        while True:
+            tasks: list = []
+            for provider in self._update_providers:
+                tasks.extend(await provider())
+            if not tasks:
+                await asyncio.sleep(_UPDATE_IDLE_INTERVAL.total_seconds())
+                continue
+            await run_tasks(*tasks)
+
     async def _process_heartbeat(self):
         while True:
             await asyncio.sleep(_HEARTBEAT_INTERVAL.total_seconds())
@@ -218,13 +237,12 @@ class ClientBase:
         assert self._reader, "Reader missing"
 
         try:
-            async with asyncio.TaskGroup() as group:
-                group.create_task(self._process_receive(self._reader))
-                group.create_task(self._process_send(self._writer))
-                group.create_task(self._process_heartbeat())
-        except BaseExceptionGroup as exc:
-            # convert to a non group exception to keep compatibility
-            raise copy(exc.exceptions[0]).with_traceback(exc.exceptions[0].__traceback__)
+            await run_tasks(
+                self._process_receive(self._reader),
+                self._process_send(self._writer),
+                self._process_updates(),
+                self._process_heartbeat(),
+            )
         finally:
             _LOGGER.debug("Process task shutting down")
             self._writer.close()

--- a/src/arcam/fmj/client.py
+++ b/src/arcam/fmj/client.py
@@ -189,6 +189,10 @@ class ClientBase:
                 try:
                     try:
                         response = await self._write_and_wait(writer, item.packet)
+                    except asyncio.CancelledError:
+                        if not item.future.done():
+                            item.future.cancel()
+                        raise
                     except TimeoutError as e:
                         if not item.future.done():
                             item.future.set_exception(e)
@@ -206,9 +210,14 @@ class ClientBase:
             queue = self._queue
             self._queue = None
             # Drain what's already in the queue to unblock all waiters
+            cancelled = asyncio.current_task().cancelling() > 0
             while not queue.empty():
                 pending = queue.get_nowait()
-                if not pending.future.done():
+                if pending.future.done():
+                    continue
+                if cancelled:
+                    pending.future.cancel()
+                else:
                     pending.future.set_exception(
                         NotConnectedException("Connection closed")
                     )

--- a/src/arcam/fmj/client.py
+++ b/src/arcam/fmj/client.py
@@ -189,10 +189,6 @@ class ClientBase:
                 try:
                     try:
                         response = await self._write_and_wait(writer, item.packet)
-                    except asyncio.CancelledError:
-                        if not item.future.done():
-                            item.future.cancel()
-                        raise
                     except TimeoutError as e:
                         if not item.future.done():
                             item.future.set_exception(e)
@@ -210,14 +206,9 @@ class ClientBase:
             queue = self._queue
             self._queue = None
             # Drain what's already in the queue to unblock all waiters
-            cancelled = asyncio.current_task().cancelling() > 0
             while not queue.empty():
                 pending = queue.get_nowait()
-                if pending.future.done():
-                    continue
-                if cancelled:
-                    pending.future.cancel()
-                else:
+                if not pending.future.done():
                     pending.future.set_exception(
                         NotConnectedException("Connection closed")
                     )

--- a/src/arcam/fmj/client.py
+++ b/src/arcam/fmj/client.py
@@ -3,11 +3,11 @@
 import asyncio
 from asyncio.streams import StreamReader, StreamWriter
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import overload
+from typing import Any, overload
 
 from serialx import open_serial_connection
 
@@ -45,6 +45,11 @@ _USER_PRIORITY = 0
 _UPDATE_PRIORITY = 10
 _HEARTBEAT_PRIORITY = 100
 
+#: A coroutine that fetches one piece of device state.
+UpdateTask = Coroutine[Any, Any, None]
+#: Supplies the update tasks wanted right now; re-invoked each loop pass.
+UpdateProvider = Callable[[], Awaitable[list[UpdateTask]]]
+
 
 @dataclass(order=True)
 class _QueueItem:
@@ -59,7 +64,7 @@ class ClientBase:
         self._reader: StreamReader | None = None
         self._writer: StreamWriter | None = None
         self._listen: set[Callable] = set()
-        self._update_providers: set[Callable] = set()
+        self._update_providers: set[UpdateProvider] = set()
         self._queue: asyncio.PriorityQueue[_QueueItem] | None = None
         self._seq: int = 0
 
@@ -86,10 +91,10 @@ class ClientBase:
         finally:
             self._listen.remove(listener)
 
-    def register_update_provider(self, provider: Callable) -> None:
+    def register_update_provider(self, provider: UpdateProvider) -> None:
         self._update_providers.add(provider)
 
-    def unregister_update_provider(self, provider: Callable) -> None:
+    def unregister_update_provider(self, provider: UpdateProvider) -> None:
         self._update_providers.discard(provider)
 
     async def start(self) -> None:
@@ -215,7 +220,7 @@ class ClientBase:
 
     async def _process_updates(self) -> None:
         while True:
-            tasks: list = []
+            tasks: list[UpdateTask] = []
             for provider in self._update_providers:
                 tasks.extend(await provider())
             if not tasks:

--- a/src/arcam/fmj/client.py
+++ b/src/arcam/fmj/client.py
@@ -28,7 +28,7 @@ from .packets import (
     read_response,
     write_packet,
 )
-from .utils import async_retry, run_tasks
+from .utils import async_retry, cancel_and_wait, run_tasks
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -67,6 +67,9 @@ class ClientBase:
         self._update_providers: set[UpdateProvider] = set()
         self._queue: asyncio.PriorityQueue[_QueueItem] | None = None
         self._seq: int = 0
+        # Set whenever no connection is up, including before the first start().
+        self._disconnected = asyncio.Event()
+        self._disconnected.set()
 
     @property
     def peer(self) -> str:
@@ -104,6 +107,7 @@ class ClientBase:
         _LOGGER.debug("Connecting to %s", self.peer)
         self._reader, self._writer = await self._open()
         self._queue = asyncio.PriorityQueue()
+        self._disconnected.clear()
         _LOGGER.info("Connected to %s", self.peer)
 
     async def stop(self) -> None:
@@ -118,6 +122,7 @@ class ClientBase:
                 self._writer = None
                 self._reader = None
                 self._queue = None
+                self._disconnected.set()
 
     @overload
     async def request_raw(self, request: CommandPacket, priority: int = _USER_PRIORITY) -> ResponsePacket: ...
@@ -250,6 +255,7 @@ class ClientBase:
             )
         finally:
             _LOGGER.debug("Process task shutting down")
+            self._disconnected.set()
             self._writer.close()
 
 class Client(ClientBase):

--- a/src/arcam/fmj/client.py
+++ b/src/arcam/fmj/client.py
@@ -302,9 +302,5 @@ class ClientContext:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self._task:
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
+            await cancel_and_wait(self._task)
         await self._client.stop()

--- a/src/arcam/fmj/commands.py
+++ b/src/arcam/fmj/commands.py
@@ -36,21 +36,11 @@ from .models import (
 )
 
 class CommandFlags(enum.IntFlag):
-    """Behavioural protocol traits of a command code.
-
-    ``priority`` controls update-loop ordering: higher-priority commands
-    are fetched first.
-    """
-
-    def __new__(cls, value, priority=0):
-        obj = int.__new__(cls, value)
-        obj._value_ = value
-        obj.priority = priority
-        return obj
+    """Behavioural protocol traits of a command code."""
 
     ZONE_SUPPORT = enum.auto()
-    POLL_REQUIRED = (enum.auto(), 20)
-    FULL_UPDATE = (enum.auto(), 10)
+    UPDATE = enum.auto()        # Fetched by the State update loop.
+    NOT_PUSHED = enum.auto()    # Device does not send unsolicited updates
 
 #: Models that accept a direct CC write for power on/off.
 POWER_WRITE_SUPPORTED = {
@@ -74,8 +64,8 @@ VOLUME_STEP_SUPPORTED = {
 
 # Short aliases for the table below.
 _Z = CommandFlags.ZONE_SUPPORT
-_P = CommandFlags.POLL_REQUIRED
-_F = CommandFlags.FULL_UPDATE
+_U = CommandFlags.UPDATE
+_NP = CommandFlags.NOT_PUSHED
 
 _AVR = APIVERSION_AVR_SERIES
 _AVR_SA = APIVERSION_AVR_AND_SA_SERIES
@@ -134,40 +124,40 @@ class CommandCodes(IntOrTypeEnum):
     # ====                            ==    =======     =====
 
     # --- System ---
-    POWER                           = 0x00, None,       _Z | _F
+    POWER                           = 0x00, None,       _Z | _U
     DISPLAY_BRIGHTNESS              = 0x01, _AVR_SA_ST
-    HEADPHONES                      = 0x02, _AVR_SA,    _F
+    HEADPHONES                      = 0x02, _AVR_SA,    _U
     FMGENRE                         = 0x03, _AVR,       _Z
     SOFTWARE_VERSION                = 0x04, None
     RESTORE_FACTORY_DEFAULT         = 0x05, None
     SAVE_RESTORE_COPY_OF_SETTINGS   = 0x06, _AVR
     SIMULATE_RC5_IR_COMMAND         = 0x08, _AVR_SA_ST, _Z
-    DISPLAY_INFORMATION_TYPE        = 0x09, _AVR,       _Z | _F
+    DISPLAY_INFORMATION_TYPE        = 0x09, _AVR,       _Z | _U
 
     # --- Input ---
-    VIDEO_SELECTION                 = 0x0A, _PRE_HDA,   _F
+    VIDEO_SELECTION                 = 0x0A, _PRE_HDA,   _U
     SELECT_ANALOG_DIGITAL           = 0x0B, _AVR,       _Z
-    IMAX_ENHANCED                   = 0x0C, _IMAX,      _F          # was "Video input type" in 450 (SH256E); not AVR5 (SH289E)
+    IMAX_ENHANCED                   = 0x0C, _IMAX,      _U          # was "Video input type" in 450 (SH256E); not AVR5 (SH289E)
 
     # --- Output ---
-    VOLUME                          = 0x0D, _AVR_SA_ST, _Z | _F
-    MUTE                            = 0x0E, None,       _Z | _F
+    VOLUME                          = 0x0D, _AVR_SA_ST, _Z | _U
+    MUTE                            = 0x0E, None,       _Z | _U
     DIRECT_MODE_STATUS              = 0x0F, _DIRECT
-    DECODE_MODE_STATUS_2CH          = 0x10, _AVR,       _F
-    DECODE_MODE_STATUS_MCH          = 0x11, _AVR,       _F
-    RDS_INFORMATION                 = 0x12, _AVR,       _Z | _F
+    DECODE_MODE_STATUS_2CH          = 0x10, _AVR,       _U
+    DECODE_MODE_STATUS_MCH          = 0x11, _AVR,       _U
+    RDS_INFORMATION                 = 0x12, _AVR,       _Z | _U
     VIDEO_OUTPUT_RESOLUTION         = 0x13, _AVR
 
     # --- Menu / Tuner / Source ---
-    MENU                            = 0x14, _AVR,       _F
-    TUNER_PRESET                    = 0x15, _AVR,       _Z | _F
+    MENU                            = 0x14, _AVR,       _U
+    TUNER_PRESET                    = 0x15, _AVR,       _Z | _U
     TUNE                            = 0x16, _AVR,       _Z
-    DAB_STATION                     = 0x18, _AVR,       _Z | _F
+    DAB_STATION                     = 0x18, _AVR,       _Z | _U
     DAB_PROGRAM_TYPE_CATEGORY       = 0x19, _AVR,       _Z
-    DLS_PDT_INFO                    = 0x1A, _AVR,       _Z | _F
-    PRESET_DETAIL                   = 0x1B, _AVR,       _Z | _F
-    NETWORK_PLAYBACK_STATUS         = 0x1C, _NET_PLAY,  _P | _F
-    CURRENT_SOURCE                  = 0x1D, _AVR_SA_ST, _Z | _F
+    DLS_PDT_INFO                    = 0x1A, _AVR,       _Z | _U
+    PRESET_DETAIL                   = 0x1B, _AVR,       _Z | _U
+    NETWORK_PLAYBACK_STATUS         = 0x1C, _NET_PLAY,  _U | _NP
+    CURRENT_SOURCE                  = 0x1D, _AVR_SA_ST, _Z | _U
     HEADPHONES_OVERRIDE             = 0x1F, _AVR_SA,    _Z
 
     # --- Extended (2.0) ---
@@ -188,28 +178,28 @@ class CommandCodes(IntOrTypeEnum):
     NETWORK_MENU_INFO               = 0x30, _NET_MENU
     BLUETOOTH_MENU_INFO             = 0x32, _HDA
     ENGINEERING_MENU_INFO           = 0x33, _HDA
-    ROOM_EQ_NAMES                   = 0x34, _ROOM_NAM,  _F
+    ROOM_EQ_NAMES                   = 0x34, _ROOM_NAM,  _U
 
     # --- Setup / EQ ---
-    TREBLE_EQUALIZATION             = 0x35, _AVR,       _Z | _F
-    BASS_EQUALIZATION               = 0x36, _AVR,       _Z | _F
-    ROOM_EQUALIZATION               = 0x37, _ROOM_EQ,   _Z | _F
-    DOLBY_AUDIO                     = 0x38, _AVR,       _Z | _F     # was "Dolby Volume" in 450/860 (SH256E/SH274E)
+    TREBLE_EQUALIZATION             = 0x35, _AVR,       _Z | _U
+    BASS_EQUALIZATION               = 0x36, _AVR,       _Z | _U
+    ROOM_EQUALIZATION               = 0x37, _ROOM_EQ,   _Z | _U
+    DOLBY_AUDIO                     = 0x38, _AVR,       _Z | _U     # was "Dolby Volume" in 450/860 (SH256E/SH274E)
     DOLBY_LEVELER                   = 0x39, _PRE_HDA,   _Z          # removed from HDA (SH289E issue C.0)
     DOLBY_VOLUME_CALIBRATION_OFFSET = 0x3A, _PRE_HDA,   _Z          # removed from HDA (SH289E issue C.0)
-    BALANCE                         = 0x3B, _AVR_SA,    _Z | _F
+    BALANCE                         = 0x3B, _AVR_SA,    _Z | _U
     DOLBY_PLII_X_MUSIC_DIMENSION    = 0x3C, _450
     DOLBY_PLII_X_MUSIC_CENTRE_WIDTH = 0x3D, _450
     DOLBY_PLII_X_MUSIC_PANORAMA     = 0x3E, _450
-    SUBWOOFER_TRIM                  = 0x3F, _AVR,       _Z | _F
-    LIPSYNC_DELAY                   = 0x40, _AVR,       _Z | _F
-    COMPRESSION                     = 0x41, _AVR,       _Z | _F
+    SUBWOOFER_TRIM                  = 0x3F, _AVR,       _Z | _U
+    LIPSYNC_DELAY                   = 0x40, _AVR,       _Z | _U
+    COMPRESSION                     = 0x41, _AVR,       _Z | _U
 
     # --- Incoming Signal / Video ---
-    INCOMING_VIDEO_PARAMETERS       = 0x42, _AVR,       _F
-    INCOMING_AUDIO_FORMAT           = 0x43, _AVR,       _F
-    INCOMING_AUDIO_SAMPLE_RATE      = 0x44, _AVR_SA_ST, _F
-    SUB_STEREO_TRIM                 = 0x45, _AVR,       _F
+    INCOMING_VIDEO_PARAMETERS       = 0x42, _AVR,       _U
+    INCOMING_AUDIO_FORMAT           = 0x43, _AVR,       _U
+    INCOMING_AUDIO_SAMPLE_RATE      = 0x44, _AVR_SA_ST, _U
+    SUB_STEREO_TRIM                 = 0x45, _AVR,       _U
     VIDEO_BRIGHTNESS                = 0x46, _450
     VIDEO_CONTRAST                  = 0x47, _450
     VIDEO_COLOUR                    = 0x48, _450
@@ -219,7 +209,7 @@ class CommandCodes(IntOrTypeEnum):
     VIDEO_MPEG_NOISE_REDUCTION      = 0x4D, _450
     ZONE_1_OSD_ON_OFF               = 0x4E, _AVR
     VIDEO_OUTPUT_SWITCHING          = 0x4F, _AVR
-    BLUETOOTH_STATUS                = 0x50, _HDA,       _P | _F     # was "Output Frame Rate" in 450 (SH256E)
+    BLUETOOTH_STATUS                = 0x50, _HDA,       _U | _NP     # was "Output Frame Rate" in 450 (SH256E)
 
     # --- Diagnostics / Amp Control ---
     DC_OFFSET                       = 0x51, _THERM
@@ -237,7 +227,7 @@ class CommandCodes(IntOrTypeEnum):
     SYSTEM_STATUS                   = 0x5D, _AMP_DIAG
     SYSTEM_MODEL                    = 0x5E, _AMP_DIAG
     DAC_FILTER                      = 0x61, _DAC_FILT                # clashes with AMPLIFIER_MODE on PA240
-    NOW_PLAYING_INFO                = 0x64, _NOW_PLAY,  _Z | _P | _F
+    NOW_PLAYING_INFO                = 0x64, _NOW_PLAY,  _Z | _U | _NP
     MAXIMUM_TURN_ON_VOLUME          = 0x65, _APP_SAFE
     MAXIMUM_VOLUME                  = 0x66, _APP_SAFE
     MAXIMUM_STREAMING_VOLUME        = 0x67, _APP_SAFE

--- a/src/arcam/fmj/console.py
+++ b/src/arcam/fmj/console.py
@@ -182,85 +182,83 @@ async def run_state(args):
         client = Client(args.host, args.port)
     else:
         client = ClientSerial(args.serial)
-    async with ClientContext(client):
-        state = State(client, args.zone)
-        async with state:
-            await state.update()
+    async with ClientContext(client), State(client, args.zone) as state:
+        await state.update()
 
-            pin = tuple(args.pin)
+        pin = tuple(args.pin)
 
-            if args.save_settings:
-                await state.save_settings(pin)
-                print("Settings saved.")
+        if args.save_settings:
+            await state.save_settings(pin)
+            print("Settings saved.")
 
-            if args.restore_settings:
-                await state.restore_settings(pin)
-                print("Settings restored.")
+        if args.restore_settings:
+            await state.restore_settings(pin)
+            print("Settings restored.")
 
-            if args.volume is not None:
-                await state.set_volume(args.volume)
+        if args.volume is not None:
+            await state.set_volume(args.volume)
 
-            if args.source is not None:
-                await state.set_source(args.source)
+        if args.source is not None:
+            await state.set_source(args.source)
 
-            if args.power_on is not None:
-                await state.set_power(True)
+        if args.power_on is not None:
+            await state.set_power(True)
 
-            if args.power_off is not None:
-                await state.set_power(False)
+        if args.power_off is not None:
+            await state.set_power(False)
 
-            if args.room_eq_on is not None:
-                await state.set_room_equalization(RoomEqMode.EQ1)
+        if args.room_eq_on is not None:
+            await state.set_room_equalization(RoomEqMode.EQ1)
 
-            if args.room_eq_off is not None:
-                await state.set_room_equalization(RoomEqMode.OFF)
+        if args.room_eq_off is not None:
+            await state.set_room_equalization(RoomEqMode.OFF)
 
-            if args.room_eq is not None:
-                await state.set_room_equalization(args.room_eq)
+        if args.room_eq is not None:
+            await state.set_room_equalization(args.room_eq)
 
-            if args.lipsync is not None:
-                await state.set_lipsync_delay(args.lipsync)
+        if args.lipsync is not None:
+            await state.set_lipsync_delay(args.lipsync)
 
-            if args.subwoofer_trim is not None:
-                await state.set_subwoofer_trim(args.subwoofer_trim)
+        if args.subwoofer_trim is not None:
+            await state.set_subwoofer_trim(args.subwoofer_trim)
 
-            if args.bass is not None:
-                await state.set_bass_equalization(args.bass)
+        if args.bass is not None:
+            await state.set_bass_equalization(args.bass)
 
-            if args.treble is not None:
-                await state.set_treble_equalization(args.treble)
+        if args.treble is not None:
+            await state.set_treble_equalization(args.treble)
 
-            if args.balance is not None:
-                await state.set_balance(args.balance)
+        if args.balance is not None:
+            await state.set_balance(args.balance)
 
-            if args.sub_stereo_trim is not None:
-                await state.set_sub_stereo_trim(args.sub_stereo_trim)
+        if args.sub_stereo_trim is not None:
+            await state.set_sub_stereo_trim(args.sub_stereo_trim)
 
-            if args.dolby_audio is not None:
-                await state.set_dolby_audio(args.dolby_audio)
+        if args.dolby_audio is not None:
+            await state.set_dolby_audio(args.dolby_audio)
 
-            if args.compression is not None:
-                await state.set_compression(args.compression)
+        if args.compression is not None:
+            await state.set_compression(args.compression)
 
-            if args.imax is not None:
-                await state.set_imax_enhanced(args.imax)
+        if args.imax is not None:
+            await state.set_imax_enhanced(args.imax)
 
-            if args.display_info is not None:
-                await state.set_display_info_type(args.display_info)
+        if args.display_info is not None:
+            await state.set_display_info_type(args.display_info)
 
-            if args.monitor:
-                updated = asyncio.Event()
-                prev = state.to_dict()
-                with client.listen(lambda _: updated.set()):
-                    while client.connected:
-                        await updated.wait()
-                        updated.clear()
-                        curr = state.to_dict()
-                        if prev != curr:
-                            pprint(curr)
-                            prev = curr
-            else:
-                pprint(state.to_dict())
+        if args.monitor:
+            updated = asyncio.Event()
+            prev = state.to_dict()
+            with client.listen(lambda _: updated.set()):
+                while client.connected:
+                    await updated.wait()
+                    updated.clear()
+                    curr = state.to_dict()
+                    if prev != curr:
+                        pprint(curr)
+                        prev = curr
+        else:
+            pprint(state.to_dict())
 
 
 async def run_server(args):

--- a/src/arcam/fmj/console.py
+++ b/src/arcam/fmj/console.py
@@ -184,72 +184,72 @@ async def run_state(args):
         client = ClientSerial(args.serial)
     async with ClientContext(client):
         state = State(client, args.zone)
-        await state.update()
+        async with state:
+            await state.update()
 
-        pin = tuple(args.pin)
+            pin = tuple(args.pin)
 
-        if args.save_settings:
-            await state.save_settings(pin)
-            print("Settings saved.")
+            if args.save_settings:
+                await state.save_settings(pin)
+                print("Settings saved.")
 
-        if args.restore_settings:
-            await state.restore_settings(pin)
-            print("Settings restored.")
+            if args.restore_settings:
+                await state.restore_settings(pin)
+                print("Settings restored.")
 
-        if args.volume is not None:
-            await state.set_volume(args.volume)
+            if args.volume is not None:
+                await state.set_volume(args.volume)
 
-        if args.source is not None:
-            await state.set_source(args.source)
+            if args.source is not None:
+                await state.set_source(args.source)
 
-        if args.power_on is not None:
-            await state.set_power(True)
+            if args.power_on is not None:
+                await state.set_power(True)
 
-        if args.power_off is not None:
-            await state.set_power(False)
+            if args.power_off is not None:
+                await state.set_power(False)
 
-        if args.room_eq_on is not None:
-            await state.set_room_equalization(RoomEqMode.EQ1)
+            if args.room_eq_on is not None:
+                await state.set_room_equalization(RoomEqMode.EQ1)
 
-        if args.room_eq_off is not None:
-            await state.set_room_equalization(RoomEqMode.OFF)
+            if args.room_eq_off is not None:
+                await state.set_room_equalization(RoomEqMode.OFF)
 
-        if args.room_eq is not None:
-            await state.set_room_equalization(args.room_eq)
+            if args.room_eq is not None:
+                await state.set_room_equalization(args.room_eq)
 
-        if args.lipsync is not None:
-            await state.set_lipsync_delay(args.lipsync)
+            if args.lipsync is not None:
+                await state.set_lipsync_delay(args.lipsync)
 
-        if args.subwoofer_trim is not None:
-            await state.set_subwoofer_trim(args.subwoofer_trim)
+            if args.subwoofer_trim is not None:
+                await state.set_subwoofer_trim(args.subwoofer_trim)
 
-        if args.bass is not None:
-            await state.set_bass_equalization(args.bass)
+            if args.bass is not None:
+                await state.set_bass_equalization(args.bass)
 
-        if args.treble is not None:
-            await state.set_treble_equalization(args.treble)
+            if args.treble is not None:
+                await state.set_treble_equalization(args.treble)
 
-        if args.balance is not None:
-            await state.set_balance(args.balance)
+            if args.balance is not None:
+                await state.set_balance(args.balance)
 
-        if args.sub_stereo_trim is not None:
-            await state.set_sub_stereo_trim(args.sub_stereo_trim)
+            if args.sub_stereo_trim is not None:
+                await state.set_sub_stereo_trim(args.sub_stereo_trim)
 
-        if args.dolby_audio is not None:
-            await state.set_dolby_audio(args.dolby_audio)
+            if args.dolby_audio is not None:
+                await state.set_dolby_audio(args.dolby_audio)
 
-        if args.compression is not None:
-            await state.set_compression(args.compression)
+            if args.compression is not None:
+                await state.set_compression(args.compression)
 
-        if args.imax is not None:
-            await state.set_imax_enhanced(args.imax)
+            if args.imax is not None:
+                await state.set_imax_enhanced(args.imax)
 
-        if args.display_info is not None:
-            await state.set_display_info_type(args.display_info)
+            if args.display_info is not None:
+                await state.set_display_info_type(args.display_info)
 
-        if args.monitor:
-            updated = asyncio.Event()
-            async with state:
+            if args.monitor:
+                updated = asyncio.Event()
                 prev = state.to_dict()
                 with client.listen(lambda _: updated.set()):
                     while client.connected:
@@ -259,8 +259,8 @@ async def run_state(args):
                         if prev != curr:
                             pprint(curr)
                             prev = curr
-        else:
-            pprint(state.to_dict())
+            else:
+                pprint(state.to_dict())
 
 
 async def run_server(args):

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -93,7 +93,7 @@ from .rc5 import (
     RC5CodeToggle,
 )
 from .client import Client, UpdateTask, _UPDATE_PRIORITY
-from .utils import run_tasks
+from .utils import run_tasks, wait_any
 
 _LOGGER = logging.getLogger(__name__)
 _T = TypeVar("_T")
@@ -908,4 +908,7 @@ class State:
 
     async def update(self) -> None:
         """Block until the provider-driven update loop completes one pass."""
-        await self._updated.wait()
+        # pylint: disable=protected-access
+        await wait_any(self._updated, self._client._disconnected)
+        if self._client._disconnected.is_set():
+            raise NotConnectedException()

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -92,7 +92,7 @@ from .rc5 import (
     RC5CodePlayback,
     RC5CodeToggle,
 )
-from .client import Client, _UPDATE_PRIORITY
+from .client import Client, UpdateTask, _UPDATE_PRIORITY
 from .utils import run_tasks
 
 _LOGGER = logging.getLogger(__name__)
@@ -764,7 +764,7 @@ class State:
             track = ""
         return status, track
 
-    async def get_update_tasks(self) -> list:
+    async def get_update_tasks(self) -> list[UpdateTask]:
         """Return a list of update coroutines for the current device state.
         """
         priority = _UPDATE_PRIORITY
@@ -878,7 +878,7 @@ class State:
         if self._amxduet is None:
             await _update_amxduet()
 
-        tasks: list = []
+        tasks: list[UpdateTask] = []
         for cc in CommandCodes:
             if not (cc.flags & CommandFlags.UPDATE):
                 continue

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -92,7 +92,8 @@ from .rc5 import (
     RC5CodePlayback,
     RC5CodeToggle,
 )
-from .client import Client
+from .client import Client, _UPDATE_PRIORITY
+from .utils import run_tasks
 
 _LOGGER = logging.getLogger(__name__)
 _T = TypeVar("_T")
@@ -136,14 +137,17 @@ class State:
         self._amxduet: AmxDuetResponse | None = None
         self._api_model = api_model
         self._unsupported_commands: set[CommandCodes] = set()
+        self._updated = asyncio.Event()
 
     async def start(self) -> None:
         # pylint: disable=protected-access
         self._client._listen.add(self._listen)
+        self._client.register_update_provider(self.get_update_tasks)
 
     async def stop(self) -> None:
         # pylint: disable=protected-access
         self._client._listen.remove(self._listen)
+        self._client.unregister_update_provider(self.get_update_tasks)
 
     async def __aenter__(self) -> "State":
         await self.start()
@@ -760,8 +764,10 @@ class State:
             track = ""
         return status, track
 
-    async def update(self, flags: CommandFlags = CommandFlags.FULL_UPDATE) -> None:
-        priority = flags.priority
+    async def get_update_tasks(self) -> list:
+        """Return a list of update coroutines for the current device state.
+        """
+        priority = _UPDATE_PRIORITY
 
         async def _update(cc: CommandCodes):
             try:
@@ -866,14 +872,15 @@ class State:
             if self._state:
                 self._state = dict()
                 self._now_playing = None
-            return
+            self._updated.clear()
+            return []
 
         if self._amxduet is None:
             await _update_amxduet()
 
         tasks: list = []
         for cc in CommandCodes:
-            if not (cc.flags & flags):
+            if not (cc.flags & CommandFlags.UPDATE):
                 continue
             if not self._is_command_supported(cc):
                 continue
@@ -883,5 +890,22 @@ class State:
                 tasks.append(_update_presets())
             else:
                 tasks.append(_update(cc))
-        if tasks:
-            await asyncio.gather(*tasks)
+
+        if not self._updated.is_set():
+            if not tasks:
+                self._updated.set()
+                return []
+
+            async def _run_and_signal():
+                try:
+                    await run_tasks(*tasks)
+                finally:
+                    self._updated.set()
+
+            return [_run_and_signal()]
+
+        return tasks
+
+    async def update(self) -> None:
+        """Block until the provider-driven update loop completes one pass."""
+        await self._updated.wait()

--- a/src/arcam/fmj/utils.py
+++ b/src/arcam/fmj/utils.py
@@ -21,6 +21,18 @@ async def run_tasks(*tasks: Coroutine) -> None:
         raise copy(exc.exceptions[0]).with_traceback(exc.exceptions[0].__traceback__)
 
 
+async def cancel_and_wait(task: asyncio.Task[Any]) -> None:
+    """Cancel a task and await it, re-raising only a cancellation of the calling task.
+    """
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        current = asyncio.current_task()
+        if current is not None and current.cancelling() > 0:
+            raise
+
+
 def async_retry(attempts=2, allowed_exceptions=()):
     def decorator(f):
         @functools.wraps(f)

--- a/src/arcam/fmj/utils.py
+++ b/src/arcam/fmj/utils.py
@@ -33,6 +33,19 @@ async def cancel_and_wait(task: asyncio.Task[Any]) -> None:
             raise
 
 
+async def wait_any(*events: asyncio.Event) -> None:
+    """Wait until at least one of the events is set."""
+    if any(event.is_set() for event in events):
+        return
+    waits = [asyncio.create_task(event.wait()) for event in events]
+    try:
+        await asyncio.wait(waits, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        for wait in waits:
+            wait.cancel()
+        await asyncio.wait(waits)
+
+
 def async_retry(attempts=2, allowed_exceptions=()):
     def decorator(f):
         @functools.wraps(f)

--- a/src/arcam/fmj/utils.py
+++ b/src/arcam/fmj/utils.py
@@ -1,4 +1,7 @@
+import asyncio
 import aiohttp
+from collections.abc import Coroutine
+from copy import copy
 import functools
 import logging
 import re
@@ -6,6 +9,16 @@ from defusedxml import ElementTree
 from typing import Optional, Any
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def run_tasks(*tasks: Coroutine) -> None:
+    """Run coroutines in a TaskGroup, unwrapping BaseExceptionGroup on failure."""
+    try:
+        async with asyncio.TaskGroup() as group:
+            for task in tasks:
+                group.create_task(task)
+    except BaseExceptionGroup as exc:
+        raise copy(exc.exceptions[0]).with_traceback(exc.exceptions[0].__traceback__)
 
 
 def async_retry(attempts=2, allowed_exceptions=()):

--- a/src/arcam/fmj/utils.py
+++ b/src/arcam/fmj/utils.py
@@ -31,6 +31,8 @@ async def cancel_and_wait(task: asyncio.Task[Any]) -> None:
         current = asyncio.current_task()
         if current is not None and current.cancelling() > 0:
             raise
+    except Exception:
+        _LOGGER.exception("Error from task %r", task)
 
 
 async def wait_any(*events: asyncio.Event) -> None:

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -10,6 +10,7 @@ from arcam.fmj.commands import CommandCodes
 from arcam.fmj.errors import (
     CommandNotRecognised,
     ConnectionFailed,
+    NotConnectedException,
     UnsupportedZone,
 )
 from arcam.fmj.client import Client, ClientContext
@@ -171,3 +172,65 @@ async def test_cancellation(silent_server):
 
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+async def test_update_raises_when_never_connected():
+    state = State(Client("localhost", 8888), 0x01)
+    with pytest.raises(NotConnectedException):
+        await state.update()
+
+
+async def test_update_raises_when_connection_drops(server):
+    """A disconnect while update() is waiting must raise rather than hang."""
+    c = Client("localhost", 8888)
+    await c.start()
+    state = State(c, 0x01)
+
+    update_task = asyncio.create_task(state.update())
+    await asyncio.sleep(0.05)
+    assert not update_task.done()
+
+    await c.stop()
+    with pytest.raises(NotConnectedException):
+        async with asyncio.timeout(2):
+            await update_task
+
+
+async def test_update_raises_when_server_goes_silent(speedy_client, silent_server):
+    """A process() teardown (missed pings) must wake a blocked update() with an error."""
+    c = Client("localhost", 8888)
+    await c.start()
+    state = State(c, 0x01)
+    await state.start()
+    try:
+        process_task = asyncio.create_task(c.process())
+        try:
+            with pytest.raises(NotConnectedException):
+                async with asyncio.timeout(5):
+                    await state.update()
+        finally:
+            with pytest.raises(ConnectionFailed):
+                await process_task
+    finally:
+        await state.stop()
+        await c.stop()
+
+
+async def test_update_returns_after_loop_pass(server):
+    """update() returns once the provider-driven loop completes a pass."""
+    c = Client("localhost", 8888)
+    state = State(c, 0x01)
+    await c.start()
+    await state.start()
+    try:
+        process_task = asyncio.create_task(c.process())
+        try:
+            async with asyncio.timeout(5):
+                await state.update()
+            assert state.get_power() is False
+            assert state.get_volume() == 0x01
+        finally:
+            await cancel_and_wait(process_task)
+    finally:
+        await state.stop()
+        await c.stop()

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -103,11 +103,9 @@ async def test_silent_server_disconnect(speedy_client, silent_server):
     from arcam.fmj.client import _HEARTBEAT_TIMEOUT
 
     c = Client("localhost", 8888)
-    connected = True
-    with pytest.raises(ConnectionFailed):
-        async with ClientContext(c):
-            await asyncio.sleep(_HEARTBEAT_TIMEOUT.total_seconds() + 0.5)
-            connected = c.connected
+    async with ClientContext(c):
+        await asyncio.sleep(_HEARTBEAT_TIMEOUT.total_seconds() + 0.5)
+        connected = c.connected
     assert not connected
 
 

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -1,11 +1,10 @@
 """Test with a fake server"""
 
 import asyncio
+import contextlib
 import logging
-import unittest
 import pytest
 from datetime import timedelta
-from unittest.mock import ANY
 
 from arcam.fmj.commands import CommandCodes
 from arcam.fmj.errors import (
@@ -84,7 +83,7 @@ async def test_invalid_command(server, client):
 
 async def test_state(server, client):
     state = State(client, 0x01)
-    await state.update()
+    await asyncio.gather(*await state.get_update_tasks())
     assert state.get(CommandCodes.POWER) == bytes([0x00])
     assert state.get(CommandCodes.VOLUME) == bytes([0x01])
 
@@ -111,14 +110,50 @@ async def test_silent_server_disconnect(speedy_client, silent_server):
     assert not connected
 
 
-async def test_heartbeat(speedy_client, server, client):
-    from arcam.fmj.client import _HEARTBEAT_INTERVAL
+async def test_process_runs_update_providers(server):
+    """When a State is started before process(), the client's update loop
+    drives it via get_update_tasks() until state is populated."""
+    c = Client("localhost", 8888)
+    state = State(c, 0x01)
 
-    with unittest.mock.patch.object(
-        server, "process_request", wraps=server.process_request
-    ) as req:
-        await asyncio.sleep(_HEARTBEAT_INTERVAL.total_seconds() + 0.5)
-        req.assert_called_once_with(ANY)
+    await c.start()
+    await state.start()
+    try:
+        process_task = asyncio.create_task(c.process())
+        try:
+            async with asyncio.timeout(5):
+                while state.get_power() is None or state.get_volume() is None:
+                    await asyncio.sleep(0.05)
+            assert state.get_power() is False  # bytes([0x00]) → False
+            assert state.get_volume() == 0x01
+        finally:
+            process_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await process_task
+    finally:
+        await state.stop()
+        await c.stop()
+
+
+async def test_heartbeat_keeps_connection_alive(speedy_client, server):
+    """With no providers registered, _process_updates falls back to
+    sleeping — the heartbeat task keeps the connection alive past
+    _RECEIVE_TIMEOUT."""
+    from arcam.fmj.client import _HEARTBEAT_TIMEOUT
+
+    c = Client("localhost", 8888)
+    await c.start()
+    try:
+        process_task = asyncio.create_task(c.process())
+        try:
+            await asyncio.sleep(_HEARTBEAT_TIMEOUT.total_seconds() + 0.5)
+            assert c.connected
+        finally:
+            process_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await process_task
+    finally:
+        await c.stop()
 
 
 async def test_cancellation(silent_server):

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -175,3 +175,39 @@ async def test_cancellation(silent_server):
 
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+async def test_cancellation_unblocks_pending_requests(silent_server):
+    """Cancelling the process loop must wake pending request awaiters with
+    CancelledError, not NotConnectedException, so the cancel isn't masked
+    when it propagates through enclosing task groups during shutdown.
+
+    Exercises both shutdown paths: the request popped into ``_write_and_wait``
+    (inner finally) and the request still sitting in the priority queue
+    (outer drain).
+    """
+    c = Client("localhost", 8888)
+    await c.start()
+    try:
+        process_task = asyncio.create_task(c.process())
+
+        in_flight = asyncio.create_task(
+            c.request(1, CommandCodes.POWER, bytes([0xF0]))
+        )
+        queued = asyncio.create_task(
+            c.request(1, CommandCodes.VOLUME, bytes([0xF0]))
+        )
+        # Yield long enough for the send loop to pop in_flight; queued
+        # stays in the priority queue behind it.
+        await asyncio.sleep(0.05)
+
+        process_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await in_flight
+        with pytest.raises(asyncio.CancelledError):
+            await queued
+        with pytest.raises(asyncio.CancelledError):
+            await process_task
+    finally:
+        await c.stop()

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -175,39 +175,3 @@ async def test_cancellation(silent_server):
 
     with pytest.raises(asyncio.CancelledError):
         await task
-
-
-async def test_cancellation_unblocks_pending_requests(silent_server):
-    """Cancelling the process loop must wake pending request awaiters with
-    CancelledError, not NotConnectedException, so the cancel isn't masked
-    when it propagates through enclosing task groups during shutdown.
-
-    Exercises both shutdown paths: the request popped into ``_write_and_wait``
-    (inner finally) and the request still sitting in the priority queue
-    (outer drain).
-    """
-    c = Client("localhost", 8888)
-    await c.start()
-    try:
-        process_task = asyncio.create_task(c.process())
-
-        in_flight = asyncio.create_task(
-            c.request(1, CommandCodes.POWER, bytes([0xF0]))
-        )
-        queued = asyncio.create_task(
-            c.request(1, CommandCodes.VOLUME, bytes([0xF0]))
-        )
-        # Yield long enough for the send loop to pop in_flight; queued
-        # stays in the priority queue behind it.
-        await asyncio.sleep(0.05)
-
-        process_task.cancel()
-
-        with pytest.raises(asyncio.CancelledError):
-            await in_flight
-        with pytest.raises(asyncio.CancelledError):
-            await queued
-        with pytest.raises(asyncio.CancelledError):
-            await process_task
-    finally:
-        await c.stop()

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -1,11 +1,11 @@
 """Test with a fake server"""
 
 import asyncio
-import contextlib
 import logging
 import pytest
 from datetime import timedelta
 
+from arcam.fmj.utils import cancel_and_wait
 from arcam.fmj.commands import CommandCodes
 from arcam.fmj.errors import (
     CommandNotRecognised,
@@ -127,9 +127,7 @@ async def test_process_runs_update_providers(server):
             assert state.get_power() is False  # bytes([0x00]) → False
             assert state.get_volume() == 0x01
         finally:
-            process_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await process_task
+            await cancel_and_wait(process_task)
     finally:
         await state.stop()
         await c.stop()
@@ -149,9 +147,7 @@ async def test_heartbeat_keeps_connection_alive(speedy_client, server):
             await asyncio.sleep(_HEARTBEAT_TIMEOUT.total_seconds() + 0.5)
             assert c.connected
         finally:
-            process_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await process_task
+            await cancel_and_wait(process_task)
     finally:
         await c.stop()
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from unittest.mock import MagicMock
 from arcam.fmj.client import Client
@@ -1054,7 +1055,7 @@ async def test_update_skips_unsupported_commands():
     state = State(client, 1, ApiModel.APISA_SERIES)
     state._amxduet = AmxDuetResponse({"Device-Model": "SA30"})
 
-    await state.update()
+    await asyncio.gather(*await state.get_update_tasks())
     requested_commands = [call.args[1] for call in client.request.call_args_list]
     # These commands have version restrictions that exclude SA30
     assert CommandCodes.IMAX_ENHANCED not in requested_commands
@@ -1075,7 +1076,7 @@ async def test_update_records_command_not_recognised():
     state._amxduet = AmxDuetResponse({"Device-Model": "AVR450"})
 
     assert CommandCodes.MENU not in state._unsupported_commands
-    await state.update()
+    await asyncio.gather(*await state.get_update_tasks())
     assert CommandCodes.MENU in state._unsupported_commands
 
 


### PR DESCRIPTION
Adding to the send, receive, and heartbeat tasks in ClientBase, we now also have an update task. It loops, polling registered callbacks (States) asking for updates it should run, and runs them. This is used for the initial update pass, as well as subsequent polling loops. The client gets all updates, including those that require polling, without having to run a polling loop of their own. Any unhandled exceptions from the update loop are propagated outward through the TaskGroup in process(), exactly the same as our other tasks there.

Again, the heartbeat task is still there. By sending with priority lower than updates, it will block forever if we have a constant stream of updates, but that's exactly what we want.

Note this is built on https://github.com/elupus/arcam_fmj/pull/96 (and so on.)