### PR TITLE
feat: Data-driven Implementation

### DIFF
--- a/src/arcam/fmj/__init__.py
+++ b/src/arcam/fmj/__init__.py
@@ -5,6 +5,6 @@ Public submodules:
 - :mod:`arcam.fmj.errors` — Exception classes
 - :mod:`arcam.fmj.codecs` — Codec enums and dataclasses (SourceCodes, DecodeMode*, etc.)
 - :mod:`arcam.fmj.rc5` — RC5 control-code tables and parameter enums
-- :mod:`arcam.fmj.commands` — CommandCodes enum (the command catalogue)
+- :mod:`arcam.fmj.commands` — the command catalogue (typed Command constants)
 - :mod:`arcam.fmj.packets` — Wire-protocol packet types and async serialization helpers
 """

--- a/src/arcam/fmj/client.py
+++ b/src/arcam/fmj/client.py
@@ -12,7 +12,7 @@ from typing import Any, overload
 from serialx import open_serial_connection
 
 from .codecs import AnswerCodes
-from .commands import CommandCodes, CommandFlags
+from .commands import POWER, CommandFlags, command_for
 from .errors import (
     ArcamException,
     ConnectionFailed,
@@ -140,11 +140,13 @@ class ClientBase:
         self._queue.put_nowait(_QueueItem(priority, self._seq, request, future))
         return await future
 
-    async def request(self, zn: int, cc: CommandCodes, data: bytes, priority: int = _USER_PRIORITY):
+    async def request(self, zn: int, cc: int, data: bytes, priority: int = _USER_PRIORITY):
         if self._queue is None:
             raise NotConnectedException()
 
-        if not (cc.flags & CommandFlags.ZONE_SUPPORT) and zn != 1:
+        command = command_for(cc)
+        flags = command.flags if command is not None else CommandFlags(0)
+        if not (flags & CommandFlags.ZONE_SUPPORT) and zn != 1:
             raise UnsupportedZone()
 
         response = await self.request_raw(CommandPacket(zn, cc, data), priority)
@@ -237,7 +239,7 @@ class ClientBase:
             await asyncio.sleep(_HEARTBEAT_INTERVAL.total_seconds())
             _LOGGER.debug("Sending heartbeat ping")
             try:
-                await self.request(1, CommandCodes.POWER, bytes([0xF0]), _HEARTBEAT_PRIORITY)
+                await self.request(1, POWER.cc, bytes([0xF0]), _HEARTBEAT_PRIORITY)
             except (ArcamException, TimeoutError):
                 _LOGGER.debug("Heartbeat ping timed out")
 

--- a/src/arcam/fmj/codecs.py
+++ b/src/arcam/fmj/codecs.py
@@ -7,7 +7,9 @@ individual docstrings for the mapping. Definitions are ordered by CC.
 from __future__ import annotations
 
 import enum
-from typing import Any, Union
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar, Union
 
 import attr
 
@@ -20,6 +22,128 @@ from .models import (
     ApiModel,
     IntOrTypeEnum,
 )
+
+# === Codecs ===
+# Codec[T] maps a command's data payload to/from a typed value; commands.py
+# attaches one to each Command and State.get/set delegate to decode/encode.
+# decode may return None for sentinel or out-of-range bytes. The generic codecs
+# live here; command-specific ones live with their CC below.
+
+_T = TypeVar("_T")
+_E = TypeVar("_E", bound=IntOrTypeEnum)
+
+
+def _get_scaled_negative(
+    data: bytes | None, min_value: float, max_value: float, scale: float
+) -> float | None:
+    if data is None:
+        return None
+    neg_limit = round(-min_value / scale) + 0x80
+    pos_limit = round(max_value / scale)
+    byte_val = int.from_bytes(data, "big")
+    if 0x81 <= byte_val <= neg_limit:
+        return -(byte_val - 0x80) * scale
+    if 0x00 <= byte_val <= pos_limit:
+        return byte_val * scale
+    return None
+
+
+def _set_scaled(value: float, min_value: float, max_value: float, scale: float) -> int:
+    value = max(min_value, min(max_value, value))
+    iv = round(value / scale)
+    return iv if iv >= 0 else 0x80 - iv
+
+
+class Codec(Generic[_T]):
+    """Maps a command payload to/from a typed value."""
+
+    def decode(self, data: bytes) -> _T | None:
+        raise NotImplementedError
+
+    def encode(self, value: _T) -> bytes:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class BoolCodec(Codec[bool]):
+    """1 byte ↔ bool. inverted=True flips the mapping (MUTE)."""
+
+    inverted: bool = False
+
+    def decode(self, data: bytes) -> bool:
+        v = int.from_bytes(data, "big")
+        return v == 0x00 if self.inverted else v == 0x01
+
+    def encode(self, value: bool) -> bytes:
+        if self.inverted:
+            return bytes([0x00 if value else 0x01])
+        return bytes([0x01 if value else 0x00])
+
+
+class IntCodec(Codec[int]):
+    """1 byte ↔ int."""
+
+    def decode(self, data: bytes) -> int:
+        return int.from_bytes(data, "big")
+
+    def encode(self, value: int) -> bytes:
+        return bytes([value])
+
+
+@dataclass(frozen=True)
+class EnumCodec(Codec[_E]):
+    """1 byte ↔ IntOrTypeEnum via from_bytes / value. set_map supplies the
+    asymmetric write codes for IMAX_ENHANCED and ZONE_1_OSD_ON_OFF."""
+
+    enum_cls: type[_E]
+    set_map: dict[_E, int] | None = None
+
+    def decode(self, data: bytes) -> _E:
+        return self.enum_cls.from_bytes(data)
+
+    def encode(self, value: _E) -> bytes:
+        if self.set_map is not None:
+            return bytes([self.set_map[value]])
+        return bytes([int(value)])
+
+
+@dataclass(frozen=True)
+class ScaledCodec(Codec[float]):
+    """Negative-biased scaled float; out-of-range bytes decode to None."""
+
+    min_value: float
+    max_value: float
+    scale: float
+
+    def decode(self, data: bytes) -> float | None:
+        return _get_scaled_negative(data, self.min_value, self.max_value, self.scale)
+
+    def encode(self, value: float) -> bytes:
+        return bytes([_set_scaled(value, self.min_value, self.max_value, self.scale)])
+
+
+@dataclass(frozen=True)
+class StringCodec(Codec[str]):
+    """N bytes ↔ str, decoded with errors='replace' and trailing whitespace stripped."""
+
+    encoding: str = "utf-8"
+
+    def decode(self, data: bytes) -> str:
+        return data.decode(self.encoding, errors="replace").rstrip()
+
+    def encode(self, value: str) -> bytes:
+        return value.encode(self.encoding)
+
+
+@dataclass(frozen=True)
+class StructCodec(Codec[_T]):
+    """Multi-byte struct via a from_bytes callable (read-only)."""
+
+    parse: Callable[[bytes], _T]
+
+    def decode(self, data: bytes) -> _T:
+        return self.parse(data)
+
 
 # --- AC byte (all responses) ---
 
@@ -191,6 +315,19 @@ class MenuCodes(IntOrTypeEnum):
     TUNER = 0x08
     NETWORK = 0x09
     USB = 0x0A
+
+# --- CC 0x15: TUNER_PRESET ---
+
+class TunerPresetCodec(Codec[int]):
+    """1 byte ↔ preset number; 0xff (no preset selected) decodes to None."""
+
+    def decode(self, data: bytes) -> int | None:
+        if data == b"\xff":
+            return None
+        return int.from_bytes(data, "big")
+
+    def encode(self, value: int) -> bytes:
+        return bytes([value])
 
 # --- CC 0x1B: PRESET_DETAIL ---
 
@@ -401,6 +538,17 @@ SOURCE_CODES: dict[tuple[ApiModel, int], dict[SourceCodes, bytes]] = {
     (ApiModel.APISA_SERIES, 2): SA_SOURCE_MAPPING,
     (ApiModel.APIST_SERIES, 1): ST_SOURCE_MAPPING,
 }
+
+# --- CC 0x34: ROOM_EQ_NAMES ---
+
+class RoomEqNamesCodec(Codec[list[str]]):
+    """Concatenated 20-byte ASCII records → list of names (read-only)."""
+
+    def decode(self, data: bytes) -> list[str]:
+        return [
+            data[i:i + 20].decode("ascii", errors="replace").rstrip("\x00").strip()
+            for i in range(0, len(data), 20)
+        ]
 
 # --- CC 0x37: ROOM_EQUALIZATION ---
 
@@ -643,6 +791,58 @@ SAMPLE_RATE_MAP: dict[int, int | None] = {
     0x08: None,  # Undetected
 }
 
+class SampleRateCodec(Codec[int]):
+    """1 byte → sample rate in Hz via SAMPLE_RATE_MAP (read-only)."""
+
+    def decode(self, data: bytes) -> int | None:
+        return SAMPLE_RATE_MAP.get(data[0], 0)
+
+# --- CC 0x49: VIDEO_FILM_MODE ---
+
+class VideoFilmMode(IntOrTypeEnum):
+    """Video film-mode detection setting.
+
+    Used by VIDEO_FILM_MODE (0x49).
+
+    See: SH256E "Set/Request Film Mode (0x49)".
+    """
+
+    AUTO = 0x00
+    OFF = 0x01
+
+# --- CC 0x4C/0x4D: VIDEO_NOISE_REDUCTION / VIDEO_MPEG_NOISE_REDUCTION ---
+
+class VideoNoiseReduction(IntOrTypeEnum):
+    """Video noise reduction level.
+
+    Shared by VIDEO_NOISE_REDUCTION (0x4C) and VIDEO_MPEG_NOISE_REDUCTION (0x4D).
+
+    See: SH256E "Set/Request Noise Reduction (0x4C)",
+         "Set/Request MPEG Noise Reduction (0x4D)".
+    """
+
+    OFF = 0x00
+    LOW = 0x01
+    MEDIUM = 0x02
+    HIGH = 0x03
+
+# --- CC 0x4E: ZONE_1_OSD_ON_OFF ---
+
+class ZoneOsd(IntOrTypeEnum):
+    """Zone 1 on-screen display state.
+
+    Used by ZONE_1_OSD_ON_OFF (0x4E). Response uses 0x00/0x01; Set uses
+    0xF1/0xF2 (via set_map on the ByteEnum schema).
+
+    See: SH256E "Set/Request Zone 1 OSD on/off (0x4E)".
+    """
+
+    ON = 0x00
+    OFF = 0x01
+
+#: Asymmetric set codes for ZONE_1_OSD_ON_OFF — the set form uses 0xF1/0xF2.
+ZONE_OSD_SET_MAP = {ZoneOsd.ON: 0xF1, ZoneOsd.OFF: 0xF2}
+
 # --- CC 0x4F: VIDEO_OUTPUT_SWITCHING ---
 
 class HdmiOutput(IntOrTypeEnum):
@@ -658,6 +858,64 @@ class HdmiOutput(IntOrTypeEnum):
     OUT_1_2 = 0x04
 
 # --- CC 0x50: BLUETOOTH_STATUS ---
+
+# --- CC 0x58: AUTO_SHUTDOWN_CONTROL ---
+
+class AutoShutdown(IntOrTypeEnum):
+    """Auto-shutdown timer setting.
+
+    Used by AUTO_SHUTDOWN_CONTROL (0x58).
+
+    See: SH277E "Auto shutdown control (0x58)".
+    """
+
+    DISABLED = 0x00
+    MINUTES_30 = 0x01
+    HOUR_1 = 0x02
+    HOURS_2 = 0x03
+    HOURS_4 = 0x04
+
+# --- CC 0x5B: PROCESSOR_MODE_INPUT ---
+
+class SaProcessorModeCodec(Codec["SourceCodes | None"]):
+    """1 byte ↔ SourceCodes | None; 0x00 → None (disabled), other bytes via the
+    SA-series source encoding (zone 1).
+
+    See: SH306E / SH320E "Processor mode input (0x5B)".
+    """
+
+    def decode(self, data: bytes) -> SourceCodes | None:
+        if int.from_bytes(data, "big") == 0x00:
+            return None
+        try:
+            return SourceCodes.from_bytes(data, ApiModel.APISA_SERIES, 1)
+        except ValueError:
+            return None
+
+    def encode(self, value: SourceCodes | None) -> bytes:
+        if value is None:
+            return bytes([0x00])
+        return value.to_bytes(ApiModel.APISA_SERIES, 1)
+
+# --- CC 0x61: DAC_FILTER ---
+
+class DacFilter(IntOrTypeEnum):
+    """DAC digital filter type.
+
+    Used by DAC_FILTER (0x61). SA20 supports all seven; SA10 supports
+    only the first three.
+
+    See: SH277E "DAC Filter (0x61)".
+    """
+
+    LINEAR_FAST = 0x00
+    LINEAR_SLOW = 0x01
+    MINIMUM_FAST = 0x02
+    MINIMUM_SLOW = 0x03
+    BRICK_WALL = 0x04
+    CORRECTED_FAST = 0x05
+    APODIZING = 0x06
+
 
 class BluetoothAudioStatus(IntOrTypeEnum):
     """Bluetooth connection and codec status.

--- a/src/arcam/fmj/codecs.py
+++ b/src/arcam/fmj/codecs.py
@@ -7,7 +7,9 @@ individual docstrings for the mapping. Definitions are ordered by CC.
 from __future__ import annotations
 
 import enum
-from typing import Any, Union
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar, Union
 
 import attr
 
@@ -20,6 +22,155 @@ from .models import (
     ApiModel,
     IntOrTypeEnum,
 )
+
+# === Codecs ===
+# Codec[T] maps a command's data payload to/from a typed value; commands.py
+# attaches one to each Command and State.get/set delegate to decode/encode.
+# decode may return None for sentinel or out-of-range bytes. The generic codecs
+# live here; command-specific ones live with their CC below.
+
+_T = TypeVar("_T")
+_E = TypeVar("_E", bound=IntOrTypeEnum)
+
+
+def _get_scaled_negative(
+    data: bytes | None, min_value: float, max_value: float, scale: float
+) -> float | None:
+    if data is None or len(data) != 1:
+        return None
+    neg_limit = round(-min_value / scale) + 0x80
+    pos_limit = round(max_value / scale)
+    byte_val = data[0]
+    if 0x81 <= byte_val <= neg_limit:
+        return -(byte_val - 0x80) * scale
+    if 0x00 <= byte_val <= pos_limit:
+        return byte_val * scale
+    return None
+
+
+def _set_scaled(value: float, min_value: float, max_value: float, scale: float) -> int:
+    value = max(min_value, min(max_value, value))
+    iv = round(value / scale)
+    return iv if iv >= 0 else 0x80 - iv
+
+
+class Codec(Generic[_T]):
+    """Maps a command payload to/from a typed value."""
+
+    def decode(self, data: bytes) -> _T | None:
+        raise NotImplementedError
+
+    def encode(self, value: _T) -> bytes:
+        raise NotImplementedError
+
+    def decode_for_model(self, data: bytes, model: str | None) -> _T | None:
+        return self.decode(data)
+
+    def decode_for_context(
+        self, data: bytes, model: str | None, source: SourceCodes | None
+    ) -> _T | None:
+        return self.decode_for_model(data, model)
+
+    def encode_for_model(self, value: _T, model: str | None) -> bytes:
+        return self.encode(value)
+
+
+@dataclass(frozen=True)
+class BoolCodec(Codec[bool]):
+    """1 byte ↔ bool. inverted=True flips the mapping (MUTE)."""
+
+    inverted: bool = False
+
+    def decode(self, data: bytes) -> bool | None:
+        if len(data) != 1:
+            return None
+        v = data[0]
+        return v == 0x00 if self.inverted else v == 0x01
+
+    def encode(self, value: bool) -> bytes:
+        if self.inverted:
+            return bytes([0x00 if value else 0x01])
+        return bytes([0x01 if value else 0x00])
+
+
+class IntCodec(Codec[int]):
+    """1 byte ↔ int."""
+
+    def decode(self, data: bytes) -> int | None:
+        if len(data) != 1:
+            return None
+        return data[0]
+
+    def encode(self, value: int) -> bytes:
+        return bytes([value])
+
+
+@dataclass(frozen=True)
+class EnumCodec(Codec[_E]):
+    """1 byte ↔ IntOrTypeEnum via from_bytes / value. set_map supplies the
+    asymmetric write codes for IMAX_ENHANCED and ZONE_1_OSD_ON_OFF."""
+
+    enum_cls: type[_E]
+    set_map: dict[_E, int] | None = None
+
+    def decode(self, data: bytes) -> _E | None:
+        if len(data) != 1:
+            return None
+        return self.enum_cls.from_bytes(data)
+
+    def encode(self, value: _E) -> bytes:
+        if self.set_map is not None:
+            return bytes([self.set_map[value]])
+        return bytes([int(value)])
+
+    def decode_for_model(self, data: bytes, model: str | None) -> _E | None:
+        if len(data) != 1:
+            return None
+        return self.enum_cls.from_bytes_for_model(data, model)
+
+    def encode_for_model(self, value: _E, model: str | None) -> bytes:
+        if self.set_map is not None:
+            return self.encode(value)
+        return value.to_bytes_for_model(model)
+
+
+@dataclass(frozen=True)
+class ScaledCodec(Codec[float]):
+    """Negative-biased scaled float; out-of-range bytes decode to None."""
+
+    min_value: float
+    max_value: float
+    scale: float
+
+    def decode(self, data: bytes) -> float | None:
+        return _get_scaled_negative(data, self.min_value, self.max_value, self.scale)
+
+    def encode(self, value: float) -> bytes:
+        return bytes([_set_scaled(value, self.min_value, self.max_value, self.scale)])
+
+
+@dataclass(frozen=True)
+class StringCodec(Codec[str]):
+    """N bytes ↔ str, decoded with errors='replace' and trailing whitespace stripped."""
+
+    encoding: str = "utf-8"
+
+    def decode(self, data: bytes) -> str:
+        return data.decode(self.encoding, errors="replace").rstrip()
+
+    def encode(self, value: str) -> bytes:
+        return value.encode(self.encoding)
+
+
+@dataclass(frozen=True)
+class StructCodec(Codec[_T]):
+    """Multi-byte struct via a from_bytes callable (read-only)."""
+
+    parse: Callable[[bytes], _T]
+
+    def decode(self, data: bytes) -> _T:
+        return self.parse(data)
+
 
 # --- AC byte (all responses) ---
 
@@ -191,6 +342,21 @@ class MenuCodes(IntOrTypeEnum):
     TUNER = 0x08
     NETWORK = 0x09
     USB = 0x0A
+
+# --- CC 0x15: TUNER_PRESET ---
+
+class TunerPresetCodec(Codec[int]):
+    """1 byte ↔ preset number; 0xff (no preset selected) decodes to None."""
+
+    def decode(self, data: bytes) -> int | None:
+        if len(data) != 1:
+            return None
+        if data == b"\xff":
+            return None
+        return data[0]
+
+    def encode(self, value: int) -> bytes:
+        return bytes([value])
 
 # --- CC 0x1B: PRESET_DETAIL ---
 
@@ -407,6 +573,17 @@ SOURCE_CODES: dict[tuple[ApiModel, int], dict[SourceCodes, bytes]] = {
     (ApiModel.APISA_SERIES, 2): SA_SOURCE_MAPPING,
     (ApiModel.APIST_SERIES, 1): ST_SOURCE_MAPPING,
 }
+
+# --- CC 0x34: ROOM_EQ_NAMES ---
+
+class RoomEqNamesCodec(Codec[list[str]]):
+    """Concatenated 20-byte ASCII records → list of names (read-only)."""
+
+    def decode(self, data: bytes) -> list[str]:
+        return [
+            data[i:i + 20].decode("ascii", errors="replace").rstrip("\x00").strip()
+            for i in range(0, len(data), 20)
+        ]
 
 # --- CC 0x37: ROOM_EQUALIZATION ---
 
@@ -651,6 +828,60 @@ SAMPLE_RATE_MAP: dict[int, int | None] = {
     0x08: None,  # Undetected
 }
 
+class SampleRateCodec(Codec[int]):
+    """1 byte → sample rate in Hz via SAMPLE_RATE_MAP (read-only)."""
+
+    def decode(self, data: bytes) -> int | None:
+        if len(data) != 1:
+            return None
+        return SAMPLE_RATE_MAP.get(data[0], 0)
+
+# --- CC 0x49: VIDEO_FILM_MODE ---
+
+class VideoFilmMode(IntOrTypeEnum):
+    """Video film-mode detection setting.
+
+    Used by VIDEO_FILM_MODE (0x49).
+
+    See: SH256E "Set/Request Film Mode (0x49)".
+    """
+
+    AUTO = 0x00
+    OFF = 0x01
+
+# --- CC 0x4C/0x4D: VIDEO_NOISE_REDUCTION / VIDEO_MPEG_NOISE_REDUCTION ---
+
+class VideoNoiseReduction(IntOrTypeEnum):
+    """Video noise reduction level.
+
+    Shared by VIDEO_NOISE_REDUCTION (0x4C) and VIDEO_MPEG_NOISE_REDUCTION (0x4D).
+
+    See: SH256E "Set/Request Noise Reduction (0x4C)",
+         "Set/Request MPEG Noise Reduction (0x4D)".
+    """
+
+    OFF = 0x00
+    LOW = 0x01
+    MEDIUM = 0x02
+    HIGH = 0x03
+
+# --- CC 0x4E: ZONE_1_OSD_ON_OFF ---
+
+class ZoneOsd(IntOrTypeEnum):
+    """Zone 1 on-screen display state.
+
+    Used by ZONE_1_OSD_ON_OFF (0x4E). Response uses 0x00/0x01; Set uses
+    0xF1/0xF2 (via set_map on the ByteEnum schema).
+
+    See: SH256E "Set/Request Zone 1 OSD on/off (0x4E)".
+    """
+
+    ON = 0x00
+    OFF = 0x01
+
+#: Asymmetric set codes for ZONE_1_OSD_ON_OFF — the set form uses 0xF1/0xF2.
+ZONE_OSD_SET_MAP = {ZoneOsd.ON: 0xF1, ZoneOsd.OFF: 0xF2}
+
 # --- CC 0x4F: VIDEO_OUTPUT_SWITCHING ---
 
 class HdmiOutput(IntOrTypeEnum):
@@ -666,6 +897,118 @@ class HdmiOutput(IntOrTypeEnum):
     OUT_1_2 = 0x04
 
 # --- CC 0x50: BLUETOOTH_STATUS ---
+
+
+class TemperatureSensor(IntOrTypeEnum):
+    SENSOR_1 = 0xF0
+    SENSOR_2 = 0xF1
+
+
+_TEMPERATURE_SENSOR_IDS = frozenset(TemperatureSensor)
+
+
+class TemperatureCodec(Codec[int]):
+    def decode(self, data: bytes) -> int | None:
+        if len(data) == 1:
+            return data[0]
+        if len(data) == 2 and data[0] in _TEMPERATURE_SENSOR_IDS:
+            return data[1]
+        return None
+
+
+# --- CC 0x58: AUTO_SHUTDOWN_CONTROL ---
+
+class AutoShutdown(IntOrTypeEnum):
+    """Auto-shutdown timer setting.
+
+    Used by AUTO_SHUTDOWN_CONTROL (0x58).
+
+    See: SH277E "Auto shutdown control (0x58)".
+    """
+
+    DISABLED = 0
+    MINUTES_20 = 20
+    MINUTES_30 = 30
+    HOUR_1 = 60
+    HOURS_2 = 120
+    HOURS_4 = 240
+
+    @classmethod
+    def _values(cls, model: str | None) -> tuple[AutoShutdown, ...]:
+        if model in {"SA10", "SA20"}:
+            return (
+                cls.DISABLED,
+                cls.MINUTES_30,
+                cls.HOUR_1,
+                cls.HOURS_2,
+                cls.HOURS_4,
+            )
+        return (
+            cls.DISABLED,
+            cls.MINUTES_20,
+            cls.MINUTES_30,
+            cls.HOUR_1,
+            cls.HOURS_2,
+            cls.HOURS_4,
+        )
+
+    @classmethod
+    def from_bytes_for_model(
+        cls, data: bytes, model: str | None
+    ) -> AutoShutdown | None:
+        value = int.from_bytes(data, "big")
+        values = cls._values(model)
+        if value >= len(values):
+            return None
+        return values[value]
+
+    def to_bytes_for_model(self, model: str | None) -> bytes:
+        try:
+            return bytes([self._values(model).index(self)])
+        except ValueError as exception:
+            raise ValueError(f"{self.name} is not supported on {model}") from exception
+
+# --- CC 0x5B: PROCESSOR_MODE_INPUT ---
+
+class SaProcessorModeCodec(Codec["SourceCodes | None"]):
+    """1 byte ↔ SourceCodes | None; 0x00 → None (disabled), other bytes via the
+    SA-series source encoding (zone 1).
+
+    See: SH306E / SH320E "Processor mode input (0x5B)".
+    """
+
+    def decode(self, data: bytes) -> SourceCodes | None:
+        if len(data) != 1 or data[0] == 0x00:
+            return None
+        try:
+            return SourceCodes.from_bytes(data, ApiModel.APISA_SERIES, 1)
+        except ValueError:
+            return None
+
+    def encode(self, value: SourceCodes | None) -> bytes:
+        if value is None:
+            return bytes([0x00])
+        return value.to_bytes(ApiModel.APISA_SERIES, 1)
+
+# --- CC 0x61: DAC_FILTER ---
+
+class DacFilter(IntOrTypeEnum):
+    """DAC digital filter type.
+
+    Used by DAC_FILTER (0x61). SA20 supports all seven; SA10 supports
+    only the first three.
+
+    See: SH277E "DAC Filter (0x61)".
+    """
+
+    LINEAR_FAST = 0x00
+    LINEAR_SLOW = 0x01
+    MINIMUM_FAST = 0x02
+    MINIMUM_SLOW = 0x03
+    BRICK_WALL = 0x04
+    CORRECTED_FAST = 0x05
+    APODIZING = 0x06
+
 
 class BluetoothAudioStatus(IntOrTypeEnum):
     """Bluetooth connection and codec status.

--- a/src/arcam/fmj/commands.py
+++ b/src/arcam/fmj/commands.py
@@ -1,13 +1,16 @@
 """CommandCodes enum — the command catalogue.
 
-Each entry carries ``(value, version, flags)`` where *version* gates model
-support and *flags* describe protocol behaviour. Definitions are ordered
-by command-code hex value within each section.
+Each entry carries ``(value, version, flags, sources)`` where *version*
+gates model support, *flags* describe protocol behaviour (including update
+loop participation), and *sources* gates both update polling and cached
+accessors to a specific source set. Definitions are ordered by
+command-code hex value within each section.
 """
 from __future__ import annotations
 
 import enum
 
+from .codecs import SourceCodes
 from .models import (
     APIVERSION_450_SERIES,
     APIVERSION_AMP_DIAGNOSTICS_SERIES,
@@ -90,15 +93,25 @@ _SIMPLE_IP = APIVERSION_SIMPLE_IP_SERIES
 _PHONO = APIVERSION_PHONO_SERIES
 _DAC_FILT = APIVERSION_DAC_FILTER_SERIES
 
+_FM = frozenset({SourceCodes.FM})
+_DAB = frozenset({SourceCodes.DAB})
+_TUN = frozenset({SourceCodes.FM, SourceCodes.DAB})
+_NET = frozenset({SourceCodes.NET, SourceCodes.USB, SourceCodes.NET_USB})
+_BT = frozenset({SourceCodes.BT})
+
 class CommandCodes(IntOrTypeEnum):
     """Per-command protocol metadata.
 
-    Each member is ``(cc_byte, version_set | None, flags)``. The ``version``
-    field gates which device families support the command; ``flags`` describe
-    zone support, polling requirements, and update behaviour.
+    Each member is ``(cc_byte, version_set | None, flags, sources)``. The
+    ``version`` field gates which device families support the command;
+    ``flags`` describe protocol behaviour (UPDATE gates participation in
+    the update loop, NOT_PUSHED forces every-cycle polling); ``sources``
+    (when not None) restricts both the update loop and cached accessors
+    to a specific source set.
     """
 
     flags: CommandFlags
+    sources: frozenset[SourceCodes] | None
 
     @classmethod
     def _create_member(cls, value):
@@ -109,26 +122,34 @@ class CommandCodes(IntOrTypeEnum):
             obj._value_ = value
             obj.version = None
             obj.flags = CommandFlags(0)
+            obj.sources = None
             pseudo_member = cls._value2member_map_.setdefault(value, obj)
         return pseudo_member
 
-    def __new__(cls, value: int, version: set[str] | None = None, flags=CommandFlags(0)):
+    def __new__(
+        cls,
+        value: int,
+        version: set[str] | None = None,
+        flags: CommandFlags | None = None,
+        sources: frozenset[SourceCodes] | None = None,
+    ):
         obj = int.__new__(cls, value)
         obj._value_ = value
         obj.version = version
-        obj.flags = flags
+        obj.flags = flags if flags is not None else CommandFlags(0)
+        obj.sources = sources
         return obj
 
     # fmt: off
-    # Name                            CC    Version     Flags
-    # ====                            ==    =======     =====
+    # Name                            CC    Version     Flags             Sources
+    # ====                            ==    =======     =====             =======
 
     # --- System ---
     POWER                           = 0x00, None,       _Z | _U
     DISPLAY_BRIGHTNESS              = 0x01, _AVR_SA_ST
     HEADPHONES                      = 0x02, _AVR_SA,    _U
-    FMGENRE                         = 0x03, _AVR,       _Z
-    SOFTWARE_VERSION                = 0x04, None
+    FMGENRE                         = 0x03, _AVR,       _Z | _U,          _FM
+    SOFTWARE_VERSION                = 0x04, None,       _U
     RESTORE_FACTORY_DEFAULT         = 0x05, None
     SAVE_RESTORE_COPY_OF_SETTINGS   = 0x06, _AVR
     SIMULATE_RC5_IR_COMMAND         = 0x08, _AVR_SA_ST, _Z
@@ -145,18 +166,18 @@ class CommandCodes(IntOrTypeEnum):
     DIRECT_MODE_STATUS              = 0x0F, _DIRECT
     DECODE_MODE_STATUS_2CH          = 0x10, _AVR,       _U
     DECODE_MODE_STATUS_MCH          = 0x11, _AVR,       _U
-    RDS_INFORMATION                 = 0x12, _AVR,       _Z | _U
+    RDS_INFORMATION                 = 0x12, _AVR,       _Z | _U,          _FM
     VIDEO_OUTPUT_RESOLUTION         = 0x13, _AVR
 
     # --- Menu / Tuner / Source ---
     MENU                            = 0x14, _AVR,       _U
-    TUNER_PRESET                    = 0x15, _AVR,       _Z | _U
+    TUNER_PRESET                    = 0x15, _AVR,       _Z | _U,          _FM
     TUNE                            = 0x16, _AVR,       _Z
-    DAB_STATION                     = 0x18, _AVR,       _Z | _U
+    DAB_STATION                     = 0x18, _AVR,       _Z | _U,          _DAB
     DAB_PROGRAM_TYPE_CATEGORY       = 0x19, _AVR,       _Z
-    DLS_PDT_INFO                    = 0x1A, _AVR,       _Z | _U
-    PRESET_DETAIL                   = 0x1B, _AVR,       _Z | _U
-    NETWORK_PLAYBACK_STATUS         = 0x1C, _NET_PLAY,  _U | _NP
+    DLS_PDT_INFO                    = 0x1A, _AVR,       _Z | _U,          _DAB
+    PRESET_DETAIL                   = 0x1B, _AVR,       _Z | _U,          _TUN
+    NETWORK_PLAYBACK_STATUS         = 0x1C, _NET_PLAY,  _U | _NP,         _NET
     CURRENT_SOURCE                  = 0x1D, _AVR_SA_ST, _Z | _U
     HEADPHONES_OVERRIDE             = 0x1F, _AVR_SA,    _Z
 
@@ -209,25 +230,25 @@ class CommandCodes(IntOrTypeEnum):
     VIDEO_MPEG_NOISE_REDUCTION      = 0x4D, _450
     ZONE_1_OSD_ON_OFF               = 0x4E, _AVR
     VIDEO_OUTPUT_SWITCHING          = 0x4F, _AVR
-    BLUETOOTH_STATUS                = 0x50, _HDA,       _U | _NP     # was "Output Frame Rate" in 450 (SH256E)
+    BLUETOOTH_STATUS                = 0x50, _HDA,       _U | _NP,          _BT     # was "Output Frame Rate" in 450 (SH256E)
 
     # --- Diagnostics / Amp Control ---
-    DC_OFFSET                       = 0x51, _THERM
-    SHORT_CIRCUIT_STATUS            = 0x52, _CLASS_G
+    DC_OFFSET                       = 0x51, _THERM,     _U | _NP
+    SHORT_CIRCUIT_STATUS            = 0x52, _CLASS_G,   _U | _NP
     FRIENDLY_NAME                   = 0x53, _SIMPLE_IP
     IP_ADDRESS                      = 0x54, _SIMPLE_IP
     TIMEOUT_COUNTER                 = 0x55, _AMP_DIAG
-    LIFTER_TEMPERATURE              = 0x56, _CLASS_G                 # bug in PA720 1.8: no sensor id in response
-    OUTPUT_TEMPERATURE              = 0x57, _THERM                   # bug in PA720 1.8: no sensor id in response
+    LIFTER_TEMPERATURE              = 0x56, _CLASS_G,   _U | _NP       # bug in PA720 1.8: no sensor id in response
+    OUTPUT_TEMPERATURE              = 0x57, _THERM,     _U | _NP       # bug in PA720 1.8: no sensor id in response
     AUTO_SHUTDOWN_CONTROL           = 0x58, _AMP_DIAG
     PHONO_INPUT_TYPE                = 0x59, _PHONO
     INPUT_DETECT                    = 0x5A, _AMP_DIAG
     PROCESSOR_MODE_INPUT            = 0x5B, _SA
-    PROCESSOR_MODE_VOLUME           = 0x5C, _SA                      # ST60 reuses 0x5C for Fixed Volume
+    PROCESSOR_MODE_VOLUME           = 0x5C, _SA                         # ST60 reuses 0x5C for Fixed Volume
     SYSTEM_STATUS                   = 0x5D, _AMP_DIAG
     SYSTEM_MODEL                    = 0x5E, _AMP_DIAG
-    DAC_FILTER                      = 0x61, _DAC_FILT                # clashes with AMPLIFIER_MODE on PA240
-    NOW_PLAYING_INFO                = 0x64, _NOW_PLAY,  _Z | _U | _NP
+    DAC_FILTER                      = 0x61, _DAC_FILT                   # clashes with AMPLIFIER_MODE on PA240
+    NOW_PLAYING_INFO                = 0x64, _NOW_PLAY,  _Z | _U | _NP,    _NET
     MAXIMUM_TURN_ON_VOLUME          = 0x65, _APP_SAFE
     MAXIMUM_VOLUME                  = 0x66, _APP_SAFE
     MAXIMUM_STREAMING_VOLUME        = 0x67, _APP_SAFE

--- a/src/arcam/fmj/commands.py
+++ b/src/arcam/fmj/commands.py
@@ -1,49 +1,56 @@
-"""CommandCodes enum — the command catalogue.
+"""The command catalogue — one table, one row per command.
 
-Each entry carries ``(value, version, flags, sources)`` where *version*
-gates model support, *flags* describe protocol behaviour (including update
-loop participation), and *sources* gates both update polling and cached
-accessors to a specific source set. Definitions are ordered by
-command-code hex value within each section.
+Each constant is a command: its CC byte (``cc``), protocol metadata (``version``,
+``flags``, ``sources``) and — where the command has a get/set form — a ``Codec``
+and a read/write/step capability via the ``ReadCommand`` / ``WriteCommand`` /
+``StepCommand`` classes. ``ro`` / ``rw`` / ``rw_step`` / ``wo`` build typed commands;
+``proto`` builds protocol-only ones (no accessor). ``State.get`` / ``set`` /
+``inc`` / ``dec`` operate on these; the wire layer keys off ``command.cc``.
+
+To add a command, add one row. Define any new codec in ``codecs`` and any RC5
+table in ``rc5`` first.
 """
 from __future__ import annotations
 
 import enum
+from dataclasses import dataclass, field
+from typing import Any, Generic, Protocol, TypeVar
 
-from .codecs import SourceCodes
-from .models import (
-    APIVERSION_450_SERIES,
-    APIVERSION_AMP_DIAGNOSTICS_SERIES,
-    APIVERSION_APP_SAFETY_SERIES,
-    APIVERSION_AVR_AND_SA_SERIES,
-    APIVERSION_AVR_PRE_HDA_SERIES,
-    APIVERSION_AVR_SA_AND_ST_SERIES,
-    APIVERSION_AVR_SERIES,
-    APIVERSION_CLASS_G_SERIES,
-    APIVERSION_DAC_FILTER_SERIES,
-    APIVERSION_DIRECT_MODE_SERIES,
-    APIVERSION_HDA_MULTI_ZONE_SERIES,
-    APIVERSION_HDA_SERIES,
-    APIVERSION_IMAX_SERIES,
-    APIVERSION_NETWORK_MENU_SERIES,
-    APIVERSION_NETWORK_PLAYBACK_SERIES,
-    APIVERSION_NOW_PLAYING_SERIES,
-    APIVERSION_PHONO_SERIES,
-    APIVERSION_ROOM_EQ_NAMES_SERIES,
-    APIVERSION_ROOM_EQ_SERIES,
-    APIVERSION_SA_SERIES,
-    APIVERSION_SIMPLE_IP_SERIES,
-    APIVERSION_THERMAL_DIAGNOSTICS_SERIES,
-    ApiModel,
-    IntOrTypeEnum,
-)
+from .codecs import *  # noqa: F401,F403
+from .models import *  # noqa: F401,F403
+from .rc5 import *  # noqa: F401,F403
+
+
+__all__ = [
+    "CommandFlags",
+    "MUTE_WRITE_SUPPORTED",
+    "POWER_WRITE_SUPPORTED",
+    "SOURCE_WRITE_SUPPORTED",
+    "VOLUME_STEP_SUPPORTED",
+    "Command",
+    "CommandContext",
+    "Rc5Step",
+    "Rc5Write",
+    "ReadCommand",
+    "WriteCommand",
+    "StepCommand",
+    "ReadWriteCommand",
+    "ReadWriteStepCommand",
+    "ro",
+    "rw",
+    "rw_step",
+    "wo",
+    "proto",
+    "COMMANDS",
+    "command_for",
+]
+
 
 class CommandFlags(enum.IntFlag):
-    """Behavioural protocol traits of a command code."""
-
+    """Behavioral protocol traits consulted by the update loop and zone gating."""
     ZONE_SUPPORT = enum.auto()
     UPDATE = enum.auto()        # Fetched by the State update loop.
-    NOT_PUSHED = enum.auto()    # Device does not send unsolicited updates
+    NOT_PUSHED = enum.auto()    # Device does not send unsolicited updates.
 
 #: Models that accept a direct CC write for power on/off.
 POWER_WRITE_SUPPORTED = {
@@ -66,6 +73,7 @@ VOLUME_STEP_SUPPORTED = {
 }
 
 # Short aliases for the table below.
+_0 = CommandFlags(0)
 _Z = CommandFlags.ZONE_SUPPORT
 _U = CommandFlags.UPDATE
 _NP = CommandFlags.NOT_PUSHED
@@ -99,157 +107,274 @@ _TUN = frozenset({SourceCodes.FM, SourceCodes.DAB})
 _NET = frozenset({SourceCodes.NET, SourceCodes.USB, SourceCodes.NET_USB})
 _BT = frozenset({SourceCodes.BT})
 
-class CommandCodes(IntOrTypeEnum):
-    """Per-command protocol metadata.
 
-    Each member is ``(cc_byte, version_set | None, flags, sources)``. The
-    ``version`` field gates which device families support the command;
-    ``flags`` describe protocol behaviour (UPDATE gates participation in
-    the update loop, NOT_PUSHED forces every-cycle polling); ``sources``
-    (when not None) restricts both the update loop and cached accessors
-    to a specific source set.
-    """
+# === Command machinery ===
 
-    flags: CommandFlags
-    sources: frozenset[SourceCodes] | None
+T = TypeVar("T")
 
-    @classmethod
-    def _create_member(cls, value):
-        pseudo_member = cls._value2member_map_.get(value, None)
-        if pseudo_member is None:
-            obj = int.__new__(cls, value)
-            obj._name_ = f"CODE_{value}"
-            obj._value_ = value
-            obj.version = None
-            obj.flags = CommandFlags(0)
-            obj.sources = None
-            pseudo_member = cls._value2member_map_.setdefault(value, obj)
-        return pseudo_member
 
-    def __new__(
-        cls,
-        value: int,
-        version: set[str] | None = None,
-        flags: CommandFlags | None = None,
-        sources: frozenset[SourceCodes] | None = None,
-    ):
-        obj = int.__new__(cls, value)
-        obj._value_ = value
-        obj.version = version
-        obj.flags = flags if flags is not None else CommandFlags(0)
-        obj.sources = sources
-        return obj
+@dataclass(frozen=True)
+class Rc5Write:
+    """RC5 fallback for a Set: direct CC write when the model is in
+    ``direct_supported``, otherwise the RC5 code for the value."""
+    table: dict
+    direct_supported: frozenset = field(default_factory=frozenset)
 
-    # fmt: off
-    # Name                            CC    Version     Flags             Sources
-    # ====                            ==    =======     =====             =======
 
-    # --- System ---
-    POWER                           = 0x00, None,       _Z | _U
-    DISPLAY_BRIGHTNESS              = 0x01, _AVR_SA_ST
-    HEADPHONES                      = 0x02, _AVR_SA,    _U
-    FMGENRE                         = 0x03, _AVR,       _Z | _U,          _FM
-    SOFTWARE_VERSION                = 0x04, None,       _U
-    RESTORE_FACTORY_DEFAULT         = 0x05, None
-    SAVE_RESTORE_COPY_OF_SETTINGS   = 0x06, _AVR
-    SIMULATE_RC5_IR_COMMAND         = 0x08, _AVR_SA_ST, _Z
-    DISPLAY_INFORMATION_TYPE        = 0x09, _AVR,       _Z | _U
+@dataclass(frozen=True)
+class Rc5Step:
+    """Inc/dec policy: step via direct CC (``inc_data`` / ``dec_data``) when the
+    model is in ``via_cc_supported``, otherwise the up/down RC5 code."""
+    table: dict
+    via_cc_supported: frozenset = field(default_factory=frozenset)
+    inc_data: bytes = b"\xF1"
+    dec_data: bytes = b"\xF2"
 
-    # --- Input ---
-    VIDEO_SELECTION                 = 0x0A, _PRE_HDA,   _U
-    SELECT_ANALOG_DIGITAL           = 0x0B, _AVR,       _Z
-    IMAX_ENHANCED                   = 0x0C, _IMAX,      _U          # was "Video input type" in 450 (SH256E); not AVR5 (SH289E)
 
-    # --- Output ---
-    VOLUME                          = 0x0D, _AVR_SA_ST, _Z | _U
-    MUTE                            = 0x0E, None,       _Z | _U
-    DIRECT_MODE_STATUS              = 0x0F, _DIRECT
-    DECODE_MODE_STATUS_2CH          = 0x10, _AVR,       _U
-    DECODE_MODE_STATUS_MCH          = 0x11, _AVR,       _U
-    RDS_INFORMATION                 = 0x12, _AVR,       _Z | _U,          _FM
-    VIDEO_OUTPUT_RESOLUTION         = 0x13, _AVR
+class CommandContext(Protocol):
+    """The slice of ``State`` that command write/step delegate into."""
+    @property
+    def api_model(self) -> ApiModel: ...
+    def set_cached(self, cc: int, data: bytes | None) -> None: ...
+    def supported_on_source(self, command: Command[Any]) -> bool: ...
+    def get_rc5code(self, table: dict, value: Any) -> bytes: ...
+    async def request(self, command: Command[Any], data: bytes) -> bytes: ...
+    async def send_rc5(self, table: dict, value: Any) -> None: ...
 
-    # --- Menu / Tuner / Source ---
-    MENU                            = 0x14, _AVR,       _U
-    TUNER_PRESET                    = 0x15, _AVR,       _Z | _U,          _FM
-    TUNE                            = 0x16, _AVR,       _Z
-    DAB_STATION                     = 0x18, _AVR,       _Z | _U,          _DAB
-    DAB_PROGRAM_TYPE_CATEGORY       = 0x19, _AVR,       _Z
-    DLS_PDT_INFO                    = 0x1A, _AVR,       _Z | _U,          _DAB
-    PRESET_DETAIL                   = 0x1B, _AVR,       _Z | _U,          _TUN
-    NETWORK_PLAYBACK_STATUS         = 0x1C, _NET_PLAY,  _U | _NP,         _NET
-    CURRENT_SOURCE                  = 0x1D, _AVR_SA_ST, _Z | _U
-    HEADPHONES_OVERRIDE             = 0x1F, _AVR_SA,    _Z
 
-    # --- Extended (2.0) ---
-    INPUT_NAME                      = 0x20, _AVR
-    FM_SCAN                         = 0x23, _AVR
-    DAB_SCAN                        = 0x24, _AVR
-    HEARTBEAT                       = 0x25, None
-    REBOOT                          = 0x26, None
-    SETUP                           = 0x27, _HDA
-    INPUT_CONFIG                    = 0x28, _HDA
-    GENERAL_SETUP                   = 0x29, _HDA
-    SPEAKER_TYPES                   = 0x2A, _HDA
-    SPEAKER_DISTANCES               = 0x2B, _HDA
-    SPEAKER_LEVELS                  = 0x2C, _HDA
-    VIDEO_INPUTS                    = 0x2D, _HDA
-    HDMI_SETTINGS                   = 0x2E, _HDA
-    ZONE_SETTINGS                   = 0x2F, _HDA_MZ
-    NETWORK_MENU_INFO               = 0x30, _NET_MENU
-    BLUETOOTH_MENU_INFO             = 0x32, _HDA
-    ENGINEERING_MENU_INFO           = 0x33, _HDA
-    ROOM_EQ_NAMES                   = 0x34, _ROOM_NAM,  _U
+@dataclass(frozen=True, eq=False, repr=False)
+class Command(Generic[T]):
+    cc: int
+    version: set[str] | None = None
+    flags: CommandFlags = CommandFlags(0)
+    sources: frozenset[SourceCodes] | None = None
+    codec: Codec[T] | None = None
+    rc5_write: Rc5Write | None = None
+    rc5_step: Rc5Step | None = None
+    name: str = ""
 
-    # --- Setup / EQ ---
-    TREBLE_EQUALIZATION             = 0x35, _AVR,       _Z | _U
-    BASS_EQUALIZATION               = 0x36, _AVR,       _Z | _U
-    ROOM_EQUALIZATION               = 0x37, _ROOM_EQ,   _Z | _U
-    DOLBY_AUDIO                     = 0x38, _AVR,       _Z | _U     # was "Dolby Volume" in 450/860 (SH256E/SH274E)
-    DOLBY_LEVELER                   = 0x39, _PRE_HDA,   _Z          # removed from HDA (SH289E issue C.0)
-    DOLBY_VOLUME_CALIBRATION_OFFSET = 0x3A, _PRE_HDA,   _Z          # removed from HDA (SH289E issue C.0)
-    BALANCE                         = 0x3B, _AVR_SA,    _Z | _U
-    DOLBY_PLII_X_MUSIC_DIMENSION    = 0x3C, _450
-    DOLBY_PLII_X_MUSIC_CENTRE_WIDTH = 0x3D, _450
-    DOLBY_PLII_X_MUSIC_PANORAMA     = 0x3E, _450
-    SUBWOOFER_TRIM                  = 0x3F, _AVR,       _Z | _U
-    LIPSYNC_DELAY                   = 0x40, _AVR,       _Z | _U
-    COMPRESSION                     = 0x41, _AVR,       _Z | _U
+    def __repr__(self) -> str:
+        return self.name or f"CODE_0x{self.cc:02X}"
 
-    # --- Incoming Signal / Video ---
-    INCOMING_VIDEO_PARAMETERS       = 0x42, _AVR,       _U
-    INCOMING_AUDIO_FORMAT           = 0x43, _AVR,       _U
-    INCOMING_AUDIO_SAMPLE_RATE      = 0x44, _AVR_SA_ST, _U
-    SUB_STEREO_TRIM                 = 0x45, _AVR,       _U
-    VIDEO_BRIGHTNESS                = 0x46, _450
-    VIDEO_CONTRAST                  = 0x47, _450
-    VIDEO_COLOUR                    = 0x48, _450
-    VIDEO_FILM_MODE                 = 0x49, _450
-    VIDEO_EDGE_ENHANCEMENT          = 0x4A, _450
-    VIDEO_NOISE_REDUCTION           = 0x4C, _450
-    VIDEO_MPEG_NOISE_REDUCTION      = 0x4D, _450
-    ZONE_1_OSD_ON_OFF               = 0x4E, _AVR
-    VIDEO_OUTPUT_SWITCHING          = 0x4F, _AVR
-    BLUETOOTH_STATUS                = 0x50, _HDA,       _U | _NP,          _BT     # was "Output Frame Rate" in 450 (SH256E)
 
-    # --- Diagnostics / Amp Control ---
-    DC_OFFSET                       = 0x51, _THERM,     _U | _NP
-    SHORT_CIRCUIT_STATUS            = 0x52, _CLASS_G,   _U | _NP
-    FRIENDLY_NAME                   = 0x53, _SIMPLE_IP
-    IP_ADDRESS                      = 0x54, _SIMPLE_IP
-    TIMEOUT_COUNTER                 = 0x55, _AMP_DIAG
-    LIFTER_TEMPERATURE              = 0x56, _CLASS_G,   _U | _NP       # bug in PA720 1.8: no sensor id in response
-    OUTPUT_TEMPERATURE              = 0x57, _THERM,     _U | _NP       # bug in PA720 1.8: no sensor id in response
-    AUTO_SHUTDOWN_CONTROL           = 0x58, _AMP_DIAG
-    PHONO_INPUT_TYPE                = 0x59, _PHONO
-    INPUT_DETECT                    = 0x5A, _AMP_DIAG
-    PROCESSOR_MODE_INPUT            = 0x5B, _SA
-    PROCESSOR_MODE_VOLUME           = 0x5C, _SA                         # ST60 reuses 0x5C for Fixed Volume
-    SYSTEM_STATUS                   = 0x5D, _AMP_DIAG
-    SYSTEM_MODEL                    = 0x5E, _AMP_DIAG
-    DAC_FILTER                      = 0x61, _DAC_FILT                   # clashes with AMPLIFIER_MODE on PA240
-    NOW_PLAYING_INFO                = 0x64, _NOW_PLAY,  _Z | _U | _NP,    _NET
-    MAXIMUM_TURN_ON_VOLUME          = 0x65, _APP_SAFE
-    MAXIMUM_VOLUME                  = 0x66, _APP_SAFE
-    MAXIMUM_STREAMING_VOLUME        = 0x67, _APP_SAFE
-    # fmt: on
+class ReadCommand(Command[T]):
+    """Read capability: ``State.get`` accepts it. Decodes the cached payload."""
+    def read(self, raw: bytes) -> T | None:
+        assert self.codec is not None
+        return self.codec.decode(raw)
+
+
+class WriteCommand(Command[T]):
+    """Write capability: ``State.set`` accepts it; direct CC or RC5 fallback."""
+    async def write(self, context: CommandContext, value: T) -> None:
+        if not context.supported_on_source(self) or self.codec is None:
+            return
+        write = self.rc5_write
+        if write is not None and context.api_model not in write.direct_supported:
+            await context.send_rc5(write.table, value)
+        else:
+            await context.request(self, self.codec.encode(value))
+
+
+class StepCommand(Command[T]):
+    """Step capability: ``State.inc`` / ``dec`` accept it."""
+    async def step(self, context: CommandContext, increment: bool) -> None:
+        if not context.supported_on_source(self):
+            return
+        step = self.rc5_step
+        assert step is not None
+        if context.api_model in step.via_cc_supported:
+            await context.request(self, step.inc_data if increment else step.dec_data)
+        else:
+            await context.send_rc5(step.table, increment)
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class ReadWriteCommand(ReadCommand[T], WriteCommand[T]): ...
+
+@dataclass(frozen=True, eq=False, repr=False)
+class ReadWriteStepCommand(ReadCommand[T], WriteCommand[T], StepCommand[T]): ...
+
+
+def ro(cc: int, version: set[str] | None, flags: CommandFlags, codec: Codec[T],
+       sources: frozenset[SourceCodes] | None = None) -> ReadCommand[T]:
+    return ReadCommand(cc, version, flags, sources, codec)
+
+
+def wo(cc: int, version: set[str] | None, flags: CommandFlags, codec: Codec[T],
+       sources: frozenset[SourceCodes] | None = None, *, rc5: Rc5Write | None = None) -> WriteCommand[T]:
+    return WriteCommand(cc, version, flags, sources, codec, rc5_write=rc5)
+
+
+def rw(cc: int, version: set[str] | None, flags: CommandFlags, codec: Codec[T],
+       sources: frozenset[SourceCodes] | None = None, *, rc5: Rc5Write | None = None) -> ReadWriteCommand[T]:
+    return ReadWriteCommand(cc, version, flags, sources, codec, rc5_write=rc5)
+
+
+def rw_step(cc: int, version: set[str] | None, flags: CommandFlags, codec: Codec[T],
+            sources: frozenset[SourceCodes] | None = None, *, step: Rc5Step,
+            rc5: Rc5Write | None = None) -> ReadWriteStepCommand[T]:
+    return ReadWriteStepCommand(cc, version, flags, sources, codec, rc5_write=rc5, rc5_step=step)
+
+
+def proto(cc: int, version: set[str] | None = None, flags: CommandFlags = _0,
+          sources: frozenset[SourceCodes] | None = None) -> Command[Any]:
+    return Command(cc, version, flags, sources)
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class _PowerCommand(ReadWriteCommand[bool]):
+    """POWER: direct CC where supported, else RC5. Power-off seeds the cache
+    first, since the device may not answer promptly while shutting down."""
+    async def write(self, context: CommandContext, value: bool) -> None:
+        assert self.codec is not None and self.rc5_write is not None
+        if not value:
+            context.set_cached(self.cc, bytes([0]))
+        if context.api_model in POWER_WRITE_SUPPORTED:
+            await context.request(self, self.codec.encode(value))
+        else:
+            await context.send_rc5(self.rc5_write.table, value)
+
+
+def power(cc: int, version: set[str] | None, flags: CommandFlags, codec: Codec[bool],
+          *, rc5: Rc5Write) -> _PowerCommand:
+    return _PowerCommand(cc, version, flags, None, codec, rc5_write=rc5)
+
+
+# === The table ===
+# Name                            Type    CC    API         Flags          Codec / policy [, sources]
+
+# --- System ---
+POWER                           = power  (0x00, None,       _Z | _U,       BoolCodec(), rc5=Rc5Write(RC5CODE_POWER))
+DISPLAY_BRIGHTNESS              = rw     (0x01, _AVR_SA_ST, _U,            EnumCodec(DisplayBrightness), rc5=Rc5Write(RC5CODE_DISPLAY_BRIGHTNESS))
+HEADPHONES                      = ro     (0x02, _AVR_SA,    _U,            BoolCodec())
+FM_GENRE                        = ro     (0x03, _AVR,       _Z | _U,       StringCodec(), _FM)
+SOFTWARE_VERSION                = proto  (0x04, None,       _U)
+RESTORE_FACTORY_DEFAULT         = proto  (0x05)
+SAVE_RESTORE_COPY_OF_SETTINGS   = proto  (0x06, _AVR)
+SIMULATE_RC5_IR_COMMAND         = proto  (0x08, _AVR_SA_ST, _Z)
+DISPLAY_INFO_TYPE               = ro     (0x09, _AVR,       _Z | _U,       IntCodec(), _FM)  # per probe — AV41 only responds in FM source
+CURRENT_SOURCE                  = proto  (0x1D, _AVR_SA_ST, _Z | _U)
+HEADPHONES_OVERRIDE             = wo     (0x1F, _AVR_SA,    _Z,            BoolCodec())
+
+# --- Input ---
+VIDEO_SELECTION                 = rw     (0x0A, _PRE_HDA,   _U,            EnumCodec(VideoSelection))
+SELECT_ANALOG_DIGITAL           = proto  (0x0B, _AVR,       _Z)
+IMAX_ENHANCED                   = rw     (0x0C, _IMAX,      _U,            EnumCodec(ImaxEnhancedMode, set_map=IMAX_ENHANCED_SET_MAP))  # was "Video input type" in 450 (SH256E)
+
+# --- Output ---
+VOLUME                          = rw_step(0x0D, _AVR_SA_ST, _Z | _U,       IntCodec(), step=Rc5Step(RC5CODE_VOLUME, frozenset(VOLUME_STEP_SUPPORTED)))
+MUTE                            = rw     (0x0E, None,       _Z | _U,       BoolCodec(inverted=True), rc5=Rc5Write(RC5CODE_MUTE, frozenset(MUTE_WRITE_SUPPORTED)))
+DIRECT_MODE                     = rw     (0x0F, _DIRECT,    _U,            BoolCodec(), rc5=Rc5Write(RC5CODE_DIRECT_MODE))
+DECODE_MODE_2CH                 = rw     (0x10, _AVR,       _U,            EnumCodec(DecodeMode2CH), rc5=Rc5Write(RC5CODE_DECODE_MODE_2CH))
+DECODE_MODE_MCH                 = rw     (0x11, _AVR,       _U,            EnumCodec(DecodeModeMCH), rc5=Rc5Write(RC5CODE_DECODE_MODE_MCH))
+RDS_INFORMATION                 = ro     (0x12, _AVR,       _Z | _U,       StringCodec(), _FM)
+VIDEO_OUTPUT_RESOLUTION         = proto  (0x13, _AVR)
+
+# --- Menu / Tuner ---
+MENU                            = ro     (0x14, _AVR,       _U,            EnumCodec(MenuCodes))
+TUNER_PRESET                    = rw     (0x15, _AVR,       _Z | _U,       TunerPresetCodec(), _FM)
+TUNE                            = proto  (0x16, _AVR,       _Z)
+DAB_STATION                     = ro     (0x18, _AVR,       _Z | _U,       StringCodec(), _DAB)
+DAB_PROGRAM_TYPE_CATEGORY       = proto  (0x19, _AVR,       _Z | _U,       _DAB)
+DLS_PDT                         = ro     (0x1A, _AVR,       _Z | _U,       StringCodec(), _DAB)
+PRESET_DETAIL                   = proto  (0x1B, _AVR,       _Z | _U,       _TUN)
+NETWORK_PLAYBACK_STATUS         = ro     (0x1C, _NET_PLAY,  _U | _NP,      EnumCodec(NetworkPlaybackStatus), _NET)
+ROOM_EQ_NAMES                   = ro     (0x34, _ROOM_NAM,  _U,            RoomEqNamesCodec())
+
+# --- Extended (2.0) ---
+INPUT_NAME                      = proto  (0x20, _AVR)
+FM_SCAN                         = proto  (0x23, _AVR)
+DAB_SCAN                        = proto  (0x24, _AVR,       _0,            _DAB)
+HEARTBEAT                       = proto  (0x25)
+REBOOT                          = proto  (0x26)
+SETUP                           = proto  (0x27, _HDA)
+INPUT_CONFIG                    = proto  (0x28, _HDA)
+GENERAL_SETUP                   = proto  (0x29, _HDA)
+SPEAKER_TYPES                   = proto  (0x2A, _HDA)
+SPEAKER_DISTANCES               = proto  (0x2B, _HDA)
+SPEAKER_LEVELS                  = proto  (0x2C, _HDA)
+VIDEO_INPUTS                    = proto  (0x2D, _HDA)
+HDMI_SETTINGS                   = proto  (0x2E, _HDA)
+ZONE_SETTINGS                   = proto  (0x2F, _HDA_MZ)
+NETWORK_MENU_INFO               = proto  (0x30, _NET_MENU)
+BLUETOOTH_MENU_INFO             = proto  (0x32, _HDA)
+ENGINEERING_MENU_INFO           = proto  (0x33, _HDA)
+
+# --- Setup / EQ ---
+TREBLE_EQUALIZATION             = rw_step(0x35, _AVR,       _Z | _U,       ScaledCodec(-12.0, 12.0, 1.0), step=Rc5Step(RC5CODE_TREBLE))
+BASS_EQUALIZATION               = rw_step(0x36, _AVR,       _Z | _U,       ScaledCodec(-12.0, 12.0, 1.0), step=Rc5Step(RC5CODE_BASS))
+ROOM_EQUALIZATION               = rw     (0x37, _ROOM_EQ,   _Z | _U,       EnumCodec(RoomEqMode))
+DOLBY_AUDIO                     = rw     (0x38, _AVR,       _Z | _U,       EnumCodec(DolbyAudioMode))  # was "Dolby Volume" in 450/860 (SH256E/SH274E)
+DOLBY_LEVELER                   = rw     (0x39, _AVR,       _Z | _U,       IntCodec())  # per probe: AV41 still responds despite spec removal at SH289E issue C.0; 0xFF = off
+DOLBY_VOLUME_CALIBRATION_OFFSET = rw     (0x3A, _AVR,       _Z | _U,       ScaledCodec(-15.0, 15.0, 1.0))  # per probe: AV41 still responds despite spec removal
+BALANCE                         = rw_step(0x3B, _AVR_SA,    _Z | _U,       ScaledCodec(-6.0, 6.0, 1.0), step=Rc5Step(RC5CODE_BALANCE))
+DOLBY_PLIIX_DIMENSION           = rw_step(0x3C, _450,       _U,            IntCodec(), step=Rc5Step(RC5CODE_DOLBY_PLIIX_DIMENSION))
+DOLBY_PLIIX_CENTRE_WIDTH        = rw_step(0x3D, _450,       _U,            IntCodec(), step=Rc5Step(RC5CODE_DOLBY_PLIIX_CENTRE_WIDTH))
+DOLBY_PLIIX_PANORAMA            = rw     (0x3E, _450,       _U,            BoolCodec(), rc5=Rc5Write(RC5CODE_DOLBY_PLIIX_PANORAMA))
+SUBWOOFER_TRIM                  = rw_step(0x3F, _AVR,       _Z | _U,       ScaledCodec(-10.0, 10.0, 0.5), step=Rc5Step(RC5CODE_SUB_TRIM))
+LIPSYNC_DELAY                   = rw_step(0x40, _AVR,       _Z | _U,       ScaledCodec(0.0, 250.0, 5.0), step=Rc5Step(RC5CODE_LIPSYNC))
+COMPRESSION                     = rw     (0x41, _AVR,       _Z | _U,       EnumCodec(CompressionMode))
+
+# --- Incoming Signal / Video ---
+INCOMING_VIDEO_PARAMETERS       = ro     (0x42, _AVR,       _U,            StructCodec(VideoParameters.from_bytes))
+INCOMING_AUDIO_FORMAT           = proto  (0x43, _AVR,       _U)
+INCOMING_AUDIO_SAMPLE_RATE      = ro     (0x44, _AVR_SA_ST, _U,            SampleRateCodec())
+SUB_STEREO_TRIM                 = rw     (0x45, _AVR,       _U,            ScaledCodec(-10.0, 0.0, 0.5))
+VIDEO_BRIGHTNESS                = rw     (0x46, _450,       _U,            ScaledCodec(-50.0, 50.0, 1.0))
+VIDEO_CONTRAST                  = rw     (0x47, _450,       _U,            ScaledCodec(-50.0, 50.0, 1.0))
+VIDEO_COLOUR                    = rw     (0x48, _450,       _U,            ScaledCodec(-50.0, 50.0, 1.0))
+VIDEO_FILM_MODE                 = rw     (0x49, _450,       _U,            EnumCodec(VideoFilmMode))
+VIDEO_EDGE_ENHANCEMENT          = rw     (0x4A, _450,       _U,            IntCodec())  # 0–50
+VIDEO_NOISE_REDUCTION           = rw     (0x4C, _450,       _U,            EnumCodec(VideoNoiseReduction))
+VIDEO_MPEG_NOISE_REDUCTION      = rw     (0x4D, _450,       _U,            EnumCodec(VideoNoiseReduction))
+ZONE_1_OSD_ON_OFF               = rw     (0x4E, _AVR,       _U,            EnumCodec(ZoneOsd, set_map=ZONE_OSD_SET_MAP))
+VIDEO_OUTPUT_SWITCHING          = rw     (0x4F, _AVR,       _U,            EnumCodec(HdmiOutput))
+BLUETOOTH_STATUS                = proto  (0x50, _HDA,       _U | _NP,      _BT)  # was "Output Frame Rate" in 450 (SH256E)
+
+# --- Diagnostics / Amp Control ---
+DC_OFFSET                       = ro     (0x51, _THERM,     _U | _NP,      BoolCodec())  # True = DC offset detected
+SHORT_CIRCUIT_STATUS            = ro     (0x52, _CLASS_G,   _U | _NP,      BoolCodec())  # True = short circuit fault
+TIMEOUT_COUNTER                 = proto  (0x55, _AMP_DIAG)
+# bug in PA720 1.8 firmware — does not return sensor id
+LIFTER_TEMPERATURE              = ro     (0x56, _CLASS_G,   _U | _NP,      IntCodec())
+OUTPUT_TEMPERATURE              = ro     (0x57, _THERM,     _U | _NP,      IntCodec())
+AUTO_SHUTDOWN_CONTROL           = rw     (0x58, _AMP_DIAG,  _U,            EnumCodec(AutoShutdown))
+
+# --- Status / Diagnostics ---
+FRIENDLY_NAME                   = rw     (0x53, _SIMPLE_IP, _U,            StringCodec())
+IP_ADDRESS                      = proto  (0x54, _SIMPLE_IP)  # 4-byte IP
+PHONO_INPUT_TYPE                = proto  (0x59, _PHONO)
+INPUT_DETECT                    = ro     (0x5A, _AMP_DIAG,  _U,            BoolCodec())
+PROCESSOR_MODE_INPUT            = rw     (0x5B, _SA,        _U,            SaProcessorModeCodec())
+PROCESSOR_MODE_VOLUME           = rw     (0x5C, _SA,        _U,            IntCodec())  # 0–99; ST60 reuses 0x5C for Fixed Volume
+SYSTEM_STATUS                   = proto  (0x5D, _AMP_DIAG)  # 0xF0 triggers bulk status dump
+SYSTEM_MODEL                    = ro     (0x5E, _AMP_DIAG,  _U,            StringCodec())
+DAC_FILTER                      = rw     (0x61, _DAC_FILT,  _U,            EnumCodec(DacFilter))  # clashes with AMPLIFIER_MODE on PA240
+NOW_PLAYING_INFO                = proto  (0x64, _NOW_PLAY,  _Z | _U | _NP, _NET)
+MAX_TURN_ON_VOLUME              = rw     (0x65, _APP_SAFE,  _U,            IntCodec())
+MAX_VOLUME                      = rw     (0x66, _APP_SAFE,  _U,            IntCodec())
+MAX_STREAMING_VOLUME            = rw     (0x67, _APP_SAFE,  _U,            IntCodec())
+# Undocumented (per probe of AV41 firmware 2.0.0); not in any published spec.
+UNKNOWN_F0                      = proto  (0xF0, _HDA)  # Returns single byte 0x01
+SERIAL_NUMBER                   = proto  (0xF1, _HDA)  # 16-byte ASCII device serial
+MAC_ADDRESS                     = proto  (0xF2, _HDA)  # 6-byte MAC address
+UNKNOWN_F3                      = proto  (0xF3, _HDA)  # Returns single byte 0x01
+
+
+# Name each command from its module global, then index by CC.
+_ALL: dict[str, Command[Any]] = {
+    _n: _v for _n, _v in list(globals().items()) if isinstance(_v, Command)
+}
+for _n, _v in _ALL.items():
+    object.__setattr__(_v, "name", _n)
+
+#: Every command, ordered by CC.
+COMMANDS: tuple[Command[Any], ...] = tuple(sorted(_ALL.values(), key=lambda c: c.cc))
+
+_BY_CODE: dict[int, Command[Any]] = {c.cc: c for c in COMMANDS}
+
+
+def command_for(cc: int) -> Command[Any] | None:
+    """The command with this CC byte, or None for an unknown code."""
+    return _BY_CODE.get(cc)

--- a/src/arcam/fmj/commands.py
+++ b/src/arcam/fmj/commands.py
@@ -1,49 +1,56 @@
-"""CommandCodes enum — the command catalogue.
+"""The command catalogue — one table, one row per command.
 
-Each entry carries ``(value, version, flags, sources)`` where *version*
-gates model support, *flags* describe protocol behaviour (including update
-loop participation), and *sources* gates both update polling and cached
-accessors to a specific source set. Definitions are ordered by
-command-code hex value within each section.
+Each constant is a command: its CC byte (``cc``), protocol metadata (``version``,
+``flags``, ``sources``) and — where the command has a get/set form — a ``Codec``
+and a read/write/step capability via the ``ReadCommand`` / ``WriteCommand`` /
+``StepCommand`` classes. ``ro`` / ``rw`` / ``rw_step`` / ``wo`` build typed commands;
+``proto`` builds protocol-only ones (no accessor). ``State.get`` / ``set`` /
+``inc`` / ``dec`` operate on these; the wire layer keys off ``command.cc``.
+
+To add a command, add one row. Define any new codec in ``codecs`` and any RC5
+table in ``rc5`` first.
 """
 from __future__ import annotations
 
 import enum
+from dataclasses import dataclass, field
+from typing import Any, Generic, Protocol, TypeVar
 
-from .codecs import SourceCodes
-from .models import (
-    APIVERSION_450_SERIES,
-    APIVERSION_AMP_DIAGNOSTICS_SERIES,
-    APIVERSION_APP_SAFETY_SERIES,
-    APIVERSION_AVR_AND_SA_SERIES,
-    APIVERSION_AVR_PRE_HDA_SERIES,
-    APIVERSION_AVR_SA_AND_ST_SERIES,
-    APIVERSION_AVR_SERIES,
-    APIVERSION_CLASS_G_SERIES,
-    APIVERSION_DAC_FILTER_SERIES,
-    APIVERSION_DIRECT_MODE_SERIES,
-    APIVERSION_HDA_MULTI_ZONE_SERIES,
-    APIVERSION_HDA_SERIES,
-    APIVERSION_IMAX_SERIES,
-    APIVERSION_NETWORK_MENU_SERIES,
-    APIVERSION_NETWORK_PLAYBACK_SERIES,
-    APIVERSION_NOW_PLAYING_SERIES,
-    APIVERSION_PHONO_SERIES,
-    APIVERSION_ROOM_EQ_NAMES_SERIES,
-    APIVERSION_ROOM_EQ_SERIES,
-    APIVERSION_SA_SERIES,
-    APIVERSION_SIMPLE_IP_SERIES,
-    APIVERSION_THERMAL_DIAGNOSTICS_SERIES,
-    ApiModel,
-    IntOrTypeEnum,
-)
+from .codecs import *  # noqa: F401,F403
+from .models import *  # noqa: F401,F403
+from .rc5 import *  # noqa: F401,F403
+
+
+__all__ = [
+    "CommandFlags",
+    "MUTE_WRITE_SUPPORTED",
+    "POWER_WRITE_SUPPORTED",
+    "SOURCE_WRITE_SUPPORTED",
+    "VOLUME_STEP_SUPPORTED",
+    "Command",
+    "CommandContext",
+    "Rc5Step",
+    "Rc5Write",
+    "ReadCommand",
+    "WriteCommand",
+    "StepCommand",
+    "ReadWriteCommand",
+    "ReadWriteStepCommand",
+    "ro",
+    "rw",
+    "rw_step",
+    "wo",
+    "proto",
+    "COMMANDS",
+    "command_for",
+]
+
 
 class CommandFlags(enum.IntFlag):
-    """Behavioural protocol traits of a command code."""
-
+    """Behavioral protocol traits consulted by the update loop and zone gating."""
     ZONE_SUPPORT = enum.auto()
     UPDATE = enum.auto()        # Fetched by the State update loop.
-    NOT_PUSHED = enum.auto()    # Device does not send unsolicited updates
+    NOT_PUSHED = enum.auto()    # Device does not send unsolicited updates.
 
 #: Models that accept a direct CC write for power on/off.
 POWER_WRITE_SUPPORTED = {
@@ -66,6 +73,7 @@ VOLUME_STEP_SUPPORTED = {
 }
 
 # Short aliases for the table below.
+_0 = CommandFlags(0)
 _Z = CommandFlags.ZONE_SUPPORT
 _U = CommandFlags.UPDATE
 _NP = CommandFlags.NOT_PUSHED
@@ -99,157 +107,281 @@ _TUN = frozenset({SourceCodes.FM, SourceCodes.DAB})
 _NET = frozenset({SourceCodes.NET, SourceCodes.USB, SourceCodes.NET_USB})
 _BT = frozenset({SourceCodes.BT})
 
-class CommandCodes(IntOrTypeEnum):
-    """Per-command protocol metadata.
 
-    Each member is ``(cc_byte, version_set | None, flags, sources)``. The
-    ``version`` field gates which device families support the command;
-    ``flags`` describe protocol behaviour (UPDATE gates participation in
-    the update loop, NOT_PUSHED forces every-cycle polling); ``sources``
-    (when not None) restricts both the update loop and cached accessors
-    to a specific source set.
-    """
+# === Command machinery ===
 
-    flags: CommandFlags
-    sources: frozenset[SourceCodes] | None
+T = TypeVar("T")
 
-    @classmethod
-    def _create_member(cls, value):
-        pseudo_member = cls._value2member_map_.get(value, None)
-        if pseudo_member is None:
-            obj = int.__new__(cls, value)
-            obj._name_ = f"CODE_{value}"
-            obj._value_ = value
-            obj.version = None
-            obj.flags = CommandFlags(0)
-            obj.sources = None
-            pseudo_member = cls._value2member_map_.setdefault(value, obj)
-        return pseudo_member
 
-    def __new__(
-        cls,
-        value: int,
-        version: set[str] | None = None,
-        flags: CommandFlags | None = None,
-        sources: frozenset[SourceCodes] | None = None,
-    ):
-        obj = int.__new__(cls, value)
-        obj._value_ = value
-        obj.version = version
-        obj.flags = flags if flags is not None else CommandFlags(0)
-        obj.sources = sources
-        return obj
+@dataclass(frozen=True)
+class Rc5Write:
+    """RC5 fallback for a Set: direct CC write when the model is in
+    ``direct_supported``, otherwise the RC5 code for the value."""
+    table: dict
+    direct_supported: frozenset = field(default_factory=frozenset)
 
-    # fmt: off
-    # Name                            CC    Version     Flags             Sources
-    # ====                            ==    =======     =====             =======
 
-    # --- System ---
-    POWER                           = 0x00, None,       _Z | _U
-    DISPLAY_BRIGHTNESS              = 0x01, _AVR_SA_ST
-    HEADPHONES                      = 0x02, _AVR_SA,    _U
-    FMGENRE                         = 0x03, _AVR,       _Z | _U,          _FM
-    SOFTWARE_VERSION                = 0x04, None,       _U
-    RESTORE_FACTORY_DEFAULT         = 0x05, None
-    SAVE_RESTORE_COPY_OF_SETTINGS   = 0x06, _AVR
-    SIMULATE_RC5_IR_COMMAND         = 0x08, _AVR_SA_ST, _Z
-    DISPLAY_INFORMATION_TYPE        = 0x09, _AVR,       _Z | _U
+@dataclass(frozen=True)
+class Rc5Step:
+    """Inc/dec policy: step via direct CC (``inc_data`` / ``dec_data``) when the
+    model is in ``via_cc_supported``, otherwise the up/down RC5 code."""
+    table: dict
+    via_cc_supported: frozenset = field(default_factory=frozenset)
+    inc_data: bytes = b"\xF1"
+    dec_data: bytes = b"\xF2"
 
-    # --- Input ---
-    VIDEO_SELECTION                 = 0x0A, _PRE_HDA,   _U
-    SELECT_ANALOG_DIGITAL           = 0x0B, _AVR,       _Z
-    IMAX_ENHANCED                   = 0x0C, _IMAX,      _U          # was "Video input type" in 450 (SH256E); not AVR5 (SH289E)
 
-    # --- Output ---
-    VOLUME                          = 0x0D, _AVR_SA_ST, _Z | _U
-    MUTE                            = 0x0E, None,       _Z | _U
-    DIRECT_MODE_STATUS              = 0x0F, _DIRECT
-    DECODE_MODE_STATUS_2CH          = 0x10, _AVR,       _U
-    DECODE_MODE_STATUS_MCH          = 0x11, _AVR,       _U
-    RDS_INFORMATION                 = 0x12, _AVR,       _Z | _U,          _FM
-    VIDEO_OUTPUT_RESOLUTION         = 0x13, _AVR
+class CommandContext(Protocol):
+    """The slice of ``State`` that command write/step delegate into."""
+    @property
+    def api_model(self) -> ApiModel: ...
+    @property
+    def model(self) -> str | None: ...
+    def set_cached(self, cc: int, data: bytes | None) -> None: ...
+    def supported_on_source(self, command: Command[Any]) -> bool: ...
+    def get_rc5code(self, table: dict, value: Any) -> bytes: ...
+    async def request(self, command: Command[Any], data: bytes) -> bytes: ...
+    async def send_rc5(self, table: dict, value: Any) -> None: ...
 
-    # --- Menu / Tuner / Source ---
-    MENU                            = 0x14, _AVR,       _U
-    TUNER_PRESET                    = 0x15, _AVR,       _Z | _U,          _FM
-    TUNE                            = 0x16, _AVR,       _Z
-    DAB_STATION                     = 0x18, _AVR,       _Z | _U,          _DAB
-    DAB_PROGRAM_TYPE_CATEGORY       = 0x19, _AVR,       _Z
-    DLS_PDT_INFO                    = 0x1A, _AVR,       _Z | _U,          _DAB
-    PRESET_DETAIL                   = 0x1B, _AVR,       _Z | _U,          _TUN
-    NETWORK_PLAYBACK_STATUS         = 0x1C, _NET_PLAY,  _U | _NP,         _NET
-    CURRENT_SOURCE                  = 0x1D, _AVR_SA_ST, _Z | _U
-    HEADPHONES_OVERRIDE             = 0x1F, _AVR_SA,    _Z
 
-    # --- Extended (2.0) ---
-    INPUT_NAME                      = 0x20, _AVR
-    FM_SCAN                         = 0x23, _AVR
-    DAB_SCAN                        = 0x24, _AVR
-    HEARTBEAT                       = 0x25, None
-    REBOOT                          = 0x26, None
-    SETUP                           = 0x27, _HDA
-    INPUT_CONFIG                    = 0x28, _HDA
-    GENERAL_SETUP                   = 0x29, _HDA
-    SPEAKER_TYPES                   = 0x2A, _HDA
-    SPEAKER_DISTANCES               = 0x2B, _HDA
-    SPEAKER_LEVELS                  = 0x2C, _HDA
-    VIDEO_INPUTS                    = 0x2D, _HDA
-    HDMI_SETTINGS                   = 0x2E, _HDA
-    ZONE_SETTINGS                   = 0x2F, _HDA_MZ
-    NETWORK_MENU_INFO               = 0x30, _NET_MENU
-    BLUETOOTH_MENU_INFO             = 0x32, _HDA
-    ENGINEERING_MENU_INFO           = 0x33, _HDA
-    ROOM_EQ_NAMES                   = 0x34, _ROOM_NAM,  _U
+@dataclass(frozen=True, eq=False, repr=False)
+class Command(Generic[T]):
+    cc: int
+    version: set[str] | None = None
+    flags: CommandFlags = CommandFlags(0)
+    sources: frozenset[SourceCodes] | None = None
+    codec: Codec[T] | None = None
+    rc5_write: Rc5Write | None = None
+    rc5_step: Rc5Step | None = None
+    name: str = ""
 
-    # --- Setup / EQ ---
-    TREBLE_EQUALIZATION             = 0x35, _AVR,       _Z | _U
-    BASS_EQUALIZATION               = 0x36, _AVR,       _Z | _U
-    ROOM_EQUALIZATION               = 0x37, _ROOM_EQ,   _Z | _U
-    DOLBY_AUDIO                     = 0x38, _AVR,       _Z | _U     # was "Dolby Volume" in 450/860 (SH256E/SH274E)
-    DOLBY_LEVELER                   = 0x39, _PRE_HDA,   _Z          # removed from HDA (SH289E issue C.0)
-    DOLBY_VOLUME_CALIBRATION_OFFSET = 0x3A, _PRE_HDA,   _Z          # removed from HDA (SH289E issue C.0)
-    BALANCE                         = 0x3B, _AVR_SA,    _Z | _U
-    DOLBY_PLII_X_MUSIC_DIMENSION    = 0x3C, _450
-    DOLBY_PLII_X_MUSIC_CENTRE_WIDTH = 0x3D, _450
-    DOLBY_PLII_X_MUSIC_PANORAMA     = 0x3E, _450
-    SUBWOOFER_TRIM                  = 0x3F, _AVR,       _Z | _U
-    LIPSYNC_DELAY                   = 0x40, _AVR,       _Z | _U
-    COMPRESSION                     = 0x41, _AVR,       _Z | _U
+    def __repr__(self) -> str:
+        return self.name or f"CODE_0x{self.cc:02X}"
 
-    # --- Incoming Signal / Video ---
-    INCOMING_VIDEO_PARAMETERS       = 0x42, _AVR,       _U
-    INCOMING_AUDIO_FORMAT           = 0x43, _AVR,       _U
-    INCOMING_AUDIO_SAMPLE_RATE      = 0x44, _AVR_SA_ST, _U
-    SUB_STEREO_TRIM                 = 0x45, _AVR,       _U
-    VIDEO_BRIGHTNESS                = 0x46, _450
-    VIDEO_CONTRAST                  = 0x47, _450
-    VIDEO_COLOUR                    = 0x48, _450
-    VIDEO_FILM_MODE                 = 0x49, _450
-    VIDEO_EDGE_ENHANCEMENT          = 0x4A, _450
-    VIDEO_NOISE_REDUCTION           = 0x4C, _450
-    VIDEO_MPEG_NOISE_REDUCTION      = 0x4D, _450
-    ZONE_1_OSD_ON_OFF               = 0x4E, _AVR
-    VIDEO_OUTPUT_SWITCHING          = 0x4F, _AVR
-    BLUETOOTH_STATUS                = 0x50, _HDA,       _U | _NP,          _BT     # was "Output Frame Rate" in 450 (SH256E)
 
-    # --- Diagnostics / Amp Control ---
-    DC_OFFSET                       = 0x51, _THERM,     _U | _NP
-    SHORT_CIRCUIT_STATUS            = 0x52, _CLASS_G,   _U | _NP
-    FRIENDLY_NAME                   = 0x53, _SIMPLE_IP
-    IP_ADDRESS                      = 0x54, _SIMPLE_IP
-    TIMEOUT_COUNTER                 = 0x55, _AMP_DIAG
-    LIFTER_TEMPERATURE              = 0x56, _CLASS_G,   _U | _NP       # bug in PA720 1.8: no sensor id in response
-    OUTPUT_TEMPERATURE              = 0x57, _THERM,     _U | _NP       # bug in PA720 1.8: no sensor id in response
-    AUTO_SHUTDOWN_CONTROL           = 0x58, _AMP_DIAG
-    PHONO_INPUT_TYPE                = 0x59, _PHONO
-    INPUT_DETECT                    = 0x5A, _AMP_DIAG
-    PROCESSOR_MODE_INPUT            = 0x5B, _SA
-    PROCESSOR_MODE_VOLUME           = 0x5C, _SA                         # ST60 reuses 0x5C for Fixed Volume
-    SYSTEM_STATUS                   = 0x5D, _AMP_DIAG
-    SYSTEM_MODEL                    = 0x5E, _AMP_DIAG
-    DAC_FILTER                      = 0x61, _DAC_FILT                   # clashes with AMPLIFIER_MODE on PA240
-    NOW_PLAYING_INFO                = 0x64, _NOW_PLAY,  _Z | _U | _NP,    _NET
-    MAXIMUM_TURN_ON_VOLUME          = 0x65, _APP_SAFE
-    MAXIMUM_VOLUME                  = 0x66, _APP_SAFE
-    MAXIMUM_STREAMING_VOLUME        = 0x67, _APP_SAFE
-    # fmt: on
+class ReadCommand(Command[T]):
+    """Read capability: ``State.get`` accepts it. Decodes the cached payload."""
+    def read(
+        self,
+        raw: bytes,
+        model: str | None = None,
+        source: SourceCodes | None = None,
+    ) -> T | None:
+        assert self.codec is not None
+        return self.codec.decode_for_context(raw, model, source)
+
+
+class WriteCommand(Command[T]):
+    """Write capability: ``State.set`` accepts it; direct CC or RC5 fallback."""
+    async def write(self, context: CommandContext, value: T) -> None:
+        if not context.supported_on_source(self) or self.codec is None:
+            return
+        write = self.rc5_write
+        if write is not None and context.api_model not in write.direct_supported:
+            await context.send_rc5(write.table, value)
+        else:
+            data = self.codec.encode_for_model(value, context.model)
+            await context.request(self, data)
+
+
+class StepCommand(Command[T]):
+    """Step capability: ``State.inc`` / ``dec`` accept it."""
+    async def step(self, context: CommandContext, increment: bool) -> None:
+        if not context.supported_on_source(self):
+            return
+        step = self.rc5_step
+        assert step is not None
+        if context.api_model in step.via_cc_supported:
+            await context.request(self, step.inc_data if increment else step.dec_data)
+        else:
+            await context.send_rc5(step.table, increment)
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class ReadWriteCommand(ReadCommand[T], WriteCommand[T]): ...
+
+@dataclass(frozen=True, eq=False, repr=False)
+class ReadWriteStepCommand(ReadCommand[T], WriteCommand[T], StepCommand[T]): ...
+
+
+def ro(cc: int, version: set[str] | None, flags: CommandFlags, codec: Codec[T],
+       sources: frozenset[SourceCodes] | None = None) -> ReadCommand[T]:
+    return ReadCommand(cc, version, flags, sources, codec)
+
+
+def wo(cc: int, version: set[str] | None, flags: CommandFlags, codec: Codec[T],
+       sources: frozenset[SourceCodes] | None = None, *, rc5: Rc5Write | None = None) -> WriteCommand[T]:
+    return WriteCommand(cc, version, flags, sources, codec, rc5_write=rc5)
+
+
+def rw(cc: int, version: set[str] | None, flags: CommandFlags, codec: Codec[T],
+       sources: frozenset[SourceCodes] | None = None, *, rc5: Rc5Write | None = None) -> ReadWriteCommand[T]:
+    return ReadWriteCommand(cc, version, flags, sources, codec, rc5_write=rc5)
+
+
+def rw_step(cc: int, version: set[str] | None, flags: CommandFlags, codec: Codec[T],
+            sources: frozenset[SourceCodes] | None = None, *, step: Rc5Step,
+            rc5: Rc5Write | None = None) -> ReadWriteStepCommand[T]:
+    return ReadWriteStepCommand(cc, version, flags, sources, codec, rc5_write=rc5, rc5_step=step)
+
+
+def proto(cc: int, version: set[str] | None = None, flags: CommandFlags = _0,
+          sources: frozenset[SourceCodes] | None = None) -> Command[Any]:
+    return Command(cc, version, flags, sources)
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class _PowerCommand(ReadWriteCommand[bool]):
+    """POWER: direct CC where supported, else RC5. Power-off seeds the cache
+    first, since the device may not answer promptly while shutting down."""
+    async def write(self, context: CommandContext, value: bool) -> None:
+        assert self.codec is not None and self.rc5_write is not None
+        if not value:
+            context.set_cached(self.cc, bytes([0]))
+        if context.api_model in POWER_WRITE_SUPPORTED:
+            await context.request(self, self.codec.encode(value))
+        else:
+            await context.send_rc5(self.rc5_write.table, value)
+
+
+def power(cc: int, version: set[str] | None, flags: CommandFlags, codec: Codec[bool],
+          *, rc5: Rc5Write) -> _PowerCommand:
+    return _PowerCommand(cc, version, flags, None, codec, rc5_write=rc5)
+
+
+# === The table ===
+# Name                            Type    CC    API         Flags          Codec / policy [, sources]
+
+# --- System ---
+POWER                           = power  (0x00, None,       _Z | _U,       BoolCodec(), rc5=Rc5Write(RC5CODE_POWER))
+DISPLAY_BRIGHTNESS              = rw     (0x01, _AVR_SA_ST, _U,            EnumCodec(DisplayBrightness), rc5=Rc5Write(RC5CODE_DISPLAY_BRIGHTNESS))
+HEADPHONES                      = ro     (0x02, _AVR_SA,    _U,            BoolCodec())
+FM_GENRE                        = ro     (0x03, _AVR,       _Z | _U,       StringCodec(), _FM)
+SOFTWARE_VERSION                = proto  (0x04, None,       _U)
+RESTORE_FACTORY_DEFAULT         = proto  (0x05)
+SAVE_RESTORE_COPY_OF_SETTINGS   = proto  (0x06, _AVR)
+SIMULATE_RC5_IR_COMMAND         = proto  (0x08, _AVR_SA_ST, _Z)
+DISPLAY_INFO_TYPE               = rw     (0x09, _AVR,       _Z | _U,       IntCodec())
+CURRENT_SOURCE                  = proto  (0x1D, _AVR_SA_ST, _Z | _U)
+HEADPHONES_OVERRIDE             = wo     (0x1F, _AVR_SA,    _Z,            BoolCodec())
+
+# --- Input ---
+VIDEO_SELECTION                 = rw     (0x0A, _PRE_HDA,   _U,            EnumCodec(VideoSelection))
+SELECT_ANALOG_DIGITAL           = proto  (0x0B, _AVR,       _Z)
+IMAX_ENHANCED                   = rw     (0x0C, _IMAX,      _U,            EnumCodec(ImaxEnhancedMode, set_map=IMAX_ENHANCED_SET_MAP))  # was "Video input type" in 450 (SH256E)
+
+# --- Output ---
+VOLUME                          = rw_step(0x0D, _AVR_SA_ST, _Z | _U,       IntCodec(), step=Rc5Step(RC5CODE_VOLUME, frozenset(VOLUME_STEP_SUPPORTED)))
+MUTE                            = rw     (0x0E, None,       _Z | _U,       BoolCodec(inverted=True), rc5=Rc5Write(RC5CODE_MUTE, frozenset(MUTE_WRITE_SUPPORTED)))
+DIRECT_MODE                     = rw     (0x0F, _DIRECT,    _U,            BoolCodec(), rc5=Rc5Write(RC5CODE_DIRECT_MODE))
+DECODE_MODE_2CH                 = rw     (0x10, _AVR,       _U,            EnumCodec(DecodeMode2CH), rc5=Rc5Write(RC5CODE_DECODE_MODE_2CH))
+DECODE_MODE_MCH                 = rw     (0x11, _AVR,       _U,            EnumCodec(DecodeModeMCH), rc5=Rc5Write(RC5CODE_DECODE_MODE_MCH))
+RDS_INFORMATION                 = ro     (0x12, _AVR,       _Z | _U,       StringCodec(), _FM)
+VIDEO_OUTPUT_RESOLUTION         = proto  (0x13, _AVR)
+
+# --- Menu / Tuner ---
+MENU                            = ro     (0x14, _AVR,       _U,            EnumCodec(MenuCodes))
+TUNER_PRESET                    = rw     (0x15, _AVR,       _Z | _U,       TunerPresetCodec(), _FM)
+TUNE                            = proto  (0x16, _AVR,       _Z)
+DAB_STATION                     = ro     (0x18, _AVR,       _Z | _U,       StringCodec(), _DAB)
+DAB_PROGRAM_TYPE_CATEGORY       = proto  (0x19, _AVR,       _Z | _U,       _DAB)
+DLS_PDT                         = ro     (0x1A, _AVR,       _Z | _U,       StringCodec(), _DAB)
+PRESET_DETAIL                   = proto  (0x1B, _AVR,       _Z | _U,       _TUN)
+NETWORK_PLAYBACK_STATUS         = ro     (0x1C, _NET_PLAY,  _U | _NP,      EnumCodec(NetworkPlaybackStatus), _NET)
+ROOM_EQ_NAMES                   = ro     (0x34, _ROOM_NAM,  _U,            RoomEqNamesCodec())
+
+# --- Extended (2.0) ---
+INPUT_NAME                      = proto  (0x20, _AVR)
+FM_SCAN                         = proto  (0x23, _AVR)
+DAB_SCAN                        = proto  (0x24, _AVR,       _0,            _DAB)
+HEARTBEAT                       = proto  (0x25)
+REBOOT                          = proto  (0x26)
+SETUP                           = proto  (0x27, _HDA)
+INPUT_CONFIG                    = proto  (0x28, _HDA)
+GENERAL_SETUP                   = proto  (0x29, _HDA)
+SPEAKER_TYPES                   = proto  (0x2A, _HDA)
+SPEAKER_DISTANCES               = proto  (0x2B, _HDA)
+SPEAKER_LEVELS                  = proto  (0x2C, _HDA)
+VIDEO_INPUTS                    = proto  (0x2D, _HDA)
+HDMI_SETTINGS                   = proto  (0x2E, _HDA)
+ZONE_SETTINGS                   = proto  (0x2F, _HDA_MZ)
+NETWORK_MENU_INFO               = proto  (0x30, _NET_MENU)
+BLUETOOTH_MENU_INFO             = proto  (0x32, _HDA)
+ENGINEERING_MENU_INFO           = proto  (0x33, _HDA)
+
+# --- Setup / EQ ---
+TREBLE_EQUALIZATION             = rw_step(0x35, _AVR,       _Z | _U,       ScaledCodec(-12.0, 12.0, 1.0), step=Rc5Step(RC5CODE_TREBLE))
+BASS_EQUALIZATION               = rw_step(0x36, _AVR,       _Z | _U,       ScaledCodec(-12.0, 12.0, 1.0), step=Rc5Step(RC5CODE_BASS))
+ROOM_EQUALIZATION               = rw     (0x37, _ROOM_EQ,   _Z | _U,       EnumCodec(RoomEqMode))
+DOLBY_AUDIO                     = rw     (0x38, _AVR,       _Z | _U,       EnumCodec(DolbyAudioMode))  # was "Dolby Volume" in 450/860 (SH256E/SH274E)
+DOLBY_LEVELER                   = rw     (0x39, _AVR,       _Z | _U,       IntCodec())  # per probe: AV41 still responds despite spec removal at SH289E issue C.0; 0xFF = off
+DOLBY_VOLUME_CALIBRATION_OFFSET = rw     (0x3A, _AVR,       _Z | _U,       ScaledCodec(-15.0, 15.0, 1.0))  # per probe: AV41 still responds despite spec removal
+BALANCE                         = rw_step(0x3B, _AVR_SA,    _Z | _U,       ScaledCodec(-6.0, 6.0, 1.0), step=Rc5Step(RC5CODE_BALANCE))
+DOLBY_PLIIX_DIMENSION           = rw_step(0x3C, _450,       _U,            IntCodec(), step=Rc5Step(RC5CODE_DOLBY_PLIIX_DIMENSION))
+DOLBY_PLIIX_CENTRE_WIDTH        = rw_step(0x3D, _450,       _U,            IntCodec(), step=Rc5Step(RC5CODE_DOLBY_PLIIX_CENTRE_WIDTH))
+DOLBY_PLIIX_PANORAMA            = rw     (0x3E, _450,       _U,            BoolCodec(), rc5=Rc5Write(RC5CODE_DOLBY_PLIIX_PANORAMA))
+SUBWOOFER_TRIM                  = rw_step(0x3F, _AVR,       _Z | _U,       ScaledCodec(-10.0, 10.0, 0.5), step=Rc5Step(RC5CODE_SUB_TRIM))
+LIPSYNC_DELAY                   = rw_step(0x40, _AVR,       _Z | _U,       ScaledCodec(0.0, 250.0, 5.0), step=Rc5Step(RC5CODE_LIPSYNC))
+COMPRESSION                     = rw     (0x41, _AVR,       _Z | _U,       EnumCodec(CompressionMode))
+
+# --- Incoming Signal / Video ---
+INCOMING_VIDEO_PARAMETERS       = ro     (0x42, _AVR,       _U,            StructCodec(VideoParameters.from_bytes))
+INCOMING_AUDIO_FORMAT           = proto  (0x43, _AVR,       _U)
+INCOMING_AUDIO_SAMPLE_RATE      = ro     (0x44, _AVR_SA_ST, _U,            SampleRateCodec())
+SUB_STEREO_TRIM                 = rw     (0x45, _AVR,       _U,            ScaledCodec(-10.0, 0.0, 0.5))
+VIDEO_BRIGHTNESS                = rw     (0x46, _450,       _U,            ScaledCodec(-50.0, 50.0, 1.0))
+VIDEO_CONTRAST                  = rw     (0x47, _450,       _U,            ScaledCodec(-50.0, 50.0, 1.0))
+VIDEO_COLOUR                    = rw     (0x48, _450,       _U,            ScaledCodec(-50.0, 50.0, 1.0))
+VIDEO_FILM_MODE                 = rw     (0x49, _450,       _U,            EnumCodec(VideoFilmMode))
+VIDEO_EDGE_ENHANCEMENT          = rw     (0x4A, _450,       _U,            IntCodec())  # 0–50
+VIDEO_NOISE_REDUCTION           = rw     (0x4C, _450,       _U,            EnumCodec(VideoNoiseReduction))
+VIDEO_MPEG_NOISE_REDUCTION      = rw     (0x4D, _450,       _U,            EnumCodec(VideoNoiseReduction))
+ZONE_1_OSD_ON_OFF               = rw     (0x4E, _AVR,       _U,            EnumCodec(ZoneOsd, set_map=ZONE_OSD_SET_MAP))
+VIDEO_OUTPUT_SWITCHING          = rw     (0x4F, _AVR,       _U,            EnumCodec(HdmiOutput))
+BLUETOOTH_STATUS                = proto  (0x50, _HDA,       _U | _NP,      _BT)  # was "Output Frame Rate" in 450 (SH256E)
+
+# --- Diagnostics / Amp Control ---
+DC_OFFSET                       = ro     (0x51, _THERM,     _U | _NP,      BoolCodec())  # True = DC offset detected
+SHORT_CIRCUIT_STATUS            = ro     (0x52, _CLASS_G,   _U | _NP,      BoolCodec())  # True = short circuit fault
+TIMEOUT_COUNTER                 = proto  (0x55, _AMP_DIAG)
+LIFTER_TEMPERATURE              = ro     (0x56, _CLASS_G,   _U | _NP,      TemperatureCodec())
+OUTPUT_TEMPERATURE              = ro     (0x57, _THERM,     _U | _NP,      TemperatureCodec())
+AUTO_SHUTDOWN_CONTROL           = rw     (0x58, _AMP_DIAG,  _U,            EnumCodec(AutoShutdown))
+
+# --- Status / Diagnostics ---
+FRIENDLY_NAME                   = rw     (0x53, _SIMPLE_IP, _U,            StringCodec())
+IP_ADDRESS                      = proto  (0x54, _SIMPLE_IP)  # 4-byte IP
+PHONO_INPUT_TYPE                = proto  (0x59, _PHONO)
+INPUT_DETECT                    = ro     (0x5A, _AMP_DIAG,  _U,            BoolCodec())
+PROCESSOR_MODE_INPUT            = rw     (0x5B, _SA,        _U,            SaProcessorModeCodec())
+PROCESSOR_MODE_VOLUME           = rw     (0x5C, _SA,        _U,            IntCodec())  # 0–99; ST60 reuses 0x5C for Fixed Volume
+SYSTEM_STATUS                   = proto  (0x5D, _AMP_DIAG)  # 0xF0 triggers bulk status dump
+SYSTEM_MODEL                    = ro     (0x5E, _AMP_DIAG,  _U,            StringCodec())
+DAC_FILTER                      = rw     (0x61, _DAC_FILT,  _U,            EnumCodec(DacFilter))  # clashes with AMPLIFIER_MODE on PA240
+NOW_PLAYING_INFO                = proto  (0x64, _NOW_PLAY,  _Z | _U | _NP, _NET)
+MAX_TURN_ON_VOLUME              = rw     (0x65, _APP_SAFE,  _U,            IntCodec())
+MAX_VOLUME                      = rw     (0x66, _APP_SAFE,  _U,            IntCodec())
+MAX_STREAMING_VOLUME            = rw     (0x67, _APP_SAFE,  _U,            IntCodec())
+# Undocumented (per probe of AV41 firmware 2.0.0); not in any published spec.
+UNKNOWN_F0                      = proto  (0xF0, _HDA)  # Returns single byte 0x01
+SERIAL_NUMBER                   = proto  (0xF1, _HDA)  # 16-byte ASCII device serial
+MAC_ADDRESS                     = proto  (0xF2, _HDA)  # 6-byte MAC address
+UNKNOWN_F3                      = proto  (0xF3, _HDA)  # Returns single byte 0x01
+
+
+# Name each command from its module global, then index by CC.
+_ALL: dict[str, Command[Any]] = {
+    _n: _v for _n, _v in list(globals().items()) if isinstance(_v, Command)
+}
+for _n, _v in _ALL.items():
+    object.__setattr__(_v, "name", _n)
+
+#: Every command, ordered by CC.
+COMMANDS: tuple[Command[Any], ...] = tuple(sorted(_ALL.values(), key=lambda c: c.cc))
+
+_BY_CODE: dict[int, Command[Any]] = {c.cc: c for c in COMMANDS}
+
+
+def command_for(cc: int) -> Command[Any] | None:
+    """The command with this CC byte, or None for an unknown code."""
+    return _BY_CODE.get(cc)

--- a/src/arcam/fmj/console.py
+++ b/src/arcam/fmj/console.py
@@ -6,31 +6,39 @@ from pprint import pprint
 
 from .codecs import (
     AnswerCodes,
-    CompressionMode,
-    DecodeMode2CH,
-    DecodeModeMCH,
-    DolbyAudioMode,
-    ImaxEnhancedMode,
+    BoolCodec,
+    EnumCodec,
     IncomingAudioConfig,
     IncomingAudioFormat,
     IncomingVideoAspectRatio,
     IncomingVideoColorspace,
-    RoomEqMode,
+    IntCodec,
+    ScaledCodec,
     SourceCodes,
+    StringCodec,
+    StructCodec,
     VideoParameters,
 )
-from .commands import CommandCodes
+from .commands import (
+    COMMANDS,
+    CURRENT_SOURCE,
+    INCOMING_AUDIO_FORMAT,
+    INCOMING_VIDEO_PARAMETERS,
+    POWER,
+    PRESET_DETAIL,
+    ReadCommand,
+    SIMULATE_RC5_IR_COMMAND,
+    TUNER_PRESET,
+    VOLUME,
+    WriteCommand,
+)
 from .errors import CommandInvalidAtThisTime, CommandNotRecognised
 from .models import (
     APIVERSION_AVR_SERIES,
     api_model_for,
 )
 from .packets import ResponsePacket
-from .rc5 import (
-    RC5CODE_DECODE_MODE_2CH,
-    RC5CODE_DECODE_MODE_MCH,
-    RC5CODE_SOURCE,
-)
+from .rc5 import RC5CODE_SOURCE
 from .client import Client, ClientSerial, ClientContext
 from .server import Server, ServerContext
 from .state import State
@@ -42,13 +50,57 @@ def auto_int(x):
     return int(x, 0)
 
 
-def auto_bytes(x):
-    print(x)
-    return bytes.decode(x)
-
-
 def auto_source(x):
     return SourceCodes[x]
+
+
+def _codec_argparse_kwargs(codec):
+    """Map a codec to argparse add_argument kwargs, or None if not CLI-settable."""
+    if isinstance(codec, BoolCodec):
+        return {"action": argparse.BooleanOptionalAction}
+    if isinstance(codec, IntCodec):
+        return {"type": int}
+    if isinstance(codec, EnumCodec):
+        cls = codec.enum_cls
+        by_name = {name.lower(): member for name, member in cls.__members__.items()}
+        return {
+            "type": lambda x, m=by_name: m[x.lower()],
+            "choices": list(cls),
+            "metavar": "MODE",
+        }
+    if isinstance(codec, ScaledCodec):
+        return {
+            "type": float,
+            "help": f"({codec.min_value} to {codec.max_value})",
+        }
+    if isinstance(codec, StringCodec):
+        return {}
+    return None
+
+
+def _codec_default_bytes(codec):
+    """A plausible default encoded value for a codec, for the dummy server store."""
+    if isinstance(codec, EnumCodec):
+        members = list(codec.enum_cls)
+        return bytes([int(members[0])]) if members else bytes([0x00])
+    if isinstance(codec, StringCodec):
+        return b"Default"
+    return bytes([0x00])
+
+
+def _register_settable_args(parser):
+    """Auto-register CLI arguments for the writable commands. Returns (stem, command) pairs."""
+    settable = []
+    for command in COMMANDS:
+        if not isinstance(command, WriteCommand):
+            continue
+        kwargs = _codec_argparse_kwargs(command.codec)
+        if kwargs is None:
+            continue
+        stem = command.name.lower()
+        parser.add_argument(f"--{stem.replace('_', '-')}", **kwargs)
+        settable.append((stem, command))
+    return settable
 
 
 parser = argparse.ArgumentParser(description="Communicate with arcam receivers.")
@@ -62,13 +114,8 @@ target.add_argument("--host")
 target.add_argument("--serial")
 parser_state.add_argument("--port", default=50000)
 parser_state.add_argument("--zone", default=1, type=int)
-parser_state.add_argument("--volume", type=int)
 parser_state.add_argument("--source", type=auto_source)
 parser_state.add_argument("--monitor", action="store_true")
-parser_state.add_argument("--power-on", action=argparse.BooleanOptionalAction)
-parser_state.add_argument("--power-off", action=argparse.BooleanOptionalAction)
-parser_state.add_argument("--room-eq-on", action=argparse.BooleanOptionalAction)
-parser_state.add_argument("--room-eq-off", action=argparse.BooleanOptionalAction)
 parser_state.add_argument(
     "--save-settings",
     action="store_true",
@@ -87,65 +134,8 @@ parser_state.add_argument(
     metavar=("D1", "D2", "D3", "D4"),
     help="Installer PIN for save/restore (default: 1 2 3 4)",
 )
-parser_state.add_argument(
-    "--room-eq",
-    type=lambda x: RoomEqMode[x.upper()],
-    choices=list(RoomEqMode),
-    help="Set room EQ mode (OFF, EQ1, EQ2, EQ3)",
-    metavar="MODE",
-)
-parser_state.add_argument("--lipsync", type=int, help="Set lip sync delay in ms")
-parser_state.add_argument(
-    "--subwoofer-trim",
-    type=float,
-    help="Set subwoofer trim in dB (-10 to +10)",
-)
-parser_state.add_argument("--bass", type=float, help="Set bass EQ in dB (-12 to +12)")
-parser_state.add_argument(
-    "--treble", type=float, help="Set treble EQ in dB (-12 to +12)"
-)
-parser_state.add_argument(
-    "--balance", type=float, help="Set balance (-6 to +6)"
-)
-parser_state.add_argument(
-    "--sub-stereo-trim",
-    type=float,
-    help="Set sub stereo trim in dB (-10 to 0)",
-)
-parser_state.add_argument(
-    "--dolby-audio",
-    type=lambda x: DolbyAudioMode[x.upper()],
-    choices=list(DolbyAudioMode),
-    help="Set Dolby Audio mode (OFF, MOVIE, MUSIC, NIGHT)",
-    metavar="MODE",
-)
-parser_state.add_argument(
-    "--compression",
-    type=lambda x: CompressionMode[x.upper()],
-    choices=list(CompressionMode),
-    help="Set compression (OFF, MEDIUM, HIGH)",
-    metavar="MODE",
-)
-parser_state.add_argument(
-    "--imax",
-    type=lambda x: ImaxEnhancedMode[x.upper()],
-    choices=list(ImaxEnhancedMode),
-    help="Set IMAX Enhanced mode (OFF, ON, AUTO)",
-    metavar="MODE",
-)
-parser_state.add_argument(
-    "--display-info", type=int, help="Set display info type (0xE0 to cycle)"
-)
-parser_state.add_argument(
-    "--show-audio",
-    action="store_true",
-    help="Show audio-related fields (format, sample rate, decode, Dirac, lipsync, subwoofer)",
-)
-parser_state.add_argument(
-    "--input-name",
-    action="store_true",
-    help="Query the user-configured input name",
-)
+
+_SETTABLE_COMMANDS = _register_settable_args(parser_state)
 
 parser_client = subparsers.add_parser("client")
 target = parser_client.add_mutually_exclusive_group(required=True)
@@ -170,7 +160,7 @@ async def run_client(args):
 
     async with ClientContext(client):
         result = await client.request(
-            args.zone, CommandCodes(args.command), bytes(args.data)
+            args.zone, args.command, bytes(args.data)
         )
         print(result)
 
@@ -193,56 +183,13 @@ async def run_state(args):
             await state.restore_settings(pin)
             print("Settings restored.")
 
-        if args.volume is not None:
-            await state.set_volume(args.volume)
-
         if args.source is not None:
             await state.set_source(args.source)
 
-        if args.power_on is not None:
-            await state.set_power(True)
-
-        if args.power_off is not None:
-            await state.set_power(False)
-
-        if args.room_eq_on is not None:
-            await state.set_room_equalization(RoomEqMode.EQ1)
-
-        if args.room_eq_off is not None:
-            await state.set_room_equalization(RoomEqMode.OFF)
-
-        if args.room_eq is not None:
-            await state.set_room_equalization(args.room_eq)
-
-        if args.lipsync is not None:
-            await state.set_lipsync_delay(args.lipsync)
-
-        if args.subwoofer_trim is not None:
-            await state.set_subwoofer_trim(args.subwoofer_trim)
-
-        if args.bass is not None:
-            await state.set_bass_equalization(args.bass)
-
-        if args.treble is not None:
-            await state.set_treble_equalization(args.treble)
-
-        if args.balance is not None:
-            await state.set_balance(args.balance)
-
-        if args.sub_stereo_trim is not None:
-            await state.set_sub_stereo_trim(args.sub_stereo_trim)
-
-        if args.dolby_audio is not None:
-            await state.set_dolby_audio(args.dolby_audio)
-
-        if args.compression is not None:
-            await state.set_compression(args.compression)
-
-        if args.imax is not None:
-            await state.set_imax_enhanced(args.imax)
-
-        if args.display_info is not None:
-            await state.set_display_info_type(args.display_info)
+        for stem, command in _SETTABLE_COMMANDS:
+            value = getattr(args, stem, None)
+            if value is not None:
+                await state.set(command, value)
 
         if args.monitor:
             updated = asyncio.Event()
@@ -269,28 +216,76 @@ async def run_server(args):
             self._api_version = api_model_for(model)
 
             rc5_key = (self._api_version, 1)
+            self._store = {}
+            self._rc5_reverse = {}
 
-            self._volume = bytes([10])
-            self._source = SourceCodes.PVR.to_bytes(self._api_version, 1)
-            self._video_parameters = VideoParameters(
+            for command in COMMANDS:
+                cc = command.cc
+                if isinstance(command.codec, StructCodec):
+                    continue
+
+                self._store[cc] = _codec_default_bytes(command.codec)
+
+                if isinstance(command, ReadCommand):
+                    self.register_handler(
+                        0x01, cc, bytes([0xF0]),
+                        lambda cc=cc, **kw: self._store[cc],
+                    )
+
+                if isinstance(command, WriteCommand):
+                    self.register_handler(
+                        0x01, cc, None,
+                        lambda data, cc=cc, **kw: self._set(cc, data),
+                    )
+
+                if command.rc5_write is not None:
+                    for value, code in command.rc5_write.table.get(rc5_key, {}).items():
+                        self._rc5_reverse[code] = (cc, command.codec.encode(value))
+
+            # Overrides for realistic defaults
+            self._store[POWER.cc] = bytes([0x01])
+            self._store[VOLUME.cc] = bytes([10])
+            self._store[TUNER_PRESET.cc] = b"\xff"
+
+            # CURRENT_SOURCE — no codec, manual handlers
+            self._store[CURRENT_SOURCE.cc] = SourceCodes.PVR.to_bytes(
+                self._api_version, 1
+            )
+            self.register_handler(
+                0x01, CURRENT_SOURCE.cc, bytes([0xF0]),
+                lambda **kw: self._store[CURRENT_SOURCE.cc],
+            )
+            source_table = RC5CODE_SOURCE.get(rc5_key, {})
+            for src, code in source_table.items():
+                self._rc5_reverse[code] = (
+                    CURRENT_SOURCE.cc,
+                    src.to_bytes(self._api_version, 1),
+                )
+
+            # INCOMING_VIDEO_PARAMETERS — StructCodec needs real data
+            self._store[INCOMING_VIDEO_PARAMETERS.cc] = VideoParameters(
                 horizontal_resolution=1920,
                 vertical_resolution=1080,
                 refresh_rate=60,
                 interlaced=False,
                 aspect_ratio=IncomingVideoAspectRatio.ASPECT_16_9,
                 colorspace=IncomingVideoColorspace.NORMAL,
+            ).to_bytes()
+            self.register_handler(
+                0x01, INCOMING_VIDEO_PARAMETERS.cc, bytes([0xF0]),
+                lambda **kw: self._store[INCOMING_VIDEO_PARAMETERS.cc],
             )
-            self._audio_format = bytes(
+
+            # INCOMING_AUDIO_FORMAT — no codec, manual handler
+            self._store[INCOMING_AUDIO_FORMAT.cc] = bytes(
                 [IncomingAudioFormat.PCM, IncomingAudioConfig.STEREO_ONLY]
             )
-            self._audio_sample_rate = bytes([0x02])  # 48000 Hz per SAMPLE_RATE_MAP
-            self._decode_mode_2ch = bytes(
-                [next(iter(RC5CODE_DECODE_MODE_2CH[rc5_key]))]
+            self.register_handler(
+                0x01, INCOMING_AUDIO_FORMAT.cc, bytes([0xF0]),
+                lambda **kw: self._store[INCOMING_AUDIO_FORMAT.cc],
             )
-            self._decode_mode_mch = bytes(
-                [next(iter(RC5CODE_DECODE_MODE_MCH[rc5_key]))]
-            )
-            self._tuner_preset = b"\xff"
+
+            # PRESET_DETAIL — custom lookup logic
             self._presets = {
                 b"\x01": b"\x03SR P1   ",
                 b"\x02": b"\x03SR Klass",
@@ -299,170 +294,51 @@ async def run_server(args):
                 b"\x05": b"\x02SR P4   ",
                 b"\x06": b"\x01jP",
             }
-
-            def invert_rc5(data):
-                return {value: key for key, value in data[rc5_key].items()}
-
-            self._source_rc5 = invert_rc5(RC5CODE_SOURCE)
-            self._decode_mode_2ch_rc5 = invert_rc5(RC5CODE_DECODE_MODE_2CH)
-            self._decode_mode_mch_rc5 = invert_rc5(RC5CODE_DECODE_MODE_MCH)
-
             self.register_handler(
-                0x01, CommandCodes.POWER, bytes([0xF0]), self.get_power
-            )
-            self.register_handler(
-                0x01, CommandCodes.VOLUME, bytes([0xF0]), self.get_volume
-            )
-            self.register_handler(0x01, CommandCodes.VOLUME, None, self.set_volume)
-            self.register_handler(
-                0x01, CommandCodes.CURRENT_SOURCE, bytes([0xF0]), self.get_source
-            )
-            self.register_handler(
-                0x01,
-                CommandCodes.INCOMING_VIDEO_PARAMETERS,
-                bytes([0xF0]),
-                self.get_incoming_video_parameters,
-            )
-            self.register_handler(
-                0x01,
-                CommandCodes.INCOMING_AUDIO_FORMAT,
-                bytes([0xF0]),
-                self.get_incoming_audio_format,
-            )
-            self.register_handler(
-                0x01,
-                CommandCodes.INCOMING_AUDIO_SAMPLE_RATE,
-                bytes([0xF0]),
-                self.get_incoming_audio_sample_rate,
-            )
-            self.register_handler(
-                0x01,
-                CommandCodes.DECODE_MODE_STATUS_2CH,
-                bytes([0xF0]),
-                self.get_decode_mode_2ch,
-            )
-            self.register_handler(
-                0x01,
-                CommandCodes.DECODE_MODE_STATUS_MCH,
-                bytes([0xF0]),
-                self.get_decode_mode_mch,
-            )
-            self.register_handler(
-                0x01, CommandCodes.SIMULATE_RC5_IR_COMMAND, None, self.ir_command
-            )
-            self.register_handler(
-                0x01, CommandCodes.PRESET_DETAIL, None, self.get_preset_detail
-            )
-            self.register_handler(
-                0x01, CommandCodes.TUNER_PRESET, bytes([0xF0]), self.get_tuner_preset
-            )
-            self.register_handler(
-                0x01, CommandCodes.TUNER_PRESET, None, self.set_tuner_preset
+                0x01, PRESET_DETAIL.cc, None, self._get_preset_detail,
             )
 
-        def get_power(self, **kwargs):
-            return bytes([1])
+            # TUNER_PRESET — write handler is auto-registered; seed read handler too
+            self.register_handler(
+                0x01, TUNER_PRESET.cc, bytes([0xF0]),
+                lambda **kw: self._store[TUNER_PRESET.cc],
+            )
 
-        def set_volume(self, data, **kwargs):
-            self._volume = data
-            return self._volume
+            # RC5 IR command handler (uses auto-built reverse table)
+            self.register_handler(
+                0x01, SIMULATE_RC5_IR_COMMAND.cc, None, self._ir_command,
+            )
 
-        def get_volume(self, **kwargs):
-            return self._volume
+        def _set(self, cc, data):
+            self._store[cc] = data
+            return data
 
-        def get_source(self, **kwargs):
-            return self._source
-
-        def set_source(self, data, **kwargs):
-            self._source = data
-            return self._source
-
-        def ir_command(self, data, **kwargs):
-            status = None
-
-            source = self._source_rc5.get(data)
-            if source:
-                self.set_source(bytes([source]))
+        def _ir_command(self, data, **kwargs):
+            result = self._rc5_reverse.get(data)
+            if result:
+                cc, encoded = result
+                self._store[cc] = encoded
                 return [
                     ResponsePacket(
                         zn=0x01,
-                        cc=CommandCodes.SIMULATE_RC5_IR_COMMAND,
+                        cc=SIMULATE_RC5_IR_COMMAND.cc,
                         ac=AnswerCodes.STATUS_UPDATE,
                         data=data,
                     ),
                     ResponsePacket(
                         zn=0x01,
-                        cc=CommandCodes.CURRENT_SOURCE,
+                        cc=cc,
                         ac=AnswerCodes.STATUS_UPDATE,
-                        data=bytes([source]),
+                        data=encoded,
                     ),
                 ]
-            decode_mode_2ch = self._decode_mode_2ch_rc5.get(data)
-            if decode_mode_2ch:
-                self._decode_mode_2ch = bytes([decode_mode_2ch])
-                return [
-                    ResponsePacket(
-                        zn=0x01,
-                        cc=CommandCodes.SIMULATE_RC5_IR_COMMAND,
-                        ac=AnswerCodes.STATUS_UPDATE,
-                        data=data,
-                    ),
-                    ResponsePacket(
-                        zn=0x01,
-                        cc=CommandCodes.DECODE_MODE_STATUS_2CH,
-                        ac=AnswerCodes.STATUS_UPDATE,
-                        data=self._decode_mode_2ch,
-                    ),
-                ]
-
-            decode_mode_mch = self._decode_mode_mch_rc5.get(data)
-            if decode_mode_mch:
-                self._decode_mode_mch = bytes([decode_mode_mch])
-                return [
-                    ResponsePacket(
-                        zn=0x01,
-                        cc=CommandCodes.SIMULATE_RC5_IR_COMMAND,
-                        ac=AnswerCodes.STATUS_UPDATE,
-                        data=data,
-                    ),
-                    ResponsePacket(
-                        zn=0x01,
-                        cc=CommandCodes.DECODE_MODE_STATUS_MCH,
-                        ac=AnswerCodes.STATUS_UPDATE,
-                        data=self._decode_mode_mch,
-                    ),
-                ]
-
             raise CommandNotRecognised()
 
-        def get_decode_mode_2ch(self, **kwargs):
-            return self._decode_mode_2ch
-
-        def get_decode_mode_mch(self, **kwargs):
-            return self._decode_mode_mch
-
-        def get_incoming_video_parameters(self, **kwargs):
-            return self._video_parameters.to_bytes()
-
-        def get_incoming_audio_format(self, **kwargs):
-            return self._audio_format
-
-        def get_incoming_audio_sample_rate(self, **kwargs):
-            return self._audio_sample_rate
-
-        def get_tuner_preset(self, **kwargs):
-            return self._tuner_preset
-
-        def set_tuner_preset(self, data, **kwargs):
-            self._tuner_preset = data
-            return self._tuner_preset
-
-        def get_preset_detail(self, data, **kwargs):
+        def _get_preset_detail(self, data, **kwargs):
             preset = self._presets.get(data)
             if preset:
                 return data + preset
-            else:
-                raise CommandInvalidAtThisTime()
+            raise CommandInvalidAtThisTime()
 
     server = DummyServer(args.host, args.port, args.model)
     async with ServerContext(server):

--- a/src/arcam/fmj/models.py
+++ b/src/arcam/fmj/models.py
@@ -287,3 +287,12 @@ class IntOrTypeEnum(enum.IntEnum):
         signed: bool = False,
     ) -> _T:  # type: ignore[override]
         return cls.from_int(int.from_bytes(bytes, byteorder=byteorder, signed=signed))
+
+    @classmethod
+    def from_bytes_for_model(
+        cls: type[_T], data: bytes, model: str | None
+    ) -> _T | None:
+        return cls.from_bytes(data)
+
+    def to_bytes_for_model(self, model: str | None) -> bytes:
+        return bytes([int(self)])

--- a/src/arcam/fmj/packets.py
+++ b/src/arcam/fmj/packets.py
@@ -20,7 +20,6 @@ from .errors import (
     NullPacket,
 )
 from .codecs import AnswerCodes
-from .commands import CommandCodes
 
 _LOGGER = logging.getLogger(__name__)
 _WRITE_TIMEOUT = 3
@@ -60,7 +59,7 @@ class ResponsePacket:
 
         return ResponsePacket(
             data[1],
-            CommandCodes.from_int(data[2]),
+            data[2],
             AnswerCodes.from_int(data[3]),
             data[5 : 5 + data[4]],
         )
@@ -103,7 +102,7 @@ class CommandPacket:
             raise InvalidPacket(f"Invalid length in data {data!r}")
 
         return CommandPacket(
-            data[1], CommandCodes.from_int(data[2]), data[4 : 4 + data[3]]
+            data[1], data[2], data[4 : 4 + data[3]]
         )
 
 @attr.s

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -233,6 +233,28 @@ class State:
             return self.model in cc.version
         return True
 
+    def _is_command_supported_on_source(self, cc: CommandCodes) -> bool:
+        """True iff `cc` has no source gate, the gate is satisfied, or the current source is unknown."""
+        if cc.sources is None:
+            return True
+        src = self.get_source()
+        return src is None or src in cc.sources
+
+    def _should_update(self, cc: CommandCodes) -> bool:
+        """Whether the update loop should fetch this command right now."""
+        if not self._is_command_supported(cc):
+            return False
+        if not (cc.flags & CommandFlags.ZONE_SUPPORT) and self._zn != 1:
+            return False
+        if not (cc.flags & CommandFlags.UPDATE):
+            return False
+        # Pushed commands are fetched only during the initial pass.
+        if not (cc.flags & CommandFlags.NOT_PUSHED) and self._updated.is_set():
+            return False
+        if not self._is_command_supported_on_source(cc):
+            return False
+        return True
+
     def _require_command(self, cc: CommandCodes) -> None:
         """Raise UnsupportedCommand if the command is not supported."""
         if not self._is_command_supported(cc):
@@ -659,33 +681,45 @@ class State:
             await self._send_rc5(RC5CODE_VOLUME, False)
 
     def get_dab_station(self) -> str | None:
+        if not self._is_command_supported_on_source(CommandCodes.DAB_STATION):
+            return None
         value = self._state.get(CommandCodes.DAB_STATION)
         if value is None:
             return None
         return value.decode("utf8", errors="replace").rstrip()
 
     def get_dls_pdt(self) -> str | None:
+        if not self._is_command_supported_on_source(CommandCodes.DLS_PDT_INFO):
+            return None
         value = self._state.get(CommandCodes.DLS_PDT_INFO)
         if value is None:
             return None
         return value.decode("utf8", errors="replace").rstrip()
 
     def get_rds_information(self) -> str | None:
+        if not self._is_command_supported_on_source(CommandCodes.RDS_INFORMATION):
+            return None
         value = self._state.get(CommandCodes.RDS_INFORMATION)
         if value is None:
             return None
         return value.decode("utf8", errors="replace").rstrip()
 
     async def set_tuner_preset(self, preset: int) -> None:
+        if not self._is_command_supported_on_source(CommandCodes.TUNER_PRESET):
+            return
         await self._request(self._zn, CommandCodes.TUNER_PRESET, bytes([preset]))
 
     def get_tuner_preset(self) -> int | None:
+        if not self._is_command_supported_on_source(CommandCodes.TUNER_PRESET):
+            return None
         value = self._state.get(CommandCodes.TUNER_PRESET)
         if value is None or value == b"\xff":
             return None
         return int.from_bytes(value, "big")
 
-    def get_preset_details(self) -> dict[int, PresetDetail]:
+    def get_preset_details(self) -> dict[int, PresetDetail] | None:
+        if not self._is_command_supported_on_source(CommandCodes.PRESET_DETAIL):
+            return None
         return self._presets
 
     async def send_navigation(self, code: RC5CodeNavigation) -> None:
@@ -737,6 +771,8 @@ class State:
 
     def get_network_playback_status(self) -> NetworkPlaybackStatus | None:
         """Return the network playback status (stopped/transitioning/playing/paused)."""
+        if not self._is_command_supported_on_source(CommandCodes.NETWORK_PLAYBACK_STATUS):
+            return None
         value = self._state.get(CommandCodes.NETWORK_PLAYBACK_STATUS)
         if value is None:
             return None
@@ -744,12 +780,16 @@ class State:
 
     def get_now_playing(self) -> NowPlayingInfo | None:
         """Return now-playing metadata (HDA series, NET/BT sources)."""
+        if not self._is_command_supported_on_source(CommandCodes.NOW_PLAYING_INFO):
+            return None
         return self._now_playing
 
     def get_bluetooth_status(
         self,
     ) -> tuple[BluetoothAudioStatus, str] | tuple[None, None]:
         """Return Bluetooth audio status and track name (HDA series)."""
+        if not self._is_command_supported_on_source(CommandCodes.BLUETOOTH_STATUS):
+            return None, None
         value = self._state.get(CommandCodes.BLUETOOTH_STATUS)
         if value is None:
             return None, None
@@ -857,9 +897,7 @@ class State:
 
         tasks: list[UpdateTask] = []
         for cc in CommandCodes:
-            if not (cc.flags & CommandFlags.UPDATE):
-                continue
-            if not self._is_command_supported(cc):
+            if not self._should_update(cc):
                 continue
             if cc == CommandCodes.NOW_PLAYING_INFO:
                 tasks.append(_update_now_playing())

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -9,35 +9,35 @@ import attr
 from .codecs import (
     AnswerCodes,
     BluetoothAudioStatus,
-    CompressionMode,
     DecodeMode2CH,
     DecodeModeMCH,
-    DisplayBrightness,
-    DolbyAudioMode,
     HdmiOutput,
-    IMAX_ENHANCED_SET_MAP,
-    ImaxEnhancedMode,
     IncomingAudioConfig,
     IncomingAudioFormat,
-    MenuCodes,
-    NetworkPlaybackStatus,
     NowPlayingInfo,
     PresetDetail,
-    RoomEqMode,
-    SAMPLE_RATE_MAP,
     SAVE_RESTORE_CONFIRMATION,
     SaveRestoreSubCommand,
     SourceCodes,
-    VideoParameters,
-    VideoSelection,
 )
 from .commands import (
-    CommandCodes,
+    BLUETOOTH_STATUS,
+    COMMANDS,
+    CURRENT_SOURCE,
     CommandFlags,
-    MUTE_WRITE_SUPPORTED,
-    POWER_WRITE_SUPPORTED,
+    Command,
+    DECODE_MODE_2CH,
+    DECODE_MODE_MCH,
+    INCOMING_AUDIO_FORMAT,
+    INPUT_NAME,
+    NOW_PLAYING_INFO,
+    PRESET_DETAIL,
+    ReadCommand,
+    SAVE_RESTORE_COPY_OF_SETTINGS,
+    SIMULATE_RC5_IR_COMMAND,
     SOURCE_WRITE_SUPPORTED,
-    VOLUME_STEP_SUPPORTED,
+    StepCommand,
+    WriteCommand,
 )
 from .errors import (
     CommandInvalidAtThisTime,
@@ -59,28 +59,15 @@ from .packets import (
     ResponsePacket,
 )
 from .rc5 import (
-    RC5CODE_BALANCE,
-    RC5CODE_BASS,
     RC5CODE_COLOR,
     RC5CODE_DECODE_MODE_2CH,
     RC5CODE_DECODE_MODE_MCH,
-    RC5CODE_DIRECT_MODE,
-    RC5CODE_DISPLAY_BRIGHTNESS,
-    RC5CODE_DOLBY_PLIIX_CENTRE_WIDTH,
-    RC5CODE_DOLBY_PLIIX_DIMENSION,
-    RC5CODE_DOLBY_PLIIX_PANORAMA,
     RC5CODE_HDMI_OUTPUT,
-    RC5CODE_LIPSYNC,
     RC5CODE_MENU_ACCESS,
-    RC5CODE_MUTE,
     RC5CODE_NAVIGATION,
     RC5CODE_PLAYBACK,
-    RC5CODE_POWER,
     RC5CODE_SOURCE,
-    RC5CODE_SUB_TRIM,
     RC5CODE_TOGGLE,
-    RC5CODE_TREBLE,
-    RC5CODE_VOLUME,
     RC5CodeColor,
     RC5CodeMenuAccess,
     RC5CodeNavigation,
@@ -94,29 +81,6 @@ _LOGGER = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
-
-def _get_scaled_negative(data: bytes | None, min_value: float, max_value: float, scale: float) -> float | None:
-    if data is None:
-        return None
-
-    neg_limit = round(-min_value / scale) + 0x80
-    pos_limit = round(max_value / scale)
-
-    byte_val = int.from_bytes(data, "big")
-    if byte_val >= 0x81 and byte_val <= neg_limit:
-        return - (byte_val - 0x80) * scale
-    if byte_val >= 0x00 and byte_val <= pos_limit:
-        return  byte_val * scale
-    return None
-
-def _set_scaled(value: float, min_value: float, max_value: float, scale: float) -> bytes:
-    value = max(min_value, min(max_value, value))
-    value = round(value / scale)
-    if value >= 0:
-        return value
-    else:
-        return 0x80 - value
-
 class State:
     _state: dict[int, bytes | None]
     _presets: dict[int, PresetDetail]
@@ -128,7 +92,7 @@ class State:
         self._presets = dict()
         self._now_playing: NowPlayingInfo | None = None
         self._amxduet: AmxDuetResponse | None = None
-        self._unsupported_commands: set[CommandCodes] = set()
+        self._unsupported_commands: set[int] = set()
         self._updated = asyncio.Event()
 
     async def start(self) -> None:
@@ -149,57 +113,24 @@ class State:
         await self.stop()
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "POWER": self.get_power(),
-            "VOLUME": self.get_volume(),
-            "SOURCE": self.get_source(),
-            "MUTE": self.get_mute(),
-            "HEADPHONES": self.get_headphones(),
-            "MENU": self.get_menu(),
-            "DISPLAY_INFO_TYPE": self.get_display_info_type(),
-            "IMAX_ENHANCED": self.get_imax_enhanced(),
-            "INCOMING_VIDEO_PARAMETERS": self.get_incoming_video_parameters(),
-            "INCOMING_AUDIO_FORMAT": self.get_incoming_audio_format(),
-            "INCOMING_AUDIO_SAMPLE_RATE": self.get_incoming_audio_sample_rate(),
-            "DECODE_MODE_2CH": self.get_decode_mode_2ch(),
-            "DECODE_MODE_MCH": self.get_decode_mode_mch(),
-            "ROOM_EQUALIZATION": self.get_room_equalization(),
-            "ROOM_EQ_NAMES": self.get_room_eq_names(),
-            "DOLBY_AUDIO": self.get_dolby_audio(),
-            "BASS_EQUALIZATION": self.get_bass_equalization(),
-            "TREBLE_EQUALIZATION": self.get_treble_equalization(),
-            "BALANCE": self.get_balance(),
-            "LIPSYNC_DELAY": self.get_lipsync_delay(),
-            "SUBWOOFER_TRIM": self.get_subwoofer_trim(),
-            "SUB_STEREO_TRIM": self.get_sub_stereo_trim(),
-            "COMPRESSION": self.get_compression(),
-            "DAB_STATION": self.get_dab_station(),
-            "DLS_PDT": self.get_dls_pdt(),
-            "RDS_INFORMATION": self.get_rds_information(),
-            "TUNER_PRESET": self.get_tuner_preset(),
-            "PRESET_DETAIL": self.get_preset_details(),
-            "NETWORK_PLAYBACK_STATUS": self.get_network_playback_status(),
-            "NOW_PLAYING": self.get_now_playing(),
-            "BLUETOOTH_STATUS": self.get_bluetooth_status(),
+        """All readable state, keyed by command name."""
+        result: dict[str, Any] = {
+            command.name: self.get(command)
+            for command in COMMANDS
+            if isinstance(command, ReadCommand)
         }
+        result["SOURCE"] = self.get_source()
+        result["DECODE_MODE"] = self.get_decode_mode()
+        result["INCOMING_AUDIO_FORMAT"] = self.get_incoming_audio_format()
+        result["BLUETOOTH_STATUS"] = self.get_bluetooth_status()
+        result["NOW_PLAYING"] = self.get_now_playing()
+        result["PRESET_DETAIL"] = self.get_preset_details()
+        return result
 
     def __repr__(self) -> str:
         return "State ({}) Amx ({})".format(
             self.to_dict(), self._amxduet.values if self._amxduet else {}
         )
-
-    def _listen(self, packet: ResponsePacket | AmxDuetResponse) -> None:
-        if isinstance(packet, AmxDuetResponse):
-            self._amxduet = packet
-            return
-
-        if packet.zn != self._zn:
-            return
-
-        if packet.ac == AnswerCodes.STATUS_UPDATE:
-            self._state[packet.cc] = packet.data
-        else:
-            self._state[packet.cc] = None
 
     @property
     def zn(self) -> int:
@@ -222,613 +153,142 @@ class State:
         return None
 
     @property
-    def _api_model(self) -> ApiModel:
+    def api_model(self) -> ApiModel:
         return api_model_for(self.model)
 
-    def _is_command_supported(self, cc: CommandCodes) -> bool:
-        """Check if a command is supported by the current device."""
-        if cc in self._unsupported_commands:
-            return False
-        if cc.version is not None and self.model is not None:
-            return self.model in cc.version
-        return True
+    # --- Generic typed accessors ---
 
-    def _is_command_supported_on_source(self, cc: CommandCodes) -> bool:
-        """True iff `cc` has no source gate, the gate is satisfied, or the current source is unknown."""
-        if cc.sources is None:
+    def get(self, command: ReadCommand[_T]) -> _T | None:
+        if not self.supported_on_source(command):
+            return None
+        raw = self.get_cached(command.cc)
+        if raw is None:
+            return None
+        return command.read(raw)
+
+    async def set(self, command: WriteCommand[_T], value: _T) -> None:
+        await command.write(self, value)
+
+    async def inc(self, command: StepCommand[Any]) -> None:
+        await command.step(self, True)
+
+    async def dec(self, command: StepCommand[Any]) -> None:
+        await command.step(self, False)
+
+    # --- CommandContext: the surface typed commands call back into ---
+
+    def get_cached(self, cc: int) -> bytes | None:
+        return self._state.get(cc)
+
+    def set_cached(self, cc: int, data: bytes | None) -> None:
+        self._state[cc] = data
+
+    def supported_on_source(self, command: Command[Any]) -> bool:
+        """True iff `command` has no source gate, the gate is satisfied, or the source is unknown."""
+        if command.sources is None:
             return True
         src = self.get_source()
-        return src is None or src in cc.sources
-
-    def _should_update(self, cc: CommandCodes) -> bool:
-        """Whether the update loop should fetch this command right now."""
-        if not self._is_command_supported(cc):
-            return False
-        if not (cc.flags & CommandFlags.ZONE_SUPPORT) and self._zn != 1:
-            return False
-        if not (cc.flags & CommandFlags.UPDATE):
-            return False
-        # Pushed commands are fetched only during the initial pass.
-        if not (cc.flags & CommandFlags.NOT_PUSHED) and self._updated.is_set():
-            return False
-        if not self._is_command_supported_on_source(cc):
-            return False
-        return True
-
-    def _require_command(self, cc: CommandCodes) -> None:
-        """Raise UnsupportedCommand if the command is not supported."""
-        if not self._is_command_supported(cc):
-            raise UnsupportedCommand(cc=cc, model=self.model)
-
-    async def _request(self, zn: int, cc: CommandCodes, data: bytes, priority: int = 0) -> bytes:
-        """Check command support, then send a request."""
-        self._require_command(cc)
-        try:
-            return await self._client.request(zn, cc, data, priority)
-        except CommandNotRecognised:
-            _LOGGER.debug("Command not recognised, marking %s as unsupported", cc)
-            self._unsupported_commands.add(cc)
-            raise
+        return src is None or src in command.sources
 
     def get_rc5code(
         self, table: dict[tuple[ApiModel, int], dict[_T, bytes]], value: _T
     ) -> bytes:
-        lookup = table.get((self._api_model, self._zn))
+        lookup = table.get((self.api_model, self._zn))
         if not lookup:
             raise ValueError(
-                "Unkown mapping for model {} and zone {}".format(
-                    self._api_model, self._zn
-                )
+                "Unkown mapping for model {} and zone {}".format(self.api_model, self._zn)
             )
 
         command = lookup.get(value)
         if not command:
             raise ValueError(
                 "Unkown command for model {} and zone {} and value {}".format(
-                    self._api_model, self._zn, value
+                    self.api_model, self._zn, value
                 )
             )
         return command
 
-    async def _send_rc5(self, table: dict, value) -> None:
-        command = self.get_rc5code(table, value)
-        await self._request(
-            self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command
-        )
-
-    def get(self, cc):
-        return self._state[cc]
-
-    def get_incoming_video_parameters(self) -> VideoParameters | None:
-        value = self._state.get(CommandCodes.INCOMING_VIDEO_PARAMETERS)
-        if value is None:
-            return None
-        return VideoParameters.from_bytes(value)
-
-    def get_incoming_audio_format(
-        self,
-    ) -> tuple[IncomingAudioFormat, IncomingAudioConfig] | tuple[None, None]:
-        value = self._state.get(CommandCodes.INCOMING_AUDIO_FORMAT)
-        if value is None:
-            return None, None
-        return (
-            IncomingAudioFormat.from_int(value[0]),
-            IncomingAudioConfig.from_int(value[1]),
-        )
-
-    def get_incoming_audio_sample_rate(self) -> int | None:
-        value = self._state.get(CommandCodes.INCOMING_AUDIO_SAMPLE_RATE)
-        if value is None:
-            return None
-        return SAMPLE_RATE_MAP.get(value[0], 0)
-
-    def get_decode_mode_2ch(self) -> DecodeMode2CH | None:
-        value = self._state.get(CommandCodes.DECODE_MODE_STATUS_2CH)
-        if value is None:
-            return None
-        return DecodeMode2CH.from_bytes(value)
-
-    async def set_decode_mode_2ch(self, mode: DecodeMode2CH) -> None:
-        await self._send_rc5(RC5CODE_DECODE_MODE_2CH, mode)
-
-    def get_decode_mode_mch(self) -> DecodeModeMCH | None:
-        value = self._state.get(CommandCodes.DECODE_MODE_STATUS_MCH)
-        if value is None:
-            return None
-        return DecodeModeMCH.from_bytes(value)
-
-    async def set_decode_mode_mch(self, mode: DecodeModeMCH) -> None:
-        await self._send_rc5(RC5CODE_DECODE_MODE_MCH, mode)
-
-    def get_2ch(self) -> bool:
-        """Return if source is 2 channel or not."""
-        audio_format, _ = self.get_incoming_audio_format()
-        return bool(
-            audio_format
-            in (
-                IncomingAudioFormat.PCM,
-                IncomingAudioFormat.ANALOGUE_DIRECT,
-                IncomingAudioFormat.UNDETECTED,
-                None,
-            )
-        )
-
-    def get_decode_mode(self) -> DecodeModeMCH | DecodeMode2CH | None:
-        if self.get_2ch():
-            return self.get_decode_mode_2ch()
-        else:
-            return self.get_decode_mode_mch()
-
-    def get_decode_modes(
-        self,
-    ) -> list[DecodeModeMCH] | list[DecodeMode2CH] | None:
-        if self.get_2ch():
-            return list(RC5CODE_DECODE_MODE_2CH.get((self._api_model, self._zn), {}))
-        else:
-            return list(RC5CODE_DECODE_MODE_MCH.get((self._api_model, self._zn), {}))
-
-    async def set_decode_mode(self, mode: str | DecodeModeMCH | DecodeMode2CH) -> None:
-        if self.get_2ch():
-            if isinstance(mode, str):
-                mode = DecodeMode2CH[mode]
-            elif not isinstance(mode, DecodeMode2CH):
-                raise ValueError("Decode mode not supported at this time")
-            await self.set_decode_mode_2ch(mode)
-        else:
-            if isinstance(mode, str):
-                mode = DecodeModeMCH[mode]
-            elif not isinstance(mode, DecodeModeMCH):
-                raise ValueError("Decode mode not supported at this time")
-            await self.set_decode_mode_mch(mode)
-
-    async def set_direct_mode(self, on: bool) -> None:
-        await self._send_rc5(RC5CODE_DIRECT_MODE, on)
-
-    def get_power(self) -> bool | None:
-        value = self._state.get(CommandCodes.POWER)
-        if value is None:
-            return None
-        return int.from_bytes(value, "big") == 0x01
-
-    async def set_power(self, power: bool) -> None:
-        if self._api_model in POWER_WRITE_SUPPORTED:
-            bool_to_hex = 0x01 if power else 0x00
-            if not power:
-                self._state[CommandCodes.POWER] = bytes([0])
-            await self._request(self._zn, CommandCodes.POWER, bytes([bool_to_hex]))
-        else:
-            if power:
-                await self._send_rc5(RC5CODE_POWER, power)
-            else:
-                command = self.get_rc5code(RC5CODE_POWER, power)
-                # seed with a response, since device might not
-                # respond in timely fashion, so let's just
-                # assume we succeded until response come
-                # back.
-                self._state[CommandCodes.POWER] = bytes([0])
-                await self._client.request(
-                    self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command
-                )
-
-    def get_menu(self) -> MenuCodes | None:
-        value = self._state.get(CommandCodes.MENU)
-        if value is None:
-            return None
-        return MenuCodes.from_bytes(value)
-
-    def get_mute(self) -> bool | None:
-        value = self._state.get(CommandCodes.MUTE)
-        if value is None:
-            return None
-        return int.from_bytes(value, "big") == 0
-
-    async def set_mute(self, mute: bool) -> None:
-        if self._api_model in MUTE_WRITE_SUPPORTED:
-            bool_to_hex = 0x00 if mute else 0x01
-            await self._request(self._zn, CommandCodes.MUTE, bytes([bool_to_hex]))
-        else:
-            await self._send_rc5(RC5CODE_MUTE, mute)
-
-    def get_headphones(self) -> bool | None:
-        """Return whether headphones are connected."""
-        value = self._state.get(CommandCodes.HEADPHONES)
-        if value is None:
-            return None
-        return int.from_bytes(value, "big") == 0x01
-
-    def get_display_info_type(self) -> int | None:
-        """Return the current display information type."""
-        value = self._state.get(CommandCodes.DISPLAY_INFORMATION_TYPE)
-        if value is None:
-            return None
-        return int.from_bytes(value, "big")
-
-    async def set_display_info_type(self, info_type: int) -> None:
-        """Set the display information type. Use 0xE0 to cycle."""
-        await self._request(self._zn, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([info_type]))
-
-    async def set_display_brightness(self, level: DisplayBrightness) -> None:
-        await self._send_rc5(RC5CODE_DISPLAY_BRIGHTNESS, level)
-
-    def get_lipsync_delay(self) -> int | None:
-        """Return lip sync delay in milliseconds (0-250ms in 5ms steps)."""
-        data = self._state.get(CommandCodes.LIPSYNC_DELAY)
-        return _get_scaled_negative(data, 0.0, 250.0, 5.0)
-
-    async def set_lipsync_delay(self, delay_ms: int) -> None:
-        """Set lip sync delay in milliseconds (0-250ms in 5ms steps)."""
-        byte_val = _set_scaled(delay_ms, 0.0, 250.0, 5.0)
-        await self._request(self._zn, CommandCodes.LIPSYNC_DELAY, bytes([byte_val]))
-
-    async def inc_lipsync_delay(self) -> None:
-        await self._send_rc5(RC5CODE_LIPSYNC, True)
-
-    async def dec_lipsync_delay(self) -> None:
-        await self._send_rc5(RC5CODE_LIPSYNC, False)
-
-    def get_subwoofer_trim(self) -> float | None:
-        """Return subwoofer trim level in dB (-10 to +10 dB in 0.5dB steps)."""
-        data = self._state.get(CommandCodes.SUBWOOFER_TRIM)
-        return _get_scaled_negative(data, -10.0, 10.0, 0.5)
-
-    async def set_subwoofer_trim(self, trim_db: float) -> None:
-        """Set subwoofer trim level in dB (-10 to +10 dB in 0.5dB steps)."""
-        byte_val = _set_scaled(trim_db, -10.0, 10.0, 0.5)
-        await self._request(self._zn, CommandCodes.SUBWOOFER_TRIM, bytes([byte_val]))
-
-    async def inc_subwoofer_trim(self) -> None:
-        await self._send_rc5(RC5CODE_SUB_TRIM, True)
-
-    async def dec_subwoofer_trim(self) -> None:
-        await self._send_rc5(RC5CODE_SUB_TRIM, False)
-
-    def get_sub_stereo_trim(self) -> float | None:
-        """Return sub stereo trim level in dB (0 to -10 dB in 0.5dB steps)."""
-        data = self._state.get(CommandCodes.SUB_STEREO_TRIM)
-        return _get_scaled_negative(data, -10.0, 0.0, 0.5)
-
-    async def set_sub_stereo_trim(self, trim_db: float) -> None:
-        """Set sub stereo trim level in dB (0 to -10 dB in 0.5dB steps)."""
-        byte_val = _set_scaled(trim_db, -10.0, 0.0, 0.5)
-        await self._request(self._zn, CommandCodes.SUB_STEREO_TRIM, bytes([byte_val]))
-
-    def get_treble_equalization(self) -> float | None:
-        """Return treble equalization level in dB (-12 to +12 dB in 1dB steps)."""
-        data = self._state.get(CommandCodes.TREBLE_EQUALIZATION)
-        return _get_scaled_negative(data, -12.0, 12.0, 1.0)
-
-    async def set_treble_equalization(self, trim_db: float) -> None:
-        """Set treble equalization level in dB (-12 to +12 dB in 1dB steps)."""
-        byte_val = _set_scaled(trim_db, -12.0, 12.0, 1.0)
-        await self._request(self._zn, CommandCodes.TREBLE_EQUALIZATION, bytes([byte_val]))
-
-    async def inc_treble_equalization(self) -> None:
-        await self._send_rc5(RC5CODE_TREBLE, True)
-
-    async def dec_treble_equalization(self) -> None:
-        await self._send_rc5(RC5CODE_TREBLE, False)
-
-    def get_bass_equalization(self) -> float | None:
-        """Return bass equalization level in dB (-12 to +12 dB in 1dB steps)."""
-        data = self._state.get(CommandCodes.BASS_EQUALIZATION)
-        return _get_scaled_negative(data, -12.0, 12.0, 1.0)
-
-    async def set_bass_equalization(self, trim_db: float) -> None:
-        """Set bass equalization level in dB (-12 to +12 dB in 1dB steps)."""
-        byte_val = _set_scaled(trim_db, -12.0, 12.0, 1.0)
-        await self._request(self._zn, CommandCodes.BASS_EQUALIZATION, bytes([byte_val]))
-
-    async def inc_bass_equalization(self) -> None:
-        await self._send_rc5(RC5CODE_BASS, True)
-
-    async def dec_bass_equalization(self) -> None:
-        await self._send_rc5(RC5CODE_BASS, False)
-
-    def get_room_equalization(self) -> RoomEqMode | None:
-        """Return room equalization (DIRAC) mode."""
-        value = self._state.get(CommandCodes.ROOM_EQUALIZATION)
-        if value is None:
-            return None
-        return RoomEqMode.from_bytes(value)
-
-    async def set_room_equalization(self, mode: RoomEqMode) -> None:
-        """Set room equalization (DIRAC) mode."""
-        await self._request(self._zn, CommandCodes.ROOM_EQUALIZATION, bytes([mode]))
-
-    def get_room_eq_names(self) -> list[str] | None:
-        """Return user-defined names for the room EQ profiles."""
-        value = self._state.get(CommandCodes.ROOM_EQ_NAMES)
-        if value is None:
-            return None
-        names = []
-        for i in range(0, len(value), 20):
-            name = value[i:i + 20].decode("ascii", errors="replace").rstrip("\x00").strip()
-            names.append(name)
-        return names
-
-    def get_dolby_audio(self) -> DolbyAudioMode | None:
-        """Return the current Dolby Audio mode."""
-        value = self._state.get(CommandCodes.DOLBY_AUDIO)
-        if value is None:
-            return None
-        return DolbyAudioMode.from_bytes(value)
-
-    async def set_dolby_audio(self, mode: DolbyAudioMode) -> None:
-        """Set the Dolby Audio mode."""
-        await self._request(self._zn, CommandCodes.DOLBY_AUDIO, bytes([mode]))
-
-    async def inc_dolby_pliix_centre_width(self) -> None:
-        await self._send_rc5(RC5CODE_DOLBY_PLIIX_CENTRE_WIDTH, True)
-
-    async def dec_dolby_pliix_centre_width(self) -> None:
-        await self._send_rc5(RC5CODE_DOLBY_PLIIX_CENTRE_WIDTH, False)
-
-    async def inc_dolby_pliix_dimension(self) -> None:
-        await self._send_rc5(RC5CODE_DOLBY_PLIIX_DIMENSION, True)
-
-    async def dec_dolby_pliix_dimension(self) -> None:
-        await self._send_rc5(RC5CODE_DOLBY_PLIIX_DIMENSION, False)
-
-    async def set_dolby_pliix_panorama(self, on: bool) -> None:
-        await self._send_rc5(RC5CODE_DOLBY_PLIIX_PANORAMA, on)
-
-    def get_balance(self) -> float | None:
-        """Return balance level (-6 to +6 in 1dB steps)."""
-        data = self._state.get(CommandCodes.BALANCE)
-        return _get_scaled_negative(data, -6.0, 6.0, 1.0)
-
-    async def set_balance(self, value: float) -> None:
-        """Set balance level (-6 to +6 in 1dB steps)."""
-        byte_val = _set_scaled(value, -6.0, 6.0, 1.0)
-        await self._request(self._zn, CommandCodes.BALANCE, bytes([byte_val]))
-
-    async def inc_balance(self) -> None:
-        """Shift balance right."""
-        await self._send_rc5(RC5CODE_BALANCE, True)
-
-    async def dec_balance(self) -> None:
-        """Shift balance left."""
-        await self._send_rc5(RC5CODE_BALANCE, False)
-
-    def get_compression(self) -> CompressionMode | None:
-        """Return the dynamic range compression setting."""
-        value = self._state.get(CommandCodes.COMPRESSION)
-        if value is None:
-            return None
-        return CompressionMode.from_bytes(value)
-
-    async def set_compression(self, mode: CompressionMode) -> None:
-        """Set the dynamic range compression setting."""
-        await self._request(self._zn, CommandCodes.COMPRESSION, bytes([mode]))
-
-    def get_imax_enhanced(self) -> ImaxEnhancedMode | None:
-        """Return the IMAX Enhanced mode (HDA premium series)."""
-        value = self._state.get(CommandCodes.IMAX_ENHANCED)
-        if value is None:
-            return None
-        return ImaxEnhancedMode.from_bytes(value)
-
-    async def set_imax_enhanced(self, mode: ImaxEnhancedMode) -> None:
-        """Set the IMAX Enhanced mode (HDA premium series)."""
-        command_byte = IMAX_ENHANCED_SET_MAP[mode]
-        await self._request(self._zn, CommandCodes.IMAX_ENHANCED, bytes([command_byte]))
-
-    def get_video_selection(self) -> VideoSelection | None:
-        """Return the video input selection (pre-HDA AVR series)."""
-        value = self._state.get(CommandCodes.VIDEO_SELECTION)
-        if value is None:
-            return None
-        return VideoSelection.from_bytes(value)
-
-    async def set_video_selection(self, mode: VideoSelection) -> None:
-        """Set the video input selection (pre-HDA AVR series)."""
-        await self._request(
-            self._zn, CommandCodes.VIDEO_SELECTION, bytes([mode])
-        )
-
-    async def set_hdmi_output(self, output: HdmiOutput) -> None:
-        await self._send_rc5(RC5CODE_HDMI_OUTPUT, output)
-
-    def get_source(self) -> SourceCodes | None:
-        value = self._state.get(CommandCodes.CURRENT_SOURCE)
-        if value is None:
-            return None
+    async def request(self, command: Command[Any], data: bytes, priority: int = 0) -> bytes:
+        self._require_command(command)
         try:
-            return SourceCodes.from_bytes(value, self._api_model, self._zn)
-        except ValueError:
-            return None
-
-    def get_source_list(self) -> list[SourceCodes]:
-        return list(RC5CODE_SOURCE.get((self._api_model, self._zn), {}).keys())
-
-    async def get_input_name(self) -> str | None:
-        """Query the user-configured input name for the current source."""
-        try:
-            data = await self._request(self._zn, CommandCodes.INPUT_NAME, bytes([0xF0]))
-            return data.decode('utf-8', errors='replace').rstrip('\x00').strip()
-        except UnsupportedCommand:
+            return await self._client.request(self._zn, command.cc, data, priority)
+        except CommandNotRecognised:
+            _LOGGER.debug("Command not recognised, marking %s as unsupported", command)
+            self._unsupported_commands.add(command.cc)
             raise
-        except Exception as e:
-            _LOGGER.warning("Failed to get input name: %s", e)
-            return None
 
-    async def set_source(self, src: SourceCodes) -> None:
-        if self._api_model in SOURCE_WRITE_SUPPORTED:
-            value = src.to_bytes(self._api_model, self._zn)
-            await self._request(self._zn, CommandCodes.CURRENT_SOURCE, value)
-        else:
-            await self._send_rc5(RC5CODE_SOURCE, src)
+    async def send_rc5(self, table: dict, value: Any) -> None:
+        code = self.get_rc5code(table, value)
+        await self.request(SIMULATE_RC5_IR_COMMAND, code)
 
-    def get_volume(self) -> int | None:
-        value = self._state.get(CommandCodes.VOLUME)
-        if value is None:
-            return None
-        return int.from_bytes(value, "big")
+    # --- Internal helpers ---
 
-    async def set_volume(self, volume: int) -> None:
-        await self._request(self._zn, CommandCodes.VOLUME, bytes([volume]))
-
-    async def inc_volume(self) -> None:
-        if self._api_model in VOLUME_STEP_SUPPORTED:
-            await self._request(self._zn, CommandCodes.VOLUME, bytes([0xF1]))
-        else:
-            await self._send_rc5(RC5CODE_VOLUME, True)
-
-    async def dec_volume(self) -> None:
-        if self._api_model in VOLUME_STEP_SUPPORTED:
-            await self._request(self._zn, CommandCodes.VOLUME, bytes([0xF2]))
-        else:
-            await self._send_rc5(RC5CODE_VOLUME, False)
-
-    def get_dab_station(self) -> str | None:
-        if not self._is_command_supported_on_source(CommandCodes.DAB_STATION):
-            return None
-        value = self._state.get(CommandCodes.DAB_STATION)
-        if value is None:
-            return None
-        return value.decode("utf8", errors="replace").rstrip()
-
-    def get_dls_pdt(self) -> str | None:
-        if not self._is_command_supported_on_source(CommandCodes.DLS_PDT_INFO):
-            return None
-        value = self._state.get(CommandCodes.DLS_PDT_INFO)
-        if value is None:
-            return None
-        return value.decode("utf8", errors="replace").rstrip()
-
-    def get_rds_information(self) -> str | None:
-        if not self._is_command_supported_on_source(CommandCodes.RDS_INFORMATION):
-            return None
-        value = self._state.get(CommandCodes.RDS_INFORMATION)
-        if value is None:
-            return None
-        return value.decode("utf8", errors="replace").rstrip()
-
-    async def set_tuner_preset(self, preset: int) -> None:
-        if not self._is_command_supported_on_source(CommandCodes.TUNER_PRESET):
+    def _listen(self, packet: ResponsePacket | AmxDuetResponse) -> None:
+        if isinstance(packet, AmxDuetResponse):
+            self._amxduet = packet
             return
-        await self._request(self._zn, CommandCodes.TUNER_PRESET, bytes([preset]))
 
-    def get_tuner_preset(self) -> int | None:
-        if not self._is_command_supported_on_source(CommandCodes.TUNER_PRESET):
-            return None
-        value = self._state.get(CommandCodes.TUNER_PRESET)
-        if value is None or value == b"\xff":
-            return None
-        return int.from_bytes(value, "big")
+        if packet.zn != self._zn:
+            return
 
-    def get_preset_details(self) -> dict[int, PresetDetail] | None:
-        if not self._is_command_supported_on_source(CommandCodes.PRESET_DETAIL):
-            return None
-        return self._presets
-
-    async def send_navigation(self, code: RC5CodeNavigation) -> None:
-        await self._send_rc5(RC5CODE_NAVIGATION, code)
-
-    async def send_playback(self, code: RC5CodePlayback) -> None:
-        await self._send_rc5(RC5CODE_PLAYBACK, code)
-
-    async def send_toggle(self, code: RC5CodeToggle) -> None:
-        await self._send_rc5(RC5CODE_TOGGLE, code)
-
-    async def send_menu_access(self, code: RC5CodeMenuAccess) -> None:
-        await self._send_rc5(RC5CODE_MENU_ACCESS, code)
-
-    async def send_numeric(self, digit: int) -> None:
-        if not 0 <= digit <= 9:
-            raise ValueError(f"Digit must be 0-9, got {digit}")
-        if self.model and self.model not in APIVERSION_RC5_NUMERIC_SERIES:
-            raise ValueError(
-                f"Numeric RC5 not supported on {self.model}"
-            )
-        await self._request(
-            self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, digit])
-        )
-
-    async def send_color(self, color: RC5CodeColor) -> None:
-        await self._send_rc5(RC5CODE_COLOR, color)
-
-    async def save_settings(self, pin: tuple[int, int, int, int] = (1, 2, 3, 4)) -> None:
-        """Save a secure backup of device settings.
-
-        The PIN defaults to (1, 2, 3, 4), the factory default installer PIN.
-        """
-        await self._request(
-            1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
-            bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, *pin]),
-        )
-
-    async def restore_settings(self, pin: tuple[int, int, int, int] = (1, 2, 3, 4)) -> None:
-        """Restore settings from the secure backup.
-
-        The PIN defaults to (1, 2, 3, 4), the factory default installer PIN.
-        Raises CommandInvalidAtThisTime if no backup exists.
-        """
-        await self._request(
-            1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
-            bytes([SaveRestoreSubCommand.RESTORE, *SAVE_RESTORE_CONFIRMATION, *pin]),
-        )
-
-    def get_network_playback_status(self) -> NetworkPlaybackStatus | None:
-        """Return the network playback status (stopped/transitioning/playing/paused)."""
-        if not self._is_command_supported_on_source(CommandCodes.NETWORK_PLAYBACK_STATUS):
-            return None
-        value = self._state.get(CommandCodes.NETWORK_PLAYBACK_STATUS)
-        if value is None:
-            return None
-        return NetworkPlaybackStatus.from_bytes(value)
-
-    def get_now_playing(self) -> NowPlayingInfo | None:
-        """Return now-playing metadata (HDA series, NET/BT sources)."""
-        if not self._is_command_supported_on_source(CommandCodes.NOW_PLAYING_INFO):
-            return None
-        return self._now_playing
-
-    def get_bluetooth_status(
-        self,
-    ) -> tuple[BluetoothAudioStatus, str] | tuple[None, None]:
-        """Return Bluetooth audio status and track name (HDA series)."""
-        if not self._is_command_supported_on_source(CommandCodes.BLUETOOTH_STATUS):
-            return None, None
-        value = self._state.get(CommandCodes.BLUETOOTH_STATUS)
-        if value is None:
-            return None, None
-        status = BluetoothAudioStatus.from_int(value[0])
-        if len(value) > 1:
-            track = value[1:].decode("ascii", errors="replace").rstrip("\x00").strip()
+        if packet.ac == AnswerCodes.STATUS_UPDATE:
+            self._state[packet.cc] = packet.data
         else:
-            track = ""
-        return status, track
+            self._state[packet.cc] = None
+
+    def _is_command_supported(self, command: Command[Any]) -> bool:
+        if command.cc in self._unsupported_commands:
+            return False
+        if command.version is not None and self.model is not None:
+            return self.model in command.version
+        return True
+
+    def _should_update(self, command: Command[Any]) -> bool:
+        if not self._is_command_supported(command):
+            return False
+        if not (command.flags & CommandFlags.ZONE_SUPPORT) and self._zn != 1:
+            return False
+        if not (command.flags & CommandFlags.UPDATE):
+            return False
+        # Pushed commands are fetched only during the initial pass.
+        if not (command.flags & CommandFlags.NOT_PUSHED) and self._updated.is_set():
+            return False
+        if not self.supported_on_source(command):
+            return False
+        return True
+
+    def _require_command(self, command: Command[Any]) -> None:
+        if not self._is_command_supported(command):
+            raise UnsupportedCommand(cc=command, model=self.model)
+
+    # --- Update provider ---
 
     async def get_update_tasks(self) -> list[UpdateTask]:
-        """Return a list of update coroutines for the current device state.
-        """
+        """Return a list of update coroutines for the current device state."""
         priority = _UPDATE_PRIORITY
 
-        async def _update(cc: CommandCodes):
+        async def _update(command: Command[Any]):
             try:
-                data = await self._request(self._zn, cc, bytes([0xF0]), priority)
-                self._state[cc] = data
+                data = await self.request(command, bytes([0xF0]), priority)
+                self._state[command.cc] = data
             except UnsupportedZone:
-                _LOGGER.debug("Unsupported zone %s for %s", self._zn, cc)
+                _LOGGER.debug("Unsupported zone %s for %s", self._zn, command)
             except CommandNotRecognised:
-                self._state[cc] = None
+                self._state[command.cc] = None
             except ResponseException as e:
-                _LOGGER.debug("Response error skipping %s - %s", cc, e.ac)
-                self._state[cc] = None
+                _LOGGER.debug("Response error skipping %s - %s", command, e.ac)
+                self._state[command.cc] = None
             except NotConnectedException as e:
-                _LOGGER.debug("Not connected skipping %s", cc)
-                self._state[cc] = None
+                _LOGGER.debug("Not connected skipping %s", command)
+                self._state[command.cc] = None
             except TimeoutError:
-                _LOGGER.error("Timeout requesting %s", cc)
+                _LOGGER.error("Timeout requesting %s", command)
 
         async def _update_presets() -> None:
             presets = {}
             for preset in range(1, 51):
                 try:
-                    data = await self._request(
-                        self._zn, CommandCodes.PRESET_DETAIL, bytes([preset]), priority
-                    )
+                    data = await self.request(PRESET_DETAIL, bytes([preset]), priority)
                     if data != b"\x00":
                         presets[preset] = PresetDetail.from_bytes(data)
                 except CommandInvalidAtThisTime:
@@ -850,8 +310,8 @@ class State:
                 if "request" not in field.metadata:
                     continue
                 try:
-                    data = await self._request(
-                        self._zn, CommandCodes.NOW_PLAYING_INFO, bytes([field.metadata["request"]]), priority
+                    data = await self.request(
+                        NOW_PLAYING_INFO, bytes([field.metadata["request"]]), priority
                     )
                     kwargs[field.name] = field.metadata["converter"](data)
                 except CommandNotRecognised:
@@ -896,15 +356,15 @@ class State:
             await _update_amxduet()
 
         tasks: list[UpdateTask] = []
-        for cc in CommandCodes:
-            if not self._should_update(cc):
+        for command in COMMANDS:
+            if not self._should_update(command):
                 continue
-            if cc == CommandCodes.NOW_PLAYING_INFO:
+            if command is NOW_PLAYING_INFO:
                 tasks.append(_update_now_playing())
-            elif cc == CommandCodes.PRESET_DETAIL:
+            elif command is PRESET_DETAIL:
                 tasks.append(_update_presets())
             else:
-                tasks.append(_update(cc))
+                tasks.append(_update(command))
 
         if not self._updated.is_set():
             if not tasks:
@@ -927,3 +387,180 @@ class State:
         await wait_any(self._updated, self._client._disconnected)
         if self._client._disconnected.is_set():
             raise NotConnectedException()
+
+    # --- Manual accessors (ordered by CC) ---
+
+    # SAVE_RESTORE_COPY_OF_SETTINGS (0x06)
+    async def save_settings(self, pin: tuple[int, int, int, int] = (1, 2, 3, 4)) -> None:
+        """Save a secure backup of device settings.
+
+        The PIN defaults to (1, 2, 3, 4), the factory default installer PIN.
+        """
+        await self.request(
+            SAVE_RESTORE_COPY_OF_SETTINGS,
+            bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, *pin]),
+        )
+
+    async def restore_settings(self, pin: tuple[int, int, int, int] = (1, 2, 3, 4)) -> None:
+        """Restore settings from the secure backup.
+
+        The PIN defaults to (1, 2, 3, 4), the factory default installer PIN.
+        Raises CommandInvalidAtThisTime if no backup exists.
+        """
+        await self.request(
+            SAVE_RESTORE_COPY_OF_SETTINGS,
+            bytes([SaveRestoreSubCommand.RESTORE, *SAVE_RESTORE_CONFIRMATION, *pin]),
+        )
+
+    # SIMULATE_RC5_IR_COMMAND (0x08) — RC5 command senders
+    async def set_hdmi_output(self, output: HdmiOutput) -> None:
+        """Switch the HDMI output via RC5."""
+        await self.send_rc5(RC5CODE_HDMI_OUTPUT, output)
+
+    async def send_navigation(self, code: RC5CodeNavigation) -> None:
+        """Send a navigation RC5 command."""
+        await self.send_rc5(RC5CODE_NAVIGATION, code)
+
+    async def send_playback(self, code: RC5CodePlayback) -> None:
+        """Send a playback RC5 command."""
+        await self.send_rc5(RC5CODE_PLAYBACK, code)
+
+    async def send_toggle(self, code: RC5CodeToggle) -> None:
+        """Send a toggle RC5 command."""
+        await self.send_rc5(RC5CODE_TOGGLE, code)
+
+    async def send_menu_access(self, code: RC5CodeMenuAccess) -> None:
+        """Send a menu-access RC5 command."""
+        await self.send_rc5(RC5CODE_MENU_ACCESS, code)
+
+    async def send_numeric(self, digit: int) -> None:
+        """Send a numeric digit (0-9) via RC5."""
+        if not 0 <= digit <= 9:
+            raise ValueError(f"Digit must be 0-9, got {digit}")
+        if self.model and self.model not in APIVERSION_RC5_NUMERIC_SERIES:
+            raise ValueError(f"Numeric RC5 not supported on {self.model}")
+        await self.request(SIMULATE_RC5_IR_COMMAND, bytes([0x10, digit]))
+
+    async def send_color(self, color: RC5CodeColor) -> None:
+        """Send a color-button RC5 command."""
+        await self.send_rc5(RC5CODE_COLOR, color)
+
+    # DECODE_MODE_2CH (0x10) / DECODE_MODE_MCH (0x11) — composite helpers
+    def get_2ch(self) -> bool:
+        """Return whether the incoming audio is 2-channel."""
+        audio_format, _ = self.get_incoming_audio_format()
+        return bool(
+            audio_format
+            in (
+                IncomingAudioFormat.PCM,
+                IncomingAudioFormat.ANALOGUE_DIRECT,
+                IncomingAudioFormat.UNDETECTED,
+                None,
+            )
+        )
+
+    def get_decode_mode(self) -> DecodeModeMCH | DecodeMode2CH | None:
+        """Return the active decode mode for the current channel count."""
+        if self.get_2ch():
+            return self.get(DECODE_MODE_2CH)
+        else:
+            return self.get(DECODE_MODE_MCH)
+
+    def get_decode_modes(
+        self,
+    ) -> list[DecodeModeMCH] | list[DecodeMode2CH] | None:
+        """Return available decode modes for the current channel count."""
+        if self.get_2ch():
+            return list(RC5CODE_DECODE_MODE_2CH.get((self.api_model, self._zn), {}))
+        else:
+            return list(RC5CODE_DECODE_MODE_MCH.get((self.api_model, self._zn), {}))
+
+    async def set_decode_mode(self, mode: str | DecodeModeMCH | DecodeMode2CH) -> None:
+        """Set the decode mode, dispatching to 2CH or MCH by current channel count."""
+        if self.get_2ch():
+            if isinstance(mode, str):
+                mode = DecodeMode2CH[mode]
+            elif not isinstance(mode, DecodeMode2CH):
+                raise ValueError("Decode mode not supported at this time")
+            await self.set(DECODE_MODE_2CH, mode)
+        else:
+            if isinstance(mode, str):
+                mode = DecodeModeMCH[mode]
+            elif not isinstance(mode, DecodeModeMCH):
+                raise ValueError("Decode mode not supported at this time")
+            await self.set(DECODE_MODE_MCH, mode)
+
+    # PRESET_DETAIL (0x1B)
+    def get_preset_details(self) -> dict[int, PresetDetail] | None:
+        """Return the buffered preset detail map, or None when the current source isn't a tuner."""
+        if not self.supported_on_source(PRESET_DETAIL):
+            return None
+        return self._presets
+
+    # CURRENT_SOURCE (0x1D)
+    def get_source(self) -> SourceCodes | None:
+        """Return the currently selected source."""
+        value = self._state.get(CURRENT_SOURCE.cc)
+        if value is None:
+            return None
+        try:
+            return SourceCodes.from_bytes(value, self.api_model, self._zn)
+        except ValueError:
+            return None
+
+    def get_source_list(self) -> list[SourceCodes]:
+        """Return the list of sources available for this model and zone."""
+        return list(RC5CODE_SOURCE.get((self.api_model, self._zn), {}).keys())
+
+    async def set_source(self, src: SourceCodes) -> None:
+        """Select a source, using direct CC or RC5 per model support."""
+        if self.api_model in SOURCE_WRITE_SUPPORTED:
+            value = src.to_bytes(self.api_model, self._zn)
+            await self.request(CURRENT_SOURCE, value)
+        else:
+            await self.send_rc5(RC5CODE_SOURCE, src)
+
+    # INPUT_NAME (0x20)
+    async def get_input_name(self) -> str | None:
+        """Fetch the name of the currently selected input (uncached)."""
+        if not self.supported_on_source(INPUT_NAME):
+            return None
+        data = await self.request(INPUT_NAME, bytes([0xF0]))
+        return data.decode("utf-8", errors="replace").rstrip("\x00").strip()
+
+    # INCOMING_AUDIO_FORMAT (0x43)
+    def get_incoming_audio_format(
+        self,
+    ) -> tuple[IncomingAudioFormat, IncomingAudioConfig] | tuple[None, None]:
+        """Return the incoming audio format and config as a 2-tuple."""
+        value = self._state.get(INCOMING_AUDIO_FORMAT.cc)
+        if value is None:
+            return None, None
+        return (
+            IncomingAudioFormat.from_int(value[0]),
+            IncomingAudioConfig.from_int(value[1]),
+        )
+
+    # BLUETOOTH_STATUS (0x50)
+    def get_bluetooth_status(
+        self,
+    ) -> tuple[BluetoothAudioStatus, str] | tuple[None, None]:
+        """Return Bluetooth audio status and track name."""
+        if not self.supported_on_source(BLUETOOTH_STATUS):
+            return None, None
+        value = self._state.get(BLUETOOTH_STATUS.cc)
+        if value is None:
+            return None, None
+        status = BluetoothAudioStatus.from_int(value[0])
+        if len(value) > 1:
+            track = value[1:].decode("ascii", errors="replace").rstrip("\x00").strip()
+        else:
+            track = ""
+        return status, track
+
+    # NOW_PLAYING_INFO (0x64)
+    def get_now_playing(self) -> NowPlayingInfo | None:
+        """Return now-playing metadata (HDA series, NET/BT sources)."""
+        if not self.supported_on_source(NOW_PLAYING_INFO):
+            return None
+        return self._now_playing

--- a/src/arcam/fmj/state.py
+++ b/src/arcam/fmj/state.py
@@ -9,35 +9,38 @@ import attr
 from .codecs import (
     AnswerCodes,
     BluetoothAudioStatus,
-    CompressionMode,
     DecodeMode2CH,
     DecodeModeMCH,
-    DisplayBrightness,
-    DolbyAudioMode,
     HdmiOutput,
-    IMAX_ENHANCED_SET_MAP,
-    ImaxEnhancedMode,
     IncomingAudioConfig,
     IncomingAudioFormat,
-    MenuCodes,
-    NetworkPlaybackStatus,
     NowPlayingInfo,
     PresetDetail,
-    RoomEqMode,
-    SAMPLE_RATE_MAP,
     SAVE_RESTORE_CONFIRMATION,
     SaveRestoreSubCommand,
     SourceCodes,
-    VideoParameters,
-    VideoSelection,
+    TemperatureSensor,
 )
 from .commands import (
-    CommandCodes,
+    BLUETOOTH_STATUS,
+    COMMANDS,
+    CURRENT_SOURCE,
     CommandFlags,
-    MUTE_WRITE_SUPPORTED,
-    POWER_WRITE_SUPPORTED,
+    Command,
+    DECODE_MODE_2CH,
+    DECODE_MODE_MCH,
+    INCOMING_AUDIO_FORMAT,
+    INPUT_NAME,
+    LIFTER_TEMPERATURE,
+    NOW_PLAYING_INFO,
+    OUTPUT_TEMPERATURE,
+    PRESET_DETAIL,
+    ReadCommand,
+    SAVE_RESTORE_COPY_OF_SETTINGS,
+    SIMULATE_RC5_IR_COMMAND,
     SOURCE_WRITE_SUPPORTED,
-    VOLUME_STEP_SUPPORTED,
+    StepCommand,
+    WriteCommand,
 )
 from .errors import (
     CommandInvalidAtThisTime,
@@ -59,28 +62,15 @@ from .packets import (
     ResponsePacket,
 )
 from .rc5 import (
-    RC5CODE_BALANCE,
-    RC5CODE_BASS,
     RC5CODE_COLOR,
     RC5CODE_DECODE_MODE_2CH,
     RC5CODE_DECODE_MODE_MCH,
-    RC5CODE_DIRECT_MODE,
-    RC5CODE_DISPLAY_BRIGHTNESS,
-    RC5CODE_DOLBY_PLIIX_CENTRE_WIDTH,
-    RC5CODE_DOLBY_PLIIX_DIMENSION,
-    RC5CODE_DOLBY_PLIIX_PANORAMA,
     RC5CODE_HDMI_OUTPUT,
-    RC5CODE_LIPSYNC,
     RC5CODE_MENU_ACCESS,
-    RC5CODE_MUTE,
     RC5CODE_NAVIGATION,
     RC5CODE_PLAYBACK,
-    RC5CODE_POWER,
     RC5CODE_SOURCE,
-    RC5CODE_SUB_TRIM,
     RC5CODE_TOGGLE,
-    RC5CODE_TREBLE,
-    RC5CODE_VOLUME,
     RC5CodeColor,
     RC5CodeMenuAccess,
     RC5CodeNavigation,
@@ -94,34 +84,6 @@ _LOGGER = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
-
-def _get_byte(data: bytes | None) -> int | None:
-    if data is None or len(data) != 1:
-        return None
-    return data[0]
-
-def _get_scaled_negative(data: bytes | None, min_value: float, max_value: float, scale: float) -> float | None:
-    byte_val = _get_byte(data)
-    if byte_val is None:
-        return None
-
-    neg_limit = round(-min_value / scale) + 0x80
-    pos_limit = round(max_value / scale)
-
-    if byte_val >= 0x81 and byte_val <= neg_limit:
-        return - (byte_val - 0x80) * scale
-    if byte_val >= 0x00 and byte_val <= pos_limit:
-        return  byte_val * scale
-    return None
-
-def _set_scaled(value: float, min_value: float, max_value: float, scale: float) -> bytes:
-    value = max(min_value, min(max_value, value))
-    value = round(value / scale)
-    if value >= 0:
-        return value
-    else:
-        return 0x80 - value
-
 class State:
     _state: dict[int, bytes | None]
     _presets: dict[int, PresetDetail]
@@ -133,7 +95,7 @@ class State:
         self._presets = dict()
         self._now_playing: NowPlayingInfo | None = None
         self._amxduet: AmxDuetResponse | None = None
-        self._unsupported_commands: set[CommandCodes] = set()
+        self._unsupported_commands: set[int] = set()
         self._updated = asyncio.Event()
 
     async def start(self) -> None:
@@ -154,57 +116,24 @@ class State:
         await self.stop()
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "POWER": self.get_power(),
-            "VOLUME": self.get_volume(),
-            "SOURCE": self.get_source(),
-            "MUTE": self.get_mute(),
-            "HEADPHONES": self.get_headphones(),
-            "MENU": self.get_menu(),
-            "DISPLAY_INFO_TYPE": self.get_display_info_type(),
-            "IMAX_ENHANCED": self.get_imax_enhanced(),
-            "INCOMING_VIDEO_PARAMETERS": self.get_incoming_video_parameters(),
-            "INCOMING_AUDIO_FORMAT": self.get_incoming_audio_format(),
-            "INCOMING_AUDIO_SAMPLE_RATE": self.get_incoming_audio_sample_rate(),
-            "DECODE_MODE_2CH": self.get_decode_mode_2ch(),
-            "DECODE_MODE_MCH": self.get_decode_mode_mch(),
-            "ROOM_EQUALIZATION": self.get_room_equalization(),
-            "ROOM_EQ_NAMES": self.get_room_eq_names(),
-            "DOLBY_AUDIO": self.get_dolby_audio(),
-            "BASS_EQUALIZATION": self.get_bass_equalization(),
-            "TREBLE_EQUALIZATION": self.get_treble_equalization(),
-            "BALANCE": self.get_balance(),
-            "LIPSYNC_DELAY": self.get_lipsync_delay(),
-            "SUBWOOFER_TRIM": self.get_subwoofer_trim(),
-            "SUB_STEREO_TRIM": self.get_sub_stereo_trim(),
-            "COMPRESSION": self.get_compression(),
-            "DAB_STATION": self.get_dab_station(),
-            "DLS_PDT": self.get_dls_pdt(),
-            "RDS_INFORMATION": self.get_rds_information(),
-            "TUNER_PRESET": self.get_tuner_preset(),
-            "PRESET_DETAIL": self.get_preset_details(),
-            "NETWORK_PLAYBACK_STATUS": self.get_network_playback_status(),
-            "NOW_PLAYING": self.get_now_playing(),
-            "BLUETOOTH_STATUS": self.get_bluetooth_status(),
+        """All readable state, keyed by command name."""
+        result: dict[str, Any] = {
+            command.name: self.get(command)
+            for command in COMMANDS
+            if isinstance(command, ReadCommand)
         }
+        result["SOURCE"] = self.get_source()
+        result["DECODE_MODE"] = self.get_decode_mode()
+        result["INCOMING_AUDIO_FORMAT"] = self.get_incoming_audio_format()
+        result["BLUETOOTH_STATUS"] = self.get_bluetooth_status()
+        result["NOW_PLAYING"] = self.get_now_playing()
+        result["PRESET_DETAIL"] = self.get_preset_details()
+        return result
 
     def __repr__(self) -> str:
         return "State ({}) Amx ({})".format(
             self.to_dict(), self._amxduet.values if self._amxduet else {}
         )
-
-    def _listen(self, packet: ResponsePacket | AmxDuetResponse) -> None:
-        if isinstance(packet, AmxDuetResponse):
-            self._amxduet = packet
-            return
-
-        if packet.zn != self._zn:
-            return
-
-        if packet.ac == AnswerCodes.STATUS_UPDATE:
-            self._state[packet.cc] = packet.data
-        else:
-            self._state[packet.cc] = None
 
     @property
     def zn(self) -> int:
@@ -227,610 +156,151 @@ class State:
         return None
 
     @property
-    def _api_model(self) -> ApiModel:
+    def api_model(self) -> ApiModel:
         return api_model_for(self.model)
 
-    def _is_command_supported(self, cc: CommandCodes) -> bool:
-        """Check if a command is supported by the current device."""
-        if cc in self._unsupported_commands:
-            return False
-        if cc.version is not None and self.model is not None:
-            return self.model in cc.version
-        return True
+    # --- Generic typed accessors ---
 
-    def _is_command_supported_on_source(self, cc: CommandCodes) -> bool:
-        """True iff `cc` has no source gate, the gate is satisfied, or the current source is unknown."""
-        if cc.sources is None:
+    def get(self, command: ReadCommand[_T]) -> _T | None:
+        if not self.supported_on_source(command):
+            return None
+        raw = self.get_cached(command.cc)
+        if raw is None:
+            return None
+        return command.read(raw, self.model, self.get_source())
+
+    async def set(self, command: WriteCommand[_T], value: _T) -> None:
+        await command.write(self, value)
+
+    async def inc(self, command: StepCommand[Any]) -> None:
+        await command.step(self, True)
+
+    async def dec(self, command: StepCommand[Any]) -> None:
+        await command.step(self, False)
+
+    # --- CommandContext: the surface typed commands call back into ---
+
+    def get_cached(self, cc: int) -> bytes | None:
+        return self._state.get(cc)
+
+    def set_cached(self, cc: int, data: bytes | None) -> None:
+        self._state[cc] = data
+
+    def supported_on_source(self, command: Command[Any]) -> bool:
+        """True iff `command` has no source gate, the gate is satisfied, or the source is unknown."""
+        if command.sources is None:
             return True
         src = self.get_source()
-        return src is None or src in cc.sources
-
-    def _should_update(self, cc: CommandCodes) -> bool:
-        """Whether the update loop should fetch this command right now."""
-        if not self._is_command_supported(cc):
-            return False
-        if not (cc.flags & CommandFlags.ZONE_SUPPORT) and self._zn != 1:
-            return False
-        if not (cc.flags & CommandFlags.UPDATE):
-            return False
-        # Pushed commands are fetched only during the initial pass.
-        if not (cc.flags & CommandFlags.NOT_PUSHED) and self._updated.is_set():
-            return False
-        if not self._is_command_supported_on_source(cc):
-            return False
-        return True
-
-    def _require_command(self, cc: CommandCodes) -> None:
-        """Raise UnsupportedCommand if the command is not supported."""
-        if not self._is_command_supported(cc):
-            raise UnsupportedCommand(cc=cc, model=self.model)
-
-    async def _request(self, zn: int, cc: CommandCodes, data: bytes, priority: int = 0) -> bytes:
-        """Check command support, then send a request."""
-        self._require_command(cc)
-        try:
-            return await self._client.request(zn, cc, data, priority)
-        except CommandNotRecognised:
-            _LOGGER.debug("Command not recognised, marking %s as unsupported", cc)
-            self._unsupported_commands.add(cc)
-            raise
+        return src is None or src in command.sources
 
     def get_rc5code(
         self, table: dict[tuple[ApiModel, int], dict[_T, bytes]], value: _T
     ) -> bytes:
-        lookup = table.get((self._api_model, self._zn))
+        lookup = table.get((self.api_model, self._zn))
         if not lookup:
             raise ValueError(
-                "Unkown mapping for model {} and zone {}".format(
-                    self._api_model, self._zn
-                )
+                "Unkown mapping for model {} and zone {}".format(self.api_model, self._zn)
             )
 
         command = lookup.get(value)
         if not command:
             raise ValueError(
                 "Unkown command for model {} and zone {} and value {}".format(
-                    self._api_model, self._zn, value
+                    self.api_model, self._zn, value
                 )
             )
         return command
 
-    async def _send_rc5(self, table: dict, value) -> None:
-        command = self.get_rc5code(table, value)
-        await self._request(
-            self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command
-        )
+    async def request(self, command: Command[Any], data: bytes, priority: int = 0) -> bytes:
+        return await self._request(self._zn, command, data, priority)
 
-    def get(self, cc):
-        return self._state[cc]
-
-    def get_incoming_video_parameters(self) -> VideoParameters | None:
-        value = self._state.get(CommandCodes.INCOMING_VIDEO_PARAMETERS)
-        if value is None:
-            return None
-        return VideoParameters.from_bytes(value)
-
-    def get_incoming_audio_format(
-        self,
-    ) -> tuple[IncomingAudioFormat, IncomingAudioConfig] | tuple[None, None]:
-        value = self._state.get(CommandCodes.INCOMING_AUDIO_FORMAT)
-        if value is None or len(value) != 2:
-            return None, None
-        return (
-            IncomingAudioFormat.from_int(value[0]),
-            IncomingAudioConfig.from_int(value[1]),
-        )
-
-    def get_incoming_audio_sample_rate(self) -> int | None:
-        value = _get_byte(self._state.get(CommandCodes.INCOMING_AUDIO_SAMPLE_RATE))
-        if value is None:
-            return None
-        return SAMPLE_RATE_MAP.get(value, 0)
-
-    def get_decode_mode_2ch(self) -> DecodeMode2CH | None:
-        value = _get_byte(self._state.get(CommandCodes.DECODE_MODE_STATUS_2CH))
-        if value is None:
-            return None
-        return DecodeMode2CH.from_int(value)
-
-    async def set_decode_mode_2ch(self, mode: DecodeMode2CH) -> None:
-        await self._send_rc5(RC5CODE_DECODE_MODE_2CH, mode)
-
-    def get_decode_mode_mch(self) -> DecodeModeMCH | None:
-        value = _get_byte(self._state.get(CommandCodes.DECODE_MODE_STATUS_MCH))
-        if value is None:
-            return None
-        return DecodeModeMCH.from_int(value)
-
-    async def set_decode_mode_mch(self, mode: DecodeModeMCH) -> None:
-        await self._send_rc5(RC5CODE_DECODE_MODE_MCH, mode)
-
-    def get_2ch(self) -> bool:
-        """Return if source is 2 channel or not."""
-        audio_format, _ = self.get_incoming_audio_format()
-        return bool(
-            audio_format
-            in (
-                IncomingAudioFormat.PCM,
-                IncomingAudioFormat.ANALOGUE_DIRECT,
-                IncomingAudioFormat.UNDETECTED,
-                None,
-            )
-        )
-
-    def get_decode_mode(self) -> DecodeModeMCH | DecodeMode2CH | None:
-        if self.get_2ch():
-            return self.get_decode_mode_2ch()
-        else:
-            return self.get_decode_mode_mch()
-
-    def get_decode_modes(
-        self,
-    ) -> list[DecodeModeMCH] | list[DecodeMode2CH] | None:
-        if self.get_2ch():
-            return list(RC5CODE_DECODE_MODE_2CH.get((self._api_model, self._zn), {}))
-        else:
-            return list(RC5CODE_DECODE_MODE_MCH.get((self._api_model, self._zn), {}))
-
-    async def set_decode_mode(self, mode: str | DecodeModeMCH | DecodeMode2CH) -> None:
-        if self.get_2ch():
-            if isinstance(mode, str):
-                mode = DecodeMode2CH[mode]
-            elif not isinstance(mode, DecodeMode2CH):
-                raise ValueError("Decode mode not supported at this time")
-            await self.set_decode_mode_2ch(mode)
-        else:
-            if isinstance(mode, str):
-                mode = DecodeModeMCH[mode]
-            elif not isinstance(mode, DecodeModeMCH):
-                raise ValueError("Decode mode not supported at this time")
-            await self.set_decode_mode_mch(mode)
-
-    async def set_direct_mode(self, on: bool) -> None:
-        await self._send_rc5(RC5CODE_DIRECT_MODE, on)
-
-    def get_power(self) -> bool | None:
-        value = _get_byte(self._state.get(CommandCodes.POWER))
-        if value is None:
-            return None
-        return value == 0x01
-
-    async def set_power(self, power: bool) -> None:
-        if self._api_model in POWER_WRITE_SUPPORTED:
-            bool_to_hex = 0x01 if power else 0x00
-            if not power:
-                self._state[CommandCodes.POWER] = bytes([0])
-            await self._request(self._zn, CommandCodes.POWER, bytes([bool_to_hex]))
-        else:
-            if power:
-                await self._send_rc5(RC5CODE_POWER, power)
-            else:
-                command = self.get_rc5code(RC5CODE_POWER, power)
-                # seed with a response, since device might not
-                # respond in timely fashion, so let's just
-                # assume we succeded until response come
-                # back.
-                self._state[CommandCodes.POWER] = bytes([0])
-                await self._client.request(
-                    self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, command
-                )
-
-    def get_menu(self) -> MenuCodes | None:
-        value = _get_byte(self._state.get(CommandCodes.MENU))
-        if value is None:
-            return None
-        return MenuCodes.from_int(value)
-
-    def get_mute(self) -> bool | None:
-        value = _get_byte(self._state.get(CommandCodes.MUTE))
-        if value is None:
-            return None
-        return value == 0
-
-    async def set_mute(self, mute: bool) -> None:
-        if self._api_model in MUTE_WRITE_SUPPORTED:
-            bool_to_hex = 0x00 if mute else 0x01
-            await self._request(self._zn, CommandCodes.MUTE, bytes([bool_to_hex]))
-        else:
-            await self._send_rc5(RC5CODE_MUTE, mute)
-
-    def get_headphones(self) -> bool | None:
-        """Return whether headphones are connected."""
-        value = _get_byte(self._state.get(CommandCodes.HEADPHONES))
-        if value is None:
-            return None
-        return value == 0x01
-
-    def get_display_info_type(self) -> int | None:
-        """Return the current display information type."""
-        return _get_byte(self._state.get(CommandCodes.DISPLAY_INFORMATION_TYPE))
-
-    async def set_display_info_type(self, info_type: int) -> None:
-        """Set the display information type. Use 0xE0 to cycle."""
-        await self._request(self._zn, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([info_type]))
-
-    async def set_display_brightness(self, level: DisplayBrightness) -> None:
-        await self._send_rc5(RC5CODE_DISPLAY_BRIGHTNESS, level)
-
-    def get_lipsync_delay(self) -> int | None:
-        """Return lip sync delay in milliseconds (0-250ms in 5ms steps)."""
-        data = self._state.get(CommandCodes.LIPSYNC_DELAY)
-        return _get_scaled_negative(data, 0.0, 250.0, 5.0)
-
-    async def set_lipsync_delay(self, delay_ms: int) -> None:
-        """Set lip sync delay in milliseconds (0-250ms in 5ms steps)."""
-        byte_val = _set_scaled(delay_ms, 0.0, 250.0, 5.0)
-        await self._request(self._zn, CommandCodes.LIPSYNC_DELAY, bytes([byte_val]))
-
-    async def inc_lipsync_delay(self) -> None:
-        await self._send_rc5(RC5CODE_LIPSYNC, True)
-
-    async def dec_lipsync_delay(self) -> None:
-        await self._send_rc5(RC5CODE_LIPSYNC, False)
-
-    def get_subwoofer_trim(self) -> float | None:
-        """Return subwoofer trim level in dB (-10 to +10 dB in 0.5dB steps)."""
-        data = self._state.get(CommandCodes.SUBWOOFER_TRIM)
-        return _get_scaled_negative(data, -10.0, 10.0, 0.5)
-
-    async def set_subwoofer_trim(self, trim_db: float) -> None:
-        """Set subwoofer trim level in dB (-10 to +10 dB in 0.5dB steps)."""
-        byte_val = _set_scaled(trim_db, -10.0, 10.0, 0.5)
-        await self._request(self._zn, CommandCodes.SUBWOOFER_TRIM, bytes([byte_val]))
-
-    async def inc_subwoofer_trim(self) -> None:
-        await self._send_rc5(RC5CODE_SUB_TRIM, True)
-
-    async def dec_subwoofer_trim(self) -> None:
-        await self._send_rc5(RC5CODE_SUB_TRIM, False)
-
-    def get_sub_stereo_trim(self) -> float | None:
-        """Return sub stereo trim level in dB (0 to -10 dB in 0.5dB steps)."""
-        data = self._state.get(CommandCodes.SUB_STEREO_TRIM)
-        return _get_scaled_negative(data, -10.0, 0.0, 0.5)
-
-    async def set_sub_stereo_trim(self, trim_db: float) -> None:
-        """Set sub stereo trim level in dB (0 to -10 dB in 0.5dB steps)."""
-        byte_val = _set_scaled(trim_db, -10.0, 0.0, 0.5)
-        await self._request(self._zn, CommandCodes.SUB_STEREO_TRIM, bytes([byte_val]))
-
-    def get_treble_equalization(self) -> float | None:
-        """Return treble equalization level in dB (-12 to +12 dB in 1dB steps)."""
-        data = self._state.get(CommandCodes.TREBLE_EQUALIZATION)
-        return _get_scaled_negative(data, -12.0, 12.0, 1.0)
-
-    async def set_treble_equalization(self, trim_db: float) -> None:
-        """Set treble equalization level in dB (-12 to +12 dB in 1dB steps)."""
-        byte_val = _set_scaled(trim_db, -12.0, 12.0, 1.0)
-        await self._request(self._zn, CommandCodes.TREBLE_EQUALIZATION, bytes([byte_val]))
-
-    async def inc_treble_equalization(self) -> None:
-        await self._send_rc5(RC5CODE_TREBLE, True)
-
-    async def dec_treble_equalization(self) -> None:
-        await self._send_rc5(RC5CODE_TREBLE, False)
-
-    def get_bass_equalization(self) -> float | None:
-        """Return bass equalization level in dB (-12 to +12 dB in 1dB steps)."""
-        data = self._state.get(CommandCodes.BASS_EQUALIZATION)
-        return _get_scaled_negative(data, -12.0, 12.0, 1.0)
-
-    async def set_bass_equalization(self, trim_db: float) -> None:
-        """Set bass equalization level in dB (-12 to +12 dB in 1dB steps)."""
-        byte_val = _set_scaled(trim_db, -12.0, 12.0, 1.0)
-        await self._request(self._zn, CommandCodes.BASS_EQUALIZATION, bytes([byte_val]))
-
-    async def inc_bass_equalization(self) -> None:
-        await self._send_rc5(RC5CODE_BASS, True)
-
-    async def dec_bass_equalization(self) -> None:
-        await self._send_rc5(RC5CODE_BASS, False)
-
-    def get_room_equalization(self) -> RoomEqMode | None:
-        """Return room equalization (DIRAC) mode."""
-        value = _get_byte(self._state.get(CommandCodes.ROOM_EQUALIZATION))
-        if value is None:
-            return None
-        return RoomEqMode.from_int(value)
-
-    async def set_room_equalization(self, mode: RoomEqMode) -> None:
-        """Set room equalization (DIRAC) mode."""
-        await self._request(self._zn, CommandCodes.ROOM_EQUALIZATION, bytes([mode]))
-
-    def get_room_eq_names(self) -> list[str] | None:
-        """Return user-defined names for the room EQ profiles."""
-        value = self._state.get(CommandCodes.ROOM_EQ_NAMES)
-        if value is None:
-            return None
-        names = []
-        for i in range(0, len(value), 20):
-            name = value[i:i + 20].decode("ascii", errors="replace").rstrip("\x00").strip()
-            names.append(name)
-        return names
-
-    def get_dolby_audio(self) -> DolbyAudioMode | None:
-        """Return the current Dolby Audio mode."""
-        value = _get_byte(self._state.get(CommandCodes.DOLBY_AUDIO))
-        if value is None:
-            return None
-        return DolbyAudioMode.from_int(value)
-
-    async def set_dolby_audio(self, mode: DolbyAudioMode) -> None:
-        """Set the Dolby Audio mode."""
-        await self._request(self._zn, CommandCodes.DOLBY_AUDIO, bytes([mode]))
-
-    async def inc_dolby_pliix_centre_width(self) -> None:
-        await self._send_rc5(RC5CODE_DOLBY_PLIIX_CENTRE_WIDTH, True)
-
-    async def dec_dolby_pliix_centre_width(self) -> None:
-        await self._send_rc5(RC5CODE_DOLBY_PLIIX_CENTRE_WIDTH, False)
-
-    async def inc_dolby_pliix_dimension(self) -> None:
-        await self._send_rc5(RC5CODE_DOLBY_PLIIX_DIMENSION, True)
-
-    async def dec_dolby_pliix_dimension(self) -> None:
-        await self._send_rc5(RC5CODE_DOLBY_PLIIX_DIMENSION, False)
-
-    async def set_dolby_pliix_panorama(self, on: bool) -> None:
-        await self._send_rc5(RC5CODE_DOLBY_PLIIX_PANORAMA, on)
-
-    def get_balance(self) -> float | None:
-        """Return balance level (-6 to +6 in 1dB steps)."""
-        data = self._state.get(CommandCodes.BALANCE)
-        return _get_scaled_negative(data, -6.0, 6.0, 1.0)
-
-    async def set_balance(self, value: float) -> None:
-        """Set balance level (-6 to +6 in 1dB steps)."""
-        byte_val = _set_scaled(value, -6.0, 6.0, 1.0)
-        await self._request(self._zn, CommandCodes.BALANCE, bytes([byte_val]))
-
-    async def inc_balance(self) -> None:
-        """Shift balance right."""
-        await self._send_rc5(RC5CODE_BALANCE, True)
-
-    async def dec_balance(self) -> None:
-        """Shift balance left."""
-        await self._send_rc5(RC5CODE_BALANCE, False)
-
-    def get_compression(self) -> CompressionMode | None:
-        """Return the dynamic range compression setting."""
-        value = _get_byte(self._state.get(CommandCodes.COMPRESSION))
-        if value is None:
-            return None
-        return CompressionMode.from_int(value)
-
-    async def set_compression(self, mode: CompressionMode) -> None:
-        """Set the dynamic range compression setting."""
-        await self._request(self._zn, CommandCodes.COMPRESSION, bytes([mode]))
-
-    def get_imax_enhanced(self) -> ImaxEnhancedMode | None:
-        """Return the IMAX Enhanced mode (HDA premium series)."""
-        value = _get_byte(self._state.get(CommandCodes.IMAX_ENHANCED))
-        if value is None:
-            return None
-        return ImaxEnhancedMode.from_int(value)
-
-    async def set_imax_enhanced(self, mode: ImaxEnhancedMode) -> None:
-        """Set the IMAX Enhanced mode (HDA premium series)."""
-        command_byte = IMAX_ENHANCED_SET_MAP[mode]
-        await self._request(self._zn, CommandCodes.IMAX_ENHANCED, bytes([command_byte]))
-
-    def get_video_selection(self) -> VideoSelection | None:
-        """Return the video input selection (pre-HDA AVR series)."""
-        value = _get_byte(self._state.get(CommandCodes.VIDEO_SELECTION))
-        if value is None:
-            return None
-        return VideoSelection.from_int(value)
-
-    async def set_video_selection(self, mode: VideoSelection) -> None:
-        """Set the video input selection (pre-HDA AVR series)."""
-        await self._request(
-            self._zn, CommandCodes.VIDEO_SELECTION, bytes([mode])
-        )
-
-    async def set_hdmi_output(self, output: HdmiOutput) -> None:
-        await self._send_rc5(RC5CODE_HDMI_OUTPUT, output)
-
-    def get_source(self) -> SourceCodes | None:
-        value = self._state.get(CommandCodes.CURRENT_SOURCE)
-        if value is None:
-            return None
+    async def _request(
+        self, zn: int, command: Command[Any], data: bytes, priority: int = 0
+    ) -> bytes:
+        self._require_command(command)
         try:
-            return SourceCodes.from_bytes(value, self._api_model, self._zn)
-        except ValueError:
-            return None
-
-    def get_source_list(self) -> list[SourceCodes]:
-        return list(RC5CODE_SOURCE.get((self._api_model, self._zn), {}).keys())
-
-    async def get_input_name(self) -> str | None:
-        """Query the user-configured input name for the current source."""
-        try:
-            data = await self._request(self._zn, CommandCodes.INPUT_NAME, bytes([0xF0]))
-            return data.decode('utf-8', errors='replace').rstrip('\x00').strip()
-        except UnsupportedCommand:
+            return await self._client.request(zn, command.cc, data, priority)
+        except CommandNotRecognised:
+            _LOGGER.debug("Command not recognised, marking %s as unsupported", command)
+            self._unsupported_commands.add(command.cc)
             raise
-        except Exception as e:
-            _LOGGER.warning("Failed to get input name: %s", e)
-            return None
 
-    async def set_source(self, src: SourceCodes) -> None:
-        if self._api_model in SOURCE_WRITE_SUPPORTED:
-            value = src.to_bytes(self._api_model, self._zn)
-            await self._request(self._zn, CommandCodes.CURRENT_SOURCE, value)
-        else:
-            await self._send_rc5(RC5CODE_SOURCE, src)
+    async def send_rc5(self, table: dict, value: Any) -> None:
+        code = self.get_rc5code(table, value)
+        await self.request(SIMULATE_RC5_IR_COMMAND, code)
 
-    def get_volume(self) -> int | None:
-        return _get_byte(self._state.get(CommandCodes.VOLUME))
+    # --- Internal helpers ---
 
-    async def set_volume(self, volume: int) -> None:
-        await self._request(self._zn, CommandCodes.VOLUME, bytes([volume]))
-
-    async def inc_volume(self) -> None:
-        if self._api_model in VOLUME_STEP_SUPPORTED:
-            await self._request(self._zn, CommandCodes.VOLUME, bytes([0xF1]))
-        else:
-            await self._send_rc5(RC5CODE_VOLUME, True)
-
-    async def dec_volume(self) -> None:
-        if self._api_model in VOLUME_STEP_SUPPORTED:
-            await self._request(self._zn, CommandCodes.VOLUME, bytes([0xF2]))
-        else:
-            await self._send_rc5(RC5CODE_VOLUME, False)
-
-    def get_dab_station(self) -> str | None:
-        if not self._is_command_supported_on_source(CommandCodes.DAB_STATION):
-            return None
-        value = self._state.get(CommandCodes.DAB_STATION)
-        if value is None:
-            return None
-        return value.decode("utf8", errors="replace").rstrip()
-
-    def get_dls_pdt(self) -> str | None:
-        if not self._is_command_supported_on_source(CommandCodes.DLS_PDT_INFO):
-            return None
-        value = self._state.get(CommandCodes.DLS_PDT_INFO)
-        if value is None:
-            return None
-        return value.decode("utf8", errors="replace").rstrip()
-
-    def get_rds_information(self) -> str | None:
-        if not self._is_command_supported_on_source(CommandCodes.RDS_INFORMATION):
-            return None
-        value = self._state.get(CommandCodes.RDS_INFORMATION)
-        if value is None:
-            return None
-        return value.decode("utf8", errors="replace").rstrip()
-
-    async def set_tuner_preset(self, preset: int) -> None:
-        if not self._is_command_supported_on_source(CommandCodes.TUNER_PRESET):
+    def _listen(self, packet: ResponsePacket | AmxDuetResponse) -> None:
+        if isinstance(packet, AmxDuetResponse):
+            self._amxduet = packet
             return
-        await self._request(self._zn, CommandCodes.TUNER_PRESET, bytes([preset]))
 
-    def get_tuner_preset(self) -> int | None:
-        if not self._is_command_supported_on_source(CommandCodes.TUNER_PRESET):
-            return None
-        value = _get_byte(self._state.get(CommandCodes.TUNER_PRESET))
-        if value is None or value == 0xFF:
-            return None
-        return value
+        if packet.zn != self._zn:
+            return
 
-    def get_preset_details(self) -> dict[int, PresetDetail] | None:
-        if not self._is_command_supported_on_source(CommandCodes.PRESET_DETAIL):
-            return None
-        return self._presets
-
-    async def send_navigation(self, code: RC5CodeNavigation) -> None:
-        await self._send_rc5(RC5CODE_NAVIGATION, code)
-
-    async def send_playback(self, code: RC5CodePlayback) -> None:
-        await self._send_rc5(RC5CODE_PLAYBACK, code)
-
-    async def send_toggle(self, code: RC5CodeToggle) -> None:
-        await self._send_rc5(RC5CODE_TOGGLE, code)
-
-    async def send_menu_access(self, code: RC5CodeMenuAccess) -> None:
-        await self._send_rc5(RC5CODE_MENU_ACCESS, code)
-
-    async def send_numeric(self, digit: int) -> None:
-        if not 0 <= digit <= 9:
-            raise ValueError(f"Digit must be 0-9, got {digit}")
-        if self.model and self.model not in APIVERSION_RC5_NUMERIC_SERIES:
-            raise ValueError(
-                f"Numeric RC5 not supported on {self.model}"
-            )
-        await self._request(
-            self._zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, digit])
-        )
-
-    async def send_color(self, color: RC5CodeColor) -> None:
-        await self._send_rc5(RC5CODE_COLOR, color)
-
-    async def save_settings(self, pin: tuple[int, int, int, int] = (1, 2, 3, 4)) -> None:
-        """Save a secure backup of device settings.
-
-        The PIN defaults to (1, 2, 3, 4), the factory default installer PIN.
-        """
-        await self._request(
-            1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
-            bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, *pin]),
-        )
-
-    async def restore_settings(self, pin: tuple[int, int, int, int] = (1, 2, 3, 4)) -> None:
-        """Restore settings from the secure backup.
-
-        The PIN defaults to (1, 2, 3, 4), the factory default installer PIN.
-        Raises CommandInvalidAtThisTime if no backup exists.
-        """
-        await self._request(
-            1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
-            bytes([SaveRestoreSubCommand.RESTORE, *SAVE_RESTORE_CONFIRMATION, *pin]),
-        )
-
-    def get_network_playback_status(self) -> NetworkPlaybackStatus | None:
-        """Return the network playback status (stopped/transitioning/playing/paused)."""
-        if not self._is_command_supported_on_source(CommandCodes.NETWORK_PLAYBACK_STATUS):
-            return None
-        value = _get_byte(self._state.get(CommandCodes.NETWORK_PLAYBACK_STATUS))
-        if value is None:
-            return None
-        return NetworkPlaybackStatus.from_int(value)
-
-    def get_now_playing(self) -> NowPlayingInfo | None:
-        """Return now-playing metadata (HDA series, NET/BT sources)."""
-        if not self._is_command_supported_on_source(CommandCodes.NOW_PLAYING_INFO):
-            return None
-        return self._now_playing
-
-    def get_bluetooth_status(
-        self,
-    ) -> tuple[BluetoothAudioStatus, str] | tuple[None, None]:
-        """Return Bluetooth audio status and track name (HDA series)."""
-        if not self._is_command_supported_on_source(CommandCodes.BLUETOOTH_STATUS):
-            return None, None
-        value = self._state.get(CommandCodes.BLUETOOTH_STATUS)
-        if not value:
-            return None, None
-        status = BluetoothAudioStatus.from_int(value[0])
-        if len(value) > 1:
-            track = value[1:].decode("ascii", errors="replace").rstrip("\x00").strip()
+        if packet.ac == AnswerCodes.STATUS_UPDATE:
+            self._state[packet.cc] = packet.data
         else:
-            track = ""
-        return status, track
+            self._state[packet.cc] = None
+
+    def _is_command_supported(self, command: Command[Any]) -> bool:
+        if command.cc in self._unsupported_commands:
+            return False
+        if command.version is not None and self.model is not None:
+            return self.model in command.version
+        return True
+
+    def _should_update(self, command: Command[Any]) -> bool:
+        if not self._is_command_supported(command):
+            return False
+        if not (command.flags & CommandFlags.ZONE_SUPPORT) and self._zn != 1:
+            return False
+        if not (command.flags & CommandFlags.UPDATE):
+            return False
+        # Pushed commands are fetched only during the initial pass.
+        if not (command.flags & CommandFlags.NOT_PUSHED) and self._updated.is_set():
+            return False
+        if not self.supported_on_source(command):
+            return False
+        return True
+
+    def _require_command(self, command: Command[Any]) -> None:
+        if not self._is_command_supported(command):
+            raise UnsupportedCommand(cc=command, model=self.model)
+
+    # --- Update provider ---
 
     async def get_update_tasks(self) -> list[UpdateTask]:
-        """Return a list of update coroutines for the current device state.
-        """
+        """Return a list of update coroutines for the current device state."""
         priority = _UPDATE_PRIORITY
 
-        async def _update(cc: CommandCodes):
+        async def _update(command: Command[Any]):
             try:
-                data = await self._request(self._zn, cc, bytes([0xF0]), priority)
-                self._state[cc] = data
+                data = await self.request(command, bytes([0xF0]), priority)
+                self._state[command.cc] = data
             except UnsupportedZone:
-                _LOGGER.debug("Unsupported zone %s for %s", self._zn, cc)
+                _LOGGER.debug("Unsupported zone %s for %s", self._zn, command)
             except CommandNotRecognised:
-                self._state[cc] = None
+                self._state[command.cc] = None
             except ResponseException as e:
-                _LOGGER.debug("Response error skipping %s - %s", cc, e.ac)
-                self._state[cc] = None
+                _LOGGER.debug("Response error skipping %s - %s", command, e.ac)
+                self._state[command.cc] = None
             except NotConnectedException as e:
-                _LOGGER.debug("Not connected skipping %s", cc)
-                self._state[cc] = None
+                _LOGGER.debug("Not connected skipping %s", command)
+                self._state[command.cc] = None
             except TimeoutError:
-                _LOGGER.error("Timeout requesting %s", cc)
+                _LOGGER.error("Timeout requesting %s", command)
 
         async def _update_presets() -> None:
             presets = {}
             for preset in range(1, 51):
                 try:
-                    data = await self._request(
-                        self._zn, CommandCodes.PRESET_DETAIL, bytes([preset]), priority
-                    )
-                    detail = PresetDetail.from_bytes(data)
-                    if detail is not None:
-                        presets[preset] = detail
+                    data = await self.request(PRESET_DETAIL, bytes([preset]), priority)
+                    if data != b"\x00":
+                        detail = PresetDetail.from_bytes(data)
+                        if detail is not None:
+                            presets[preset] = detail
                 except CommandInvalidAtThisTime:
                     break
                 except CommandNotRecognised:
@@ -850,8 +320,8 @@ class State:
                 if "request" not in field.metadata:
                     continue
                 try:
-                    data = await self._request(
-                        self._zn, CommandCodes.NOW_PLAYING_INFO, bytes([field.metadata["request"]]), priority
+                    data = await self.request(
+                        NOW_PLAYING_INFO, bytes([field.metadata["request"]]), priority
                     )
                     kwargs[field.name] = field.metadata["converter"](data)
                 except CommandNotRecognised:
@@ -896,15 +366,15 @@ class State:
             await _update_amxduet()
 
         tasks: list[UpdateTask] = []
-        for cc in CommandCodes:
-            if not self._should_update(cc):
+        for command in COMMANDS:
+            if not self._should_update(command):
                 continue
-            if cc == CommandCodes.NOW_PLAYING_INFO:
+            if command is NOW_PLAYING_INFO:
                 tasks.append(_update_now_playing())
-            elif cc == CommandCodes.PRESET_DETAIL:
+            elif command is PRESET_DETAIL:
                 tasks.append(_update_presets())
             else:
-                tasks.append(_update(cc))
+                tasks.append(_update(command))
 
         if not self._updated.is_set():
             if not tasks:
@@ -927,3 +397,194 @@ class State:
         await wait_any(self._updated, self._client._disconnected)
         if self._client._disconnected.is_set():
             raise NotConnectedException()
+
+    # --- Manual accessors (ordered by CC) ---
+
+    # SAVE_RESTORE_COPY_OF_SETTINGS (0x06)
+    async def save_settings(self, pin: tuple[int, int, int, int] = (1, 2, 3, 4)) -> None:
+        """Save a secure backup of device settings.
+
+        The PIN defaults to (1, 2, 3, 4), the factory default installer PIN.
+        """
+        await self._request(
+            1,
+            SAVE_RESTORE_COPY_OF_SETTINGS,
+            bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, *pin]),
+        )
+
+    async def restore_settings(self, pin: tuple[int, int, int, int] = (1, 2, 3, 4)) -> None:
+        """Restore settings from the secure backup.
+
+        The PIN defaults to (1, 2, 3, 4), the factory default installer PIN.
+        Raises CommandInvalidAtThisTime if no backup exists.
+        """
+        await self._request(
+            1,
+            SAVE_RESTORE_COPY_OF_SETTINGS,
+            bytes([SaveRestoreSubCommand.RESTORE, *SAVE_RESTORE_CONFIRMATION, *pin]),
+        )
+
+    # SIMULATE_RC5_IR_COMMAND (0x08) — RC5 command senders
+    async def set_hdmi_output(self, output: HdmiOutput) -> None:
+        """Switch the HDMI output via RC5."""
+        await self.send_rc5(RC5CODE_HDMI_OUTPUT, output)
+
+    async def send_navigation(self, code: RC5CodeNavigation) -> None:
+        """Send a navigation RC5 command."""
+        await self.send_rc5(RC5CODE_NAVIGATION, code)
+
+    async def send_playback(self, code: RC5CodePlayback) -> None:
+        """Send a playback RC5 command."""
+        await self.send_rc5(RC5CODE_PLAYBACK, code)
+
+    async def send_toggle(self, code: RC5CodeToggle) -> None:
+        """Send a toggle RC5 command."""
+        await self.send_rc5(RC5CODE_TOGGLE, code)
+
+    async def send_menu_access(self, code: RC5CodeMenuAccess) -> None:
+        """Send a menu-access RC5 command."""
+        await self.send_rc5(RC5CODE_MENU_ACCESS, code)
+
+    async def send_numeric(self, digit: int) -> None:
+        """Send a numeric digit (0-9) via RC5."""
+        if not 0 <= digit <= 9:
+            raise ValueError(f"Digit must be 0-9, got {digit}")
+        if self.model and self.model not in APIVERSION_RC5_NUMERIC_SERIES:
+            raise ValueError(f"Numeric RC5 not supported on {self.model}")
+        await self.request(SIMULATE_RC5_IR_COMMAND, bytes([0x10, digit]))
+
+    async def send_color(self, color: RC5CodeColor) -> None:
+        """Send a color-button RC5 command."""
+        await self.send_rc5(RC5CODE_COLOR, color)
+
+    # DECODE_MODE_2CH (0x10) / DECODE_MODE_MCH (0x11) — composite helpers
+    def get_2ch(self) -> bool:
+        """Return whether the incoming audio is 2-channel."""
+        audio_format, _ = self.get_incoming_audio_format()
+        return bool(
+            audio_format
+            in (
+                IncomingAudioFormat.PCM,
+                IncomingAudioFormat.ANALOGUE_DIRECT,
+                IncomingAudioFormat.UNDETECTED,
+                None,
+            )
+        )
+
+    def get_decode_mode(self) -> DecodeModeMCH | DecodeMode2CH | None:
+        """Return the active decode mode for the current channel count."""
+        if self.get_2ch():
+            return self.get(DECODE_MODE_2CH)
+        else:
+            return self.get(DECODE_MODE_MCH)
+
+    def get_decode_modes(
+        self,
+    ) -> list[DecodeModeMCH] | list[DecodeMode2CH] | None:
+        """Return available decode modes for the current channel count."""
+        if self.get_2ch():
+            return list(RC5CODE_DECODE_MODE_2CH.get((self.api_model, self._zn), {}))
+        else:
+            return list(RC5CODE_DECODE_MODE_MCH.get((self.api_model, self._zn), {}))
+
+    async def set_decode_mode(self, mode: str | DecodeModeMCH | DecodeMode2CH) -> None:
+        """Set the decode mode, dispatching to 2CH or MCH by current channel count."""
+        if self.get_2ch():
+            if isinstance(mode, str):
+                mode = DecodeMode2CH[mode]
+            elif not isinstance(mode, DecodeMode2CH):
+                raise ValueError("Decode mode not supported at this time")
+            await self.set(DECODE_MODE_2CH, mode)
+        else:
+            if isinstance(mode, str):
+                mode = DecodeModeMCH[mode]
+            elif not isinstance(mode, DecodeModeMCH):
+                raise ValueError("Decode mode not supported at this time")
+            await self.set(DECODE_MODE_MCH, mode)
+
+    # PRESET_DETAIL (0x1B)
+    def get_preset_details(self) -> dict[int, PresetDetail] | None:
+        """Return the buffered preset detail map, or None when the current source isn't a tuner."""
+        if not self.supported_on_source(PRESET_DETAIL):
+            return None
+        return self._presets
+
+    # CURRENT_SOURCE (0x1D)
+    def get_source(self) -> SourceCodes | None:
+        """Return the currently selected source."""
+        value = self._state.get(CURRENT_SOURCE.cc)
+        if value is None:
+            return None
+        try:
+            return SourceCodes.from_bytes(value, self.api_model, self._zn)
+        except ValueError:
+            return None
+
+    def get_source_list(self) -> list[SourceCodes]:
+        """Return the list of sources available for this model and zone."""
+        return list(RC5CODE_SOURCE.get((self.api_model, self._zn), {}).keys())
+
+    async def set_source(self, src: SourceCodes) -> None:
+        """Select a source, using direct CC or RC5 per model support."""
+        if self.api_model in SOURCE_WRITE_SUPPORTED:
+            value = src.to_bytes(self.api_model, self._zn)
+            await self.request(CURRENT_SOURCE, value)
+        else:
+            await self.send_rc5(RC5CODE_SOURCE, src)
+
+    # INPUT_NAME (0x20)
+    async def get_input_name(self) -> str | None:
+        """Fetch the name of the currently selected input (uncached)."""
+        if not self.supported_on_source(INPUT_NAME):
+            return None
+        data = await self.request(INPUT_NAME, bytes([0xF0]))
+        return data.decode("utf-8", errors="replace").rstrip("\x00").strip()
+
+    # INCOMING_AUDIO_FORMAT (0x43)
+    def get_incoming_audio_format(
+        self,
+    ) -> tuple[IncomingAudioFormat, IncomingAudioConfig] | tuple[None, None]:
+        """Return the incoming audio format and config as a 2-tuple."""
+        value = self._state.get(INCOMING_AUDIO_FORMAT.cc)
+        if value is None or len(value) != 2:
+            return None, None
+        return (
+            IncomingAudioFormat.from_int(value[0]),
+            IncomingAudioConfig.from_int(value[1]),
+        )
+
+    # BLUETOOTH_STATUS (0x50)
+    def get_bluetooth_status(
+        self,
+    ) -> tuple[BluetoothAudioStatus, str] | tuple[None, None]:
+        """Return Bluetooth audio status and track name."""
+        if not self.supported_on_source(BLUETOOTH_STATUS):
+            return None, None
+        value = self._state.get(BLUETOOTH_STATUS.cc)
+        if not value:
+            return None, None
+        status = BluetoothAudioStatus.from_int(value[0])
+        if len(value) > 1:
+            track = value[1:].decode("ascii", errors="replace").rstrip("\x00").strip()
+        else:
+            track = ""
+        return status, track
+
+    async def get_lifter_temperature(
+        self, sensor: TemperatureSensor = TemperatureSensor.SENSOR_1
+    ) -> int | None:
+        data = await self.request(LIFTER_TEMPERATURE, bytes([sensor]))
+        return LIFTER_TEMPERATURE.read(data)
+
+    async def get_output_temperature(
+        self, sensor: TemperatureSensor = TemperatureSensor.SENSOR_1
+    ) -> int | None:
+        data = await self.request(OUTPUT_TEMPERATURE, bytes([sensor]))
+        return OUTPUT_TEMPERATURE.read(data)
+
+    # NOW_PLAYING_INFO (0x64)
+    def get_now_playing(self) -> NowPlayingInfo | None:
+        """Return now-playing metadata (HDA series, NET/BT sources)."""
+        if not self.supported_on_source(NOW_PLAYING_INFO):
+            return None
+        return self._now_playing

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1,0 +1,184 @@
+"""Tests for the codecs and the typed command catalogue.
+
+Covers:
+- Per-codec round-trip behavior (decode/encode), including sentinels
+- Catalogue coverage: every CommandCodes is either a typed Command or listed
+  as manual / protocol-only
+- Capability composition: read/write/step are derivable via isinstance
+"""
+from __future__ import annotations
+
+import pytest
+
+from arcam.fmj.codecs import (
+    BoolCodec,
+    DolbyAudioMode,
+    EnumCodec,
+    IMAX_ENHANCED_SET_MAP,
+    ImaxEnhancedMode,
+    IntCodec,
+    RoomEqNamesCodec,
+    SaProcessorModeCodec,
+    SampleRateCodec,
+    ScaledCodec,
+    SourceCodes,
+    StringCodec,
+    StructCodec,
+    TunerPresetCodec,
+)
+from arcam.fmj.commands import (
+    COMMANDS,
+    Command,
+    OUTPUT_TEMPERATURE,
+    ReadCommand,
+    StepCommand,
+    VOLUME,
+    WriteCommand,
+)
+
+
+# --- Per-codec round-trip ---
+
+
+def test_boolcodec_default():
+    s = BoolCodec()
+    assert s.decode(bytes([0x01])) is True
+    assert s.decode(bytes([0x00])) is False
+    assert s.encode(True) == bytes([0x01])
+    assert s.encode(False) == bytes([0x00])
+
+
+def test_boolcodec_inverted():
+    s = BoolCodec(inverted=True)
+    assert s.decode(bytes([0x00])) is True
+    assert s.decode(bytes([0x01])) is False
+    assert s.encode(True) == bytes([0x00])
+    assert s.encode(False) == bytes([0x01])
+
+
+def test_intcodec_roundtrip():
+    s = IntCodec()
+    for v in (0, 1, 127, 255):
+        assert s.decode(s.encode(v)) == v
+
+
+def test_enumcodec_symmetric():
+    s = EnumCodec(DolbyAudioMode)
+    assert s.decode(s.encode(DolbyAudioMode.MOVIE)) == DolbyAudioMode.MOVIE
+
+
+def test_enumcodec_asymmetric_set_map():
+    s = EnumCodec(ImaxEnhancedMode, set_map=IMAX_ENHANCED_SET_MAP)
+    # Decode uses the wire response codes
+    assert s.decode(bytes([ImaxEnhancedMode.AUTO.value])) == ImaxEnhancedMode.AUTO
+    # Encode uses the set_map
+    assert s.encode(ImaxEnhancedMode.AUTO) == bytes([IMAX_ENHANCED_SET_MAP[ImaxEnhancedMode.AUTO]])
+
+
+@pytest.mark.parametrize(
+    "scale, in_db, expected_byte",
+    [
+        (1.0, 0.0, 0x00),
+        (1.0, 6.0, 0x06),
+        (1.0, -6.0, 0x86),
+        (0.5, 5.0, 0x0A),
+        (0.5, -5.0, 0x8A),
+    ],
+)
+def test_scaledcodec_encode(scale, in_db, expected_byte):
+    s = ScaledCodec(-12.0, 12.0, scale)
+    assert s.encode(in_db) == bytes([expected_byte])
+
+
+@pytest.mark.parametrize(
+    "scale, byte, expected",
+    [
+        (1.0, 0x00, 0.0),
+        (1.0, 0x06, 6.0),
+        (1.0, 0x86, -6.0),
+        (0.5, 0x0A, 5.0),
+    ],
+)
+def test_scaledcodec_decode(scale, byte, expected):
+    s = ScaledCodec(-12.0, 12.0, scale)
+    assert s.decode(bytes([byte])) == expected
+
+
+def test_scaledcodec_out_of_range_is_none():
+    s = ScaledCodec(-6.0, 6.0, 1.0)
+    assert s.decode(bytes([0x40])) is None
+
+
+def test_stringcodec():
+    s = StringCodec()
+    assert s.decode(b"hello   ") == "hello"
+    assert s.decode(b"\xff\xfe") == "��"  # replace on invalid
+
+
+def test_structcodec():
+    s = StructCodec(DolbyAudioMode.from_bytes)  # any from_bytes callable
+    assert s.decode(bytes([DolbyAudioMode.MOVIE.value])) == DolbyAudioMode.MOVIE
+
+
+def test_tunerpresetcodec_sentinel():
+    s = TunerPresetCodec()
+    assert s.decode(b"\xff") is None
+    assert s.decode(bytes([5])) == 5
+    assert s.encode(5) == bytes([5])
+
+
+def test_samplerate_codec():
+    s = SampleRateCodec()
+    assert s.decode(bytes([0x02])) == 48000
+    assert s.decode(bytes([0x07])) is None  # unknown
+    assert s.decode(bytes([0x42])) == 0  # not in map
+
+
+def test_roomeqnames_codec():
+    s = RoomEqNamesCodec()
+    data = b"Profile 1".ljust(20, b"\x00") + b"Profile 2".ljust(20, b"\x00")
+    assert s.decode(data) == ["Profile 1", "Profile 2"]
+
+
+def test_saprocessormode_codec():
+    s = SaProcessorModeCodec()
+    assert s.decode(bytes([0x00])) is None
+    assert s.encode(None) == bytes([0x00])
+    assert s.decode(bytes([0x01])) == SourceCodes.PHONO  # SA encoding, zone 1
+    assert s.encode(SourceCodes.PHONO) == bytes([0x01])
+    assert s.decode(bytes([0x0A])) is None  # gap in SA source map — must not raise
+    assert s.decode(bytes([0x0C])) is None
+
+
+# --- Capability composition ---
+
+
+def test_capabilities_derived_via_isinstance():
+    assert isinstance(VOLUME, ReadCommand)
+    assert isinstance(VOLUME, WriteCommand)
+    assert isinstance(VOLUME, StepCommand)
+    assert isinstance(OUTPUT_TEMPERATURE, ReadCommand)
+    assert not isinstance(OUTPUT_TEMPERATURE, WriteCommand)
+    assert not isinstance(OUTPUT_TEMPERATURE, StepCommand)
+
+
+# --- Catalogue integrity ---
+
+
+def test_no_duplicate_codes():
+    codes = [command.cc for command in COMMANDS]
+    assert len(codes) == len(set(codes)), "duplicate CC bytes in the catalogue"
+
+
+def test_every_command_typed_or_proto():
+    """Each command is exactly one of: a typed accessor (ReadCommand/WriteCommand) or
+    a protocol-only command (a bare Command instance)."""
+    for command in COMMANDS:
+        typed = isinstance(command, (ReadCommand, WriteCommand))
+        is_proto = type(command) is Command
+        assert typed != is_proto, f"{command.name} must be exactly one of typed / proto"
+
+
+def test_every_command_named():
+    for command in COMMANDS:
+        assert command.name, f"command 0x{command.cc:02X} has no name"

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1,0 +1,200 @@
+"""Tests for the codecs and the typed command catalogue.
+
+Covers:
+- Per-codec round-trip behavior (decode/encode), including sentinels
+- Catalogue coverage: every CommandCodes is either a typed Command or listed
+  as manual / protocol-only
+- Capability composition: read/write/step are derivable via isinstance
+"""
+from __future__ import annotations
+
+import pytest
+
+from arcam.fmj.codecs import (
+    BoolCodec,
+    DolbyAudioMode,
+    EnumCodec,
+    IMAX_ENHANCED_SET_MAP,
+    ImaxEnhancedMode,
+    IntCodec,
+    RoomEqNamesCodec,
+    SaProcessorModeCodec,
+    SampleRateCodec,
+    ScaledCodec,
+    SourceCodes,
+    StringCodec,
+    StructCodec,
+    TemperatureCodec,
+    TunerPresetCodec,
+)
+from arcam.fmj.commands import (
+    COMMANDS,
+    Command,
+    OUTPUT_TEMPERATURE,
+    ReadCommand,
+    StepCommand,
+    VOLUME,
+    WriteCommand,
+)
+
+
+# --- Per-codec round-trip ---
+
+
+def test_boolcodec_default():
+    s = BoolCodec()
+    assert s.decode(bytes([0x01])) is True
+    assert s.decode(bytes([0x00])) is False
+    assert s.encode(True) == bytes([0x01])
+    assert s.encode(False) == bytes([0x00])
+
+
+def test_boolcodec_inverted():
+    s = BoolCodec(inverted=True)
+    assert s.decode(bytes([0x00])) is True
+    assert s.decode(bytes([0x01])) is False
+    assert s.encode(True) == bytes([0x00])
+    assert s.encode(False) == bytes([0x01])
+
+
+def test_intcodec_roundtrip():
+    s = IntCodec()
+    for v in (0, 1, 127, 255):
+        assert s.decode(s.encode(v)) == v
+
+
+def test_enumcodec_symmetric():
+    s = EnumCodec(DolbyAudioMode)
+    assert s.decode(s.encode(DolbyAudioMode.MOVIE)) == DolbyAudioMode.MOVIE
+
+
+def test_enumcodec_asymmetric_set_map():
+    s = EnumCodec(ImaxEnhancedMode, set_map=IMAX_ENHANCED_SET_MAP)
+    # Decode uses the wire response codes
+    assert s.decode(bytes([ImaxEnhancedMode.AUTO.value])) == ImaxEnhancedMode.AUTO
+    # Encode uses the set_map
+    assert s.encode(ImaxEnhancedMode.AUTO) == bytes([IMAX_ENHANCED_SET_MAP[ImaxEnhancedMode.AUTO]])
+
+
+@pytest.mark.parametrize(
+    "scale, in_db, expected_byte",
+    [
+        (1.0, 0.0, 0x00),
+        (1.0, 6.0, 0x06),
+        (1.0, -6.0, 0x86),
+        (0.5, 5.0, 0x0A),
+        (0.5, -5.0, 0x8A),
+    ],
+)
+def test_scaledcodec_encode(scale, in_db, expected_byte):
+    s = ScaledCodec(-12.0, 12.0, scale)
+    assert s.encode(in_db) == bytes([expected_byte])
+
+
+@pytest.mark.parametrize(
+    "scale, byte, expected",
+    [
+        (1.0, 0x00, 0.0),
+        (1.0, 0x06, 6.0),
+        (1.0, 0x86, -6.0),
+        (0.5, 0x0A, 5.0),
+    ],
+)
+def test_scaledcodec_decode(scale, byte, expected):
+    s = ScaledCodec(-12.0, 12.0, scale)
+    assert s.decode(bytes([byte])) == expected
+
+
+def test_scaledcodec_out_of_range_is_none():
+    s = ScaledCodec(-6.0, 6.0, 1.0)
+    assert s.decode(bytes([0x40])) is None
+
+
+def test_stringcodec():
+    s = StringCodec()
+    assert s.decode(b"hello   ") == "hello"
+    assert s.decode(b"\xff\xfe") == "��"  # replace on invalid
+
+
+def test_structcodec():
+    s = StructCodec(DolbyAudioMode.from_bytes)  # any from_bytes callable
+    assert s.decode(bytes([DolbyAudioMode.MOVIE.value])) == DolbyAudioMode.MOVIE
+
+
+def test_tunerpresetcodec_sentinel():
+    s = TunerPresetCodec()
+    assert s.decode(b"\xff") is None
+    assert s.decode(bytes([5])) == 5
+    assert s.encode(5) == bytes([5])
+
+
+def test_samplerate_codec():
+    s = SampleRateCodec()
+    assert s.decode(bytes([0x02])) == 48000
+    assert s.decode(bytes([0x07])) is None  # unknown
+    assert s.decode(bytes([0x42])) == 0  # not in map
+
+
+def test_roomeqnames_codec():
+    s = RoomEqNamesCodec()
+    data = b"Profile 1".ljust(20, b"\x00") + b"Profile 2".ljust(20, b"\x00")
+    assert s.decode(data) == ["Profile 1", "Profile 2"]
+
+
+def test_saprocessormode_codec():
+    s = SaProcessorModeCodec()
+    assert s.decode(bytes([0x00])) is None
+    assert s.encode(None) == bytes([0x00])
+    assert s.decode(bytes([0x01])) == SourceCodes.PHONO  # SA encoding, zone 1
+    assert s.encode(SourceCodes.PHONO) == bytes([0x01])
+    assert s.decode(bytes([0x0A])) is None  # gap in SA source map — must not raise
+    assert s.decode(bytes([0x0C])) is None
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (bytes([0x4B]), 75),
+        (bytes([0xF0, 0x4B]), 75),
+        (bytes([0xF1, 0x32]), 50),
+        (bytes([0xEF, 0x4B]), None),
+        (bytes(), None),
+        (bytes([0xF0, 0x4B, 0x00]), None),
+    ],
+)
+def test_temperature_codec(data, expected):
+    assert TemperatureCodec().decode(data) == expected
+
+
+# --- Capability composition ---
+
+
+def test_capabilities_derived_via_isinstance():
+    assert isinstance(VOLUME, ReadCommand)
+    assert isinstance(VOLUME, WriteCommand)
+    assert isinstance(VOLUME, StepCommand)
+    assert isinstance(OUTPUT_TEMPERATURE, ReadCommand)
+    assert not isinstance(OUTPUT_TEMPERATURE, WriteCommand)
+    assert not isinstance(OUTPUT_TEMPERATURE, StepCommand)
+
+
+# --- Catalogue integrity ---
+
+
+def test_no_duplicate_codes():
+    codes = [command.cc for command in COMMANDS]
+    assert len(codes) == len(set(codes)), "duplicate CC bytes in the catalogue"
+
+
+def test_every_command_typed_or_proto():
+    """Each command is exactly one of: a typed accessor (ReadCommand/WriteCommand) or
+    a protocol-only command (a bare Command instance)."""
+    for command in COMMANDS:
+        typed = isinstance(command, (ReadCommand, WriteCommand))
+        is_proto = type(command) is Command
+        assert typed != is_proto, f"{command.name} must be exactly one of typed / proto"
+
+
+def test_every_command_named():
+    for command in COMMANDS:
+        assert command.name, f"command 0x{command.cc:02X} has no name"

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -1,3 +1,6 @@
+from arcam.fmj.commands import (
+    DECODE_MODE_2CH,
+)
 """Test with a fake server"""
 
 import asyncio
@@ -6,7 +9,7 @@ import pytest
 from datetime import timedelta
 
 from arcam.fmj.utils import cancel_and_wait
-from arcam.fmj.commands import CommandCodes
+from arcam.fmj.commands import POWER, VOLUME
 from arcam.fmj.errors import (
     CommandNotRecognised,
     ConnectionFailed,
@@ -27,10 +30,10 @@ async def server(request):
     s = Server("localhost", 8888, "AVR450")
     async with ServerContext(s):
         s.register_handler(
-            0x01, CommandCodes.POWER, bytes([0xF0]), lambda **kwargs: bytes([0x00])
+            0x01, POWER.cc, bytes([0xF0]), lambda **kwargs: bytes([0x00])
         )
         s.register_handler(
-            0x01, CommandCodes.VOLUME, bytes([0xF0]), lambda **kwargs: bytes([0x01])
+            0x01, VOLUME.cc, bytes([0xF0]), lambda **kwargs: bytes([0x01])
         )
         yield s
 
@@ -64,14 +67,14 @@ async def speedy_client(mocker):
 
 
 async def test_power(server, client):
-    data = await client.request(0x01, CommandCodes.POWER, bytes([0xF0]))
+    data = await client.request(0x01, POWER.cc, bytes([0xF0]))
     assert data == bytes([0x00])
 
 
 async def test_multiple(server, client):
     data = await asyncio.gather(
-        client.request(0x01, CommandCodes.POWER, bytes([0xF0])),
-        client.request(0x01, CommandCodes.VOLUME, bytes([0xF0])),
+        client.request(0x01, POWER.cc, bytes([0xF0])),
+        client.request(0x01, VOLUME.cc, bytes([0xF0])),
     )
     assert data[0] == bytes([0x00])
     assert data[1] == bytes([0x01])
@@ -79,24 +82,24 @@ async def test_multiple(server, client):
 
 async def test_invalid_command(server, client):
     with pytest.raises(CommandNotRecognised):
-        await client.request(0x01, CommandCodes.from_int(0xFF), bytes([0xF0]))
+        await client.request(0x01, 0xFF, bytes([0xF0]))
 
 
 async def test_state(server, client):
     state = State(client, 0x01)
     await asyncio.gather(*await state.get_update_tasks())
-    assert state.get(CommandCodes.POWER) == bytes([0x00])
-    assert state.get(CommandCodes.VOLUME) == bytes([0x01])
+    assert state.get_cached(POWER.cc) == bytes([0x00])
+    assert state.get_cached(VOLUME.cc) == bytes([0x01])
 
 
 async def test_silent_server_request(speedy_client, silent_server, client):
     with pytest.raises(asyncio.TimeoutError):
-        await client.request(0x01, CommandCodes.POWER, bytes([0xF0]))
+        await client.request(0x01, POWER.cc, bytes([0xF0]))
 
 
 async def test_unsupported_zone(speedy_client, silent_server, client):
     with pytest.raises(UnsupportedZone):
-        await client.request(0x02, CommandCodes.DECODE_MODE_STATUS_2CH, bytes([0xF0]))
+        await client.request(0x02, DECODE_MODE_2CH.cc, bytes([0xF0]))
 
 
 async def test_silent_server_disconnect(speedy_client, silent_server):
@@ -121,10 +124,10 @@ async def test_process_runs_update_providers(server):
         process_task = asyncio.create_task(c.process())
         try:
             async with asyncio.timeout(5):
-                while state.get_power() is None or state.get_volume() is None:
+                while state.get(POWER) is None or state.get(VOLUME) is None:
                     await asyncio.sleep(0.05)
-            assert state.get_power() is False  # bytes([0x00]) → False
-            assert state.get_volume() == 0x01
+            assert state.get(POWER) is False  # bytes([0x00]) → False
+            assert state.get(VOLUME) == 0x01
         finally:
             await cancel_and_wait(process_task)
     finally:
@@ -225,8 +228,8 @@ async def test_update_returns_after_loop_pass(server):
         try:
             async with asyncio.timeout(5):
                 await state.update()
-            assert state.get_power() is False
-            assert state.get_volume() == 0x01
+            assert state.get(POWER) is False
+            assert state.get(VOLUME) == 0x01
         finally:
             await cancel_and_wait(process_task)
     finally:

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,3 +1,7 @@
+from arcam.fmj.commands import (
+    CURRENT_SOURCE,
+    SIMULATE_RC5_IR_COMMAND,
+)
 import logging
 
 import pytest
@@ -6,7 +10,6 @@ from unittest.mock import MagicMock
 from arcam.fmj.client import Client
 from arcam.fmj.state import State
 from arcam.fmj.codecs import AnswerCodes, SourceCodes
-from arcam.fmj.commands import CommandCodes
 from arcam.fmj.models import ApiModel
 from arcam.fmj.packets import AmxDuetResponse, ResponsePacket
 
@@ -49,7 +52,7 @@ def make_state(client, zn, api_model):
 async def test_get_source(zn, api_model, source, data):
     client = MagicMock(spec=Client)
     state = make_state(client, zn, api_model)
-    state._state[CommandCodes.CURRENT_SOURCE] = data
+    state._state[CURRENT_SOURCE.cc] = data
 
     assert state.get_source() == source
 
@@ -74,9 +77,9 @@ async def test_set_source(zn, api_model, source, ir, data):
     state = make_state(client, zn, api_model)
 
     if ir:
-        command_code = CommandCodes.SIMULATE_RC5_IR_COMMAND
+        command_code = SIMULATE_RC5_IR_COMMAND.cc
     else:
-        command_code = CommandCodes.CURRENT_SOURCE
+        command_code = CURRENT_SOURCE.cc
 
     client.request.return_value = ResponsePacket(
         zn,

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -1,3 +1,7 @@
+from arcam.fmj.commands import (
+    POWER,
+    VOLUME,
+)
 """Standard tests for component"""
 
 import asyncio
@@ -11,7 +15,6 @@ from arcam.fmj.codecs import (
     IncomingVideoColorspace,
     VideoParameters,
 )
-from arcam.fmj.commands import CommandCodes
 from arcam.fmj.errors import (
     CommandInvalidAtThisTime,
     CommandNotRecognised,
@@ -113,13 +116,13 @@ async def test_amx():
 
 
 def test_response_packet_roundtrip():
-    original = ResponsePacket(1, CommandCodes.VOLUME, AnswerCodes.STATUS_UPDATE, bytes([42]))
+    original = ResponsePacket(1, VOLUME.cc, AnswerCodes.STATUS_UPDATE, bytes([42]))
     rebuilt = ResponsePacket.from_bytes(original.to_bytes())
     assert rebuilt == original
 
 
 def test_command_packet_roundtrip():
-    original = CommandPacket(1, CommandCodes.POWER, bytes([0xF0]))
+    original = CommandPacket(1, POWER.cc, bytes([0xF0]))
     rebuilt = CommandPacket.from_bytes(original.to_bytes())
     assert rebuilt == original
 
@@ -132,7 +135,7 @@ def test_command_packet_roundtrip():
     (AnswerCodes.INVALID_DATA_LENGTH, InvalidDataLength),
 ])
 def test_response_exception_from_response(ac, expected_type):
-    response = ResponsePacket(1, CommandCodes.POWER, ac, b"")
+    response = ResponsePacket(1, POWER.cc, ac, b"")
     exc = ResponseException.from_response(response)
     assert isinstance(exc, expected_type)
 

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -1,3 +1,7 @@
+from arcam.fmj.commands import (
+    POWER,
+    VOLUME,
+)
 """Standard tests for component"""
 
 import asyncio
@@ -13,7 +17,6 @@ from arcam.fmj.codecs import (
     PresetType,
     VideoParameters,
 )
-from arcam.fmj.commands import CommandCodes
 from arcam.fmj.errors import (
     CommandInvalidAtThisTime,
     CommandNotRecognised,
@@ -115,13 +118,13 @@ async def test_amx():
 
 
 def test_response_packet_roundtrip():
-    original = ResponsePacket(1, CommandCodes.VOLUME, AnswerCodes.STATUS_UPDATE, bytes([42]))
+    original = ResponsePacket(1, VOLUME.cc, AnswerCodes.STATUS_UPDATE, bytes([42]))
     rebuilt = ResponsePacket.from_bytes(original.to_bytes())
     assert rebuilt == original
 
 
 def test_command_packet_roundtrip():
-    original = CommandPacket(1, CommandCodes.POWER, bytes([0xF0]))
+    original = CommandPacket(1, POWER.cc, bytes([0xF0]))
     rebuilt = CommandPacket.from_bytes(original.to_bytes())
     assert rebuilt == original
 
@@ -134,7 +137,7 @@ def test_command_packet_roundtrip():
     (AnswerCodes.INVALID_DATA_LENGTH, InvalidDataLength),
 ])
 def test_response_exception_from_response(ac, expected_type):
-    response = ResponsePacket(1, CommandCodes.POWER, ac, b"")
+    response = ResponsePacket(1, POWER.cc, ac, b"")
     exc = ResponseException.from_response(response)
     assert isinstance(exc, expected_type)
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -18,9 +18,10 @@ from arcam.fmj.codecs import (
     RoomEqMode,
     SAVE_RESTORE_CONFIRMATION,
     SaveRestoreSubCommand,
+    SourceCodes,
     VideoSelection,
 )
-from arcam.fmj.commands import CommandCodes, POWER_WRITE_SUPPORTED
+from arcam.fmj.commands import CommandCodes, CommandFlags, POWER_WRITE_SUPPORTED
 from arcam.fmj.errors import UnsupportedCommand
 from arcam.fmj.models import ApiModel
 from arcam.fmj.packets import AmxDuetResponse, ResponsePacket
@@ -1118,3 +1119,169 @@ async def test_set_video_selection():
     state = State(client, 1)
     await state.set_video_selection(VideoSelection.SAT)
     client.request.assert_called_with(1, CommandCodes.VIDEO_SELECTION, bytes([0x01]), 0)
+
+
+# --- Update conditions / _should_update -----------------------------------
+
+def _state_at_source(source: SourceCodes) -> State:
+    """Helper: a fresh State with CURRENT_SOURCE seeded to `source`."""
+    client = MagicMock(spec=Client)
+    state = State(client, 1)
+    state._state[CommandCodes.CURRENT_SOURCE] = source.to_bytes(
+        state._api_model, state._zn,
+    )
+    return state
+
+
+def test_should_update_no_update_flag():
+    """Commands without the UPDATE flag are never polled."""
+    state = State(MagicMock(spec=Client), 1)
+    assert not (CommandCodes.RESTORE_FACTORY_DEFAULT.flags & CommandFlags.UPDATE)
+    assert state._should_update(CommandCodes.RESTORE_FACTORY_DEFAULT) is False
+
+
+def test_should_update_pushed_first_pass_polls_even_if_known():
+    """Pushed CCs are polled during the initial pass regardless of cache."""
+    state = State(MagicMock(spec=Client), 1)
+    state._state[CommandCodes.POWER] = bytes([1])
+    assert state._updated.is_set() is False
+    assert state._should_update(CommandCodes.POWER) is True
+
+
+def test_should_update_pushed_skipped_after_first_pass():
+    state = State(MagicMock(spec=Client), 1)
+    state._updated.set()
+    assert CommandCodes.POWER not in state._state
+    assert state._should_update(CommandCodes.POWER) is False
+
+
+def test_should_update_not_pushed_always_polls():
+    state = _state_at_source(SourceCodes.NET)
+    state._updated.set()
+    # NETWORK_PLAYBACK_STATUS is NOT_PUSHED, sources={NET, USB, NET_USB}
+    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is True
+
+
+def test_should_update_sources_no_match():
+    state = _state_at_source(SourceCodes.CD)
+    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is False
+
+
+def test_should_update_sources_match():
+    state = _state_at_source(SourceCodes.NET)
+    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is True
+
+
+def test_should_update_sources_unknown_is_permissive():
+    """When source isn't yet known, fetch source-gated CCs anyway."""
+    state = State(MagicMock(spec=Client), 1)
+    assert state.get_source() is None
+    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is True
+
+
+def test_should_update_zone_2_requires_zone_support():
+    """Commands without ZONE_SUPPORT are skipped on zone 2 even if eligible."""
+    client = MagicMock(spec=Client)
+    state = State(client, 2)
+    # MUTE has ZONE_SUPPORT — ok
+    assert state._should_update(CommandCodes.MUTE) is True
+    # INCOMING_AUDIO_FORMAT has no ZONE_SUPPORT
+    assert state._should_update(CommandCodes.INCOMING_AUDIO_FORMAT) is False
+
+
+async def test_update_skips_commands_for_wrong_source():
+    """get_update_tasks() must not produce a request for NETWORK_PLAYBACK_STATUS
+    when source is not in its sources set."""
+    state = _state_at_source(SourceCodes.CD)
+    state._amxduet = AmxDuetResponse({"Device-Model": "AVR450"})
+    tasks = await state.get_update_tasks()
+    # Run the tasks so we can inspect what got requested
+    await asyncio.gather(*tasks)
+    requested = [call.args[1] for call in state._client.request.call_args_list]
+    assert CommandCodes.NETWORK_PLAYBACK_STATUS not in requested
+    assert CommandCodes.NOW_PLAYING_INFO not in requested
+    # But POWER (no source gate) should be fetched
+    assert CommandCodes.POWER in requested
+
+
+async def test_update_pushed_skipped_after_first_pass():
+    """After the initial pass, pushed CCs are no longer requested;
+    NOT_PUSHED ones still are (when source matches)."""
+    state = _state_at_source(SourceCodes.NET)
+    state._amxduet = AmxDuetResponse({"Device-Model": "AVR450"})
+    state._updated.set()
+    tasks = await state.get_update_tasks()
+    await asyncio.gather(*tasks)
+    requested = [call.args[1] for call in state._client.request.call_args_list]
+    # POWER is pushed — should NOT appear in a post-first-pass batch
+    assert CommandCodes.POWER not in requested
+    # NETWORK_PLAYBACK_STATUS is NOT_PUSHED + source matches — should appear
+    assert CommandCodes.NETWORK_PLAYBACK_STATUS in requested
+
+
+# --- Accessor source gating ----------------------------------------------
+
+def test_get_dab_station_returns_none_when_source_mismatch():
+    state = _state_at_source(SourceCodes.CD)
+    state._state[CommandCodes.DAB_STATION] = b"BBC R4"
+    assert state.get_dab_station() is None
+
+
+def test_get_dab_station_returns_value_when_source_unknown():
+    state = State(MagicMock(spec=Client), 1)
+    state._state[CommandCodes.DAB_STATION] = b"BBC R4"
+    assert state.get_dab_station() == "BBC R4"
+
+
+def test_get_dab_station_returns_value_when_source_matches():
+    state = _state_at_source(SourceCodes.DAB)
+    state._state[CommandCodes.DAB_STATION] = b"BBC R4"
+    assert state.get_dab_station() == "BBC R4"
+
+
+def test_get_dls_pdt_gated_by_source():
+    state = _state_at_source(SourceCodes.CD)
+    state._state[CommandCodes.DLS_PDT_INFO] = b"Now Playing"
+    assert state.get_dls_pdt() is None
+
+
+def test_get_rds_information_gated_by_source():
+    state = _state_at_source(SourceCodes.CD)
+    state._state[CommandCodes.RDS_INFORMATION] = b"BBC R4"
+    assert state.get_rds_information() is None
+
+
+def test_get_tuner_preset_gated_by_source():
+    state = _state_at_source(SourceCodes.CD)
+    state._state[CommandCodes.TUNER_PRESET] = bytes([3])
+    assert state.get_tuner_preset() is None
+
+
+def test_get_preset_details_gated_by_source():
+    state = _state_at_source(SourceCodes.CD)
+    state._presets = {1: object()}
+    assert state.get_preset_details() is None
+
+
+def test_get_network_playback_status_gated_by_source():
+    state = _state_at_source(SourceCodes.CD)
+    state._state[CommandCodes.NETWORK_PLAYBACK_STATUS] = bytes([0x01])
+    assert state.get_network_playback_status() is None
+
+
+def test_get_bluetooth_status_gated_by_source():
+    state = _state_at_source(SourceCodes.CD)
+    state._state[CommandCodes.BLUETOOTH_STATUS] = bytes([0x01]) + b"Track"
+    assert state.get_bluetooth_status() == (None, None)
+
+
+def test_get_now_playing_gated_by_source():
+    state = _state_at_source(SourceCodes.CD)
+    state._now_playing = object()  # sentinel; gate must return None before this is observed
+    assert state.get_now_playing() is None
+
+
+async def test_set_tuner_preset_noops_when_source_mismatch():
+    state = _state_at_source(SourceCodes.CD)
+    await state.set_tuner_preset(3)
+    state._client.request.assert_not_called()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,8 +1,19 @@
+from arcam.fmj.commands import (
+    BLUETOOTH_STATUS,
+    CURRENT_SOURCE,
+    INCOMING_AUDIO_FORMAT,
+    MENU,
+    NOW_PLAYING_INFO,
+    RESTORE_FACTORY_DEFAULT,
+    SAVE_RESTORE_COPY_OF_SETTINGS,
+    SIMULATE_RC5_IR_COMMAND,
+)
 import asyncio
 import pytest
 from unittest.mock import MagicMock
 from arcam.fmj.client import Client
-from arcam.fmj.state import State, _get_scaled_negative, _set_scaled
+from arcam.fmj.state import State
+from arcam.fmj.codecs import _get_scaled_negative, _set_scaled
 from arcam.fmj.codecs import (
     AnswerCodes,
     BluetoothAudioStatus,
@@ -21,7 +32,33 @@ from arcam.fmj.codecs import (
     SourceCodes,
     VideoSelection,
 )
-from arcam.fmj.commands import CommandCodes, CommandFlags, POWER_WRITE_SUPPORTED
+from arcam.fmj.commands import CommandFlags, POWER_WRITE_SUPPORTED
+from arcam.fmj.commands import (
+    BALANCE,
+    BASS_EQUALIZATION,
+    COMPRESSION,
+    DAB_STATION,
+    DIRECT_MODE,
+    DISPLAY_BRIGHTNESS,
+    DISPLAY_INFO_TYPE,
+    DLS_PDT,
+    DOLBY_AUDIO,
+    HEADPHONES,
+    IMAX_ENHANCED,
+    LIPSYNC_DELAY,
+    MUTE,
+    NETWORK_PLAYBACK_STATUS,
+    POWER,
+    RDS_INFORMATION,
+    ROOM_EQUALIZATION,
+    ROOM_EQ_NAMES,
+    SUBWOOFER_TRIM,
+    SUB_STEREO_TRIM,
+    TREBLE_EQUALIZATION,
+    TUNER_PRESET,
+    VIDEO_SELECTION,
+    VOLUME,
+)
 from arcam.fmj.errors import UnsupportedCommand
 from arcam.fmj.models import ApiModel
 from arcam.fmj.packets import AmxDuetResponse, ResponsePacket
@@ -96,19 +133,19 @@ async def test_power_on(zn, api_model):
     state = make_state(client, zn, api_model)
     response = ResponsePacket(
         zn,
-        CommandCodes.SIMULATE_RC5_IR_COMMAND,
+        SIMULATE_RC5_IR_COMMAND.cc,
         AnswerCodes.STATUS_UPDATE,
         bytes([0x01]),
     )
     client.request.return_value = response
-    await state.set_power(True)
+    await state.set(POWER, True)
     if api_model in POWER_WRITE_SUPPORTED:
-        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x01]), 0)
+        client.request.assert_called_with(zn, POWER.cc, bytes([0x01]), 0)
     else:
         # zn, api_model, power
         code = PARAMS_TO_RC5COMMAND[zn, api_model, True]
         client.request.assert_called_with(
-            zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code, 0)
+            zn, SIMULATE_RC5_IR_COMMAND.cc, code, 0)
 
 
 @pytest.mark.parametrize("zn, api_model", TEST_PARAMS)
@@ -116,15 +153,15 @@ async def test_power_off(zn, api_model):
     client = MagicMock(spec=Client)
     state = make_state(client, zn, api_model)
 
-    assert state.get_power() is None
-    await state.set_power(False)
+    assert state.get(POWER) is None
+    await state.set(POWER, False)
     if api_model in POWER_WRITE_SUPPORTED:
-        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x00]), 0)
+        client.request.assert_called_with(zn, POWER.cc, bytes([0x00]), 0)
     else:
         # zn, api_model, power
         code = PARAMS_TO_RC5COMMAND[zn, api_model, False]
-        client.request.assert_called_with(zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code)
-    assert state.get_power() is False
+        client.request.assert_called_with(zn, SIMULATE_RC5_IR_COMMAND.cc, code, 0)
+    assert state.get(POWER) is False
 
 
 # --- Scaled value encoding ---
@@ -177,14 +214,14 @@ def test_set_scaled():
 def test_get_volume_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_volume() is None
+    assert state.get(VOLUME) is None
 
 
 def test_get_volume():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.VOLUME] = bytes([50])
-    assert state.get_volume() == 50
+    state._state[VOLUME.cc] = bytes([50])
+    assert state.get(VOLUME) == 50
 
 
 # --- Mute ---
@@ -193,7 +230,7 @@ def test_get_volume():
 def test_get_mute_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_mute() is None
+    assert state.get(MUTE) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -203,25 +240,25 @@ def test_get_mute_none():
 def test_get_mute(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.MUTE] = bytes([byte_val])
-    assert state.get_mute() == expected
+    state._state[MUTE.cc] = bytes([byte_val])
+    assert state.get(MUTE) == expected
 
 
 async def test_set_mute_write_supported():
     """SA/PA/ST series use direct MUTE command."""
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APISA_SERIES)
-    await state.set_mute(True)
-    client.request.assert_called_with(1, CommandCodes.MUTE, bytes([0x00]), 0)
+    await state.set(MUTE, True)
+    client.request.assert_called_with(1, MUTE.cc, bytes([0x00]), 0)
 
 
 async def test_set_mute_rc5():
     """450/860/HDA series use RC5 IR command for mute."""
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.API450_SERIES)
-    await state.set_mute(True)
+    await state.set(MUTE, True)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([16, 119]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([16, 119]), 0)
 
 
 # --- Decode mode ---
@@ -237,7 +274,7 @@ async def test_set_mute_rc5():
 def test_get_2ch(fmt, expected):
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.INCOMING_AUDIO_FORMAT] = bytes([fmt, 0x02])
+    state._state[INCOMING_AUDIO_FORMAT.cc] = bytes([fmt, 0x02])
     assert state.get_2ch() == expected
 
 
@@ -254,23 +291,23 @@ def test_get_2ch_no_audio():
 def test_listen_status_update():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._listen(ResponsePacket(1, CommandCodes.VOLUME, AnswerCodes.STATUS_UPDATE, bytes([42])))
-    assert state.get_volume() == 42
+    state._listen(ResponsePacket(1, VOLUME.cc, AnswerCodes.STATUS_UPDATE, bytes([42])))
+    assert state.get(VOLUME) == 42
 
 
 def test_listen_ignores_other_zone():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._listen(ResponsePacket(2, CommandCodes.VOLUME, AnswerCodes.STATUS_UPDATE, bytes([42])))
-    assert state.get_volume() is None
+    state._listen(ResponsePacket(2, VOLUME.cc, AnswerCodes.STATUS_UPDATE, bytes([42])))
+    assert state.get(VOLUME) is None
 
 
 def test_listen_clears_on_error():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.VOLUME] = bytes([42])
-    state._listen(ResponsePacket(1, CommandCodes.VOLUME, AnswerCodes.COMMAND_NOT_RECOGNISED, b""))
-    assert state.get_volume() is None
+    state._state[VOLUME.cc] = bytes([42])
+    state._listen(ResponsePacket(1, VOLUME.cc, AnswerCodes.COMMAND_NOT_RECOGNISED, b""))
+    assert state.get(VOLUME) is None
 
 
 def test_listen_amxduet():
@@ -280,7 +317,7 @@ def test_listen_amxduet():
     state._listen(amx)
     assert state.model == "AV860"
     assert state.revision == "1.2.3"
-    assert state._api_model == ApiModel.API860_SERIES
+    assert state.api_model == ApiModel.API860_SERIES
 
 
 def test_amxduet_resolves_api_model_for_every_zone():
@@ -291,7 +328,7 @@ def test_amxduet_resolves_api_model_for_every_zone():
     z1._listen(amx)
     z2._listen(amx)
     assert z1.model == z2.model == "AV41"
-    assert z1._api_model == z2._api_model == ApiModel.APIHDA_SERIES
+    assert z1.api_model == z2.api_model == ApiModel.APIHDA_SERIES
 
 
 # --- Save/Restore Settings (0x06) ---
@@ -302,7 +339,7 @@ async def test_save_settings_default_pin():
     state = State(client, 1)
     await state.save_settings()
     client.request.assert_called_with(
-        1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
+        1, SAVE_RESTORE_COPY_OF_SETTINGS.cc,
         bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]), 0)
 
 
@@ -311,7 +348,7 @@ async def test_restore_settings_default_pin():
     state = State(client, 1)
     await state.restore_settings()
     client.request.assert_called_with(
-        1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
+        1, SAVE_RESTORE_COPY_OF_SETTINGS.cc,
         bytes([SaveRestoreSubCommand.RESTORE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]), 0)
 
 
@@ -320,7 +357,7 @@ async def test_save_settings_custom_pin():
     state = State(client, 1)
     await state.save_settings(pin=(9, 8, 7, 6))
     client.request.assert_called_with(
-        1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
+        1, SAVE_RESTORE_COPY_OF_SETTINGS.cc,
         bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x09, 0x08, 0x07, 0x06]), 0)
 
 
@@ -330,7 +367,7 @@ async def test_save_settings_custom_pin():
 def test_get_headphones_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_headphones() is None
+    assert state.get(HEADPHONES) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -340,8 +377,8 @@ def test_get_headphones_none():
 def test_get_headphones(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.HEADPHONES] = bytes([byte_val])
-    assert state.get_headphones() == expected
+    state._state[HEADPHONES.cc] = bytes([byte_val])
+    assert state.get(HEADPHONES) == expected
 
 
 # --- Display Information Type (0x09) ---
@@ -350,30 +387,14 @@ def test_get_headphones(byte_val, expected):
 def test_get_display_info_type_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_display_info_type() is None
+    assert state.get(DISPLAY_INFO_TYPE) is None
 
 
 def test_get_display_info_type():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.DISPLAY_INFORMATION_TYPE] = bytes([0x02])
-    assert state.get_display_info_type() == 2
-
-
-async def test_set_display_info_type():
-    client = MagicMock(spec=Client)
-    state = State(client, 1)
-    await state.set_display_info_type(0x03)
-    client.request.assert_called_with(
-        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0x03]), 0)
-
-
-async def test_set_display_info_type_cycle():
-    client = MagicMock(spec=Client)
-    state = State(client, 1)
-    await state.set_display_info_type(0xE0)
-    client.request.assert_called_with(
-        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0xE0]), 0)
+    state._state[DISPLAY_INFO_TYPE.cc] = bytes([0x02])
+    assert state.get(DISPLAY_INFO_TYPE) == 2
 
 
 # --- Lipsync Delay (0x40) ---
@@ -382,7 +403,7 @@ async def test_set_display_info_type_cycle():
 def test_get_lipsync_delay_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_lipsync_delay() is None
+    assert state.get(LIPSYNC_DELAY) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -393,8 +414,8 @@ def test_get_lipsync_delay_none():
 def test_get_lipsync_delay(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.LIPSYNC_DELAY] = bytes([byte_val])
-    assert state.get_lipsync_delay() == expected
+    state._state[LIPSYNC_DELAY.cc] = bytes([byte_val])
+    assert state.get(LIPSYNC_DELAY) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -405,8 +426,8 @@ def test_get_lipsync_delay(byte_val, expected):
 async def test_set_lipsync_delay(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_lipsync_delay(value)
-    client.request.assert_called_with(1, CommandCodes.LIPSYNC_DELAY, bytes([expected_byte]), 0)
+    await state.set(LIPSYNC_DELAY, value)
+    client.request.assert_called_with(1, LIPSYNC_DELAY.cc, bytes([expected_byte]), 0)
 
 
 # --- Subwoofer Trim (0x3F) ---
@@ -415,7 +436,7 @@ async def test_set_lipsync_delay(value, expected_byte):
 def test_get_subwoofer_trim_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_subwoofer_trim() is None
+    assert state.get(SUBWOOFER_TRIM) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -429,8 +450,8 @@ def test_get_subwoofer_trim_none():
 def test_get_subwoofer_trim(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.SUBWOOFER_TRIM] = bytes([byte_val])
-    assert state.get_subwoofer_trim() == expected
+    state._state[SUBWOOFER_TRIM.cc] = bytes([byte_val])
+    assert state.get(SUBWOOFER_TRIM) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -443,8 +464,8 @@ def test_get_subwoofer_trim(byte_val, expected):
 async def test_set_subwoofer_trim(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_subwoofer_trim(value)
-    client.request.assert_called_with(1, CommandCodes.SUBWOOFER_TRIM, bytes([expected_byte]), 0)
+    await state.set(SUBWOOFER_TRIM, value)
+    client.request.assert_called_with(1, SUBWOOFER_TRIM.cc, bytes([expected_byte]), 0)
 
 
 # --- Sub Stereo Trim (0x45) ---
@@ -453,7 +474,7 @@ async def test_set_subwoofer_trim(value, expected_byte):
 def test_get_sub_stereo_trim_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_sub_stereo_trim() is None
+    assert state.get(SUB_STEREO_TRIM) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -465,8 +486,8 @@ def test_get_sub_stereo_trim_none():
 def test_get_sub_stereo_trim(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.SUB_STEREO_TRIM] = bytes([byte_val])
-    assert state.get_sub_stereo_trim() == expected
+    state._state[SUB_STEREO_TRIM.cc] = bytes([byte_val])
+    assert state.get(SUB_STEREO_TRIM) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -478,8 +499,8 @@ def test_get_sub_stereo_trim(byte_val, expected):
 async def test_set_sub_stereo_trim(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_sub_stereo_trim(value)
-    client.request.assert_called_with(1, CommandCodes.SUB_STEREO_TRIM, bytes([expected_byte]), 0)
+    await state.set(SUB_STEREO_TRIM, value)
+    client.request.assert_called_with(1, SUB_STEREO_TRIM.cc, bytes([expected_byte]), 0)
 
 
 # --- Treble Equalization (0x35) ---
@@ -488,7 +509,7 @@ async def test_set_sub_stereo_trim(value, expected_byte):
 def test_get_treble_equalization_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_treble_equalization() is None
+    assert state.get(TREBLE_EQUALIZATION) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -501,8 +522,8 @@ def test_get_treble_equalization_none():
 def test_get_treble_equalization(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.TREBLE_EQUALIZATION] = bytes([byte_val])
-    assert state.get_treble_equalization() == expected
+    state._state[TREBLE_EQUALIZATION.cc] = bytes([byte_val])
+    assert state.get(TREBLE_EQUALIZATION) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -513,8 +534,8 @@ def test_get_treble_equalization(byte_val, expected):
 async def test_set_treble_equalization(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_treble_equalization(value)
-    client.request.assert_called_with(1, CommandCodes.TREBLE_EQUALIZATION, bytes([expected_byte]), 0)
+    await state.set(TREBLE_EQUALIZATION, value)
+    client.request.assert_called_with(1, TREBLE_EQUALIZATION.cc, bytes([expected_byte]), 0)
 
 
 # --- Bass Equalization (0x36) ---
@@ -523,7 +544,7 @@ async def test_set_treble_equalization(value, expected_byte):
 def test_get_bass_equalization_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_bass_equalization() is None
+    assert state.get(BASS_EQUALIZATION) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -536,8 +557,8 @@ def test_get_bass_equalization_none():
 def test_get_bass_equalization(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.BASS_EQUALIZATION] = bytes([byte_val])
-    assert state.get_bass_equalization() == expected
+    state._state[BASS_EQUALIZATION.cc] = bytes([byte_val])
+    assert state.get(BASS_EQUALIZATION) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -550,8 +571,8 @@ def test_get_bass_equalization(byte_val, expected):
 async def test_set_bass_equalization(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_bass_equalization(value)
-    client.request.assert_called_with(1, CommandCodes.BASS_EQUALIZATION, bytes([expected_byte]), 0)
+    await state.set(BASS_EQUALIZATION, value)
+    client.request.assert_called_with(1, BASS_EQUALIZATION.cc, bytes([expected_byte]), 0)
 
 
 # --- Room EQ (0x37) ---
@@ -560,7 +581,7 @@ async def test_set_bass_equalization(value, expected_byte):
 def test_get_room_equalization_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_room_equalization() is None
+    assert state.get(ROOM_EQUALIZATION) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -572,8 +593,8 @@ def test_get_room_equalization_none():
 def test_get_room_equalization(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.ROOM_EQUALIZATION] = bytes([byte_val])
-    assert state.get_room_equalization() == expected
+    state._state[ROOM_EQUALIZATION.cc] = bytes([byte_val])
+    assert state.get(ROOM_EQUALIZATION) == expected
 
 
 @pytest.mark.parametrize("mode, expected_byte", [
@@ -585,8 +606,8 @@ def test_get_room_equalization(byte_val, expected):
 async def test_set_room_equalization(mode, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_room_equalization(mode)
-    client.request.assert_called_with(1, CommandCodes.ROOM_EQUALIZATION, bytes([expected_byte]), 0)
+    await state.set(ROOM_EQUALIZATION, mode)
+    client.request.assert_called_with(1, ROOM_EQUALIZATION.cc, bytes([expected_byte]), 0)
 
 
 # --- Room EQ Names (0x34) ---
@@ -595,7 +616,7 @@ async def test_set_room_equalization(mode, expected_byte):
 def test_get_room_eq_names_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_room_eq_names() is None
+    assert state.get(ROOM_EQ_NAMES) is None
 
 
 def test_get_room_eq_names():
@@ -603,8 +624,8 @@ def test_get_room_eq_names():
     state = State(client, 1)
     name1 = b"Living Room\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     name2 = b"Flat\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-    state._state[CommandCodes.ROOM_EQ_NAMES] = name1 + name2
-    names = state.get_room_eq_names()
+    state._state[ROOM_EQ_NAMES.cc] = name1 + name2
+    names = state.get(ROOM_EQ_NAMES)
     assert names == ["Living Room", "Flat"]
 
 
@@ -614,7 +635,7 @@ def test_get_room_eq_names():
 def test_get_dolby_audio_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_dolby_audio() is None
+    assert state.get(DOLBY_AUDIO) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -626,15 +647,15 @@ def test_get_dolby_audio_none():
 def test_get_dolby_audio(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.DOLBY_AUDIO] = bytes([byte_val])
-    assert state.get_dolby_audio() == expected
+    state._state[DOLBY_AUDIO.cc] = bytes([byte_val])
+    assert state.get(DOLBY_AUDIO) == expected
 
 
 async def test_set_dolby_audio():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_dolby_audio(DolbyAudioMode.NIGHT)
-    client.request.assert_called_with(1, CommandCodes.DOLBY_AUDIO, bytes([0x03]), 0)
+    await state.set(DOLBY_AUDIO, DolbyAudioMode.NIGHT)
+    client.request.assert_called_with(1, DOLBY_AUDIO.cc, bytes([0x03]), 0)
 
 
 # --- Balance (0x3B) ---
@@ -643,7 +664,7 @@ async def test_set_dolby_audio():
 def test_get_balance_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_balance() is None
+    assert state.get(BALANCE) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -657,8 +678,8 @@ def test_get_balance_none():
 def test_get_balance(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.BALANCE] = bytes([byte_val])
-    assert state.get_balance() == expected
+    state._state[BALANCE.cc] = bytes([byte_val])
+    assert state.get(BALANCE) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -671,8 +692,8 @@ def test_get_balance(byte_val, expected):
 async def test_set_balance(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_balance(value)
-    client.request.assert_called_with(1, CommandCodes.BALANCE, bytes([expected_byte]), 0)
+    await state.set(BALANCE, value)
+    client.request.assert_called_with(1, BALANCE.cc, bytes([expected_byte]), 0)
 
 
 # --- Compression (0x41) ---
@@ -681,7 +702,7 @@ async def test_set_balance(value, expected_byte):
 def test_get_compression_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_compression() is None
+    assert state.get(COMPRESSION) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -692,15 +713,15 @@ def test_get_compression_none():
 def test_get_compression(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.COMPRESSION] = bytes([byte_val])
-    assert state.get_compression() == expected
+    state._state[COMPRESSION.cc] = bytes([byte_val])
+    assert state.get(COMPRESSION) == expected
 
 
 async def test_set_compression():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_compression(CompressionMode.HIGH)
-    client.request.assert_called_with(1, CommandCodes.COMPRESSION, bytes([0x02]), 0)
+    await state.set(COMPRESSION, CompressionMode.HIGH)
+    client.request.assert_called_with(1, COMPRESSION.cc, bytes([0x02]), 0)
 
 
 # --- IMAX Enhanced (0x0C) ---
@@ -709,7 +730,7 @@ async def test_set_compression():
 def test_get_imax_enhanced_none():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    assert state.get_imax_enhanced() is None
+    assert state.get(IMAX_ENHANCED) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -720,8 +741,8 @@ def test_get_imax_enhanced_none():
 def test_get_imax_enhanced(byte_val, expected):
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.IMAX_ENHANCED] = bytes([byte_val])
-    assert state.get_imax_enhanced() == expected
+    state._state[IMAX_ENHANCED.cc] = bytes([byte_val])
+    assert state.get(IMAX_ENHANCED) == expected
 
 
 @pytest.mark.parametrize("mode, expected_byte", [
@@ -733,9 +754,9 @@ async def test_set_imax_enhanced(mode, expected_byte):
     """Set values are asymmetric: OFF->0xF3, ON->0xF2, AUTO->0xF1."""
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    await state.set_imax_enhanced(mode)
+    await state.set(IMAX_ENHANCED, mode)
     client.request.assert_called_with(
-        1, CommandCodes.IMAX_ENHANCED, bytes([expected_byte]), 0)
+        1, IMAX_ENHANCED.cc, bytes([expected_byte]), 0)
 
 
 # --- Network Playback Status (0x1C) ---
@@ -744,7 +765,7 @@ async def test_set_imax_enhanced(mode, expected_byte):
 def test_get_network_playback_status_none():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    assert state.get_network_playback_status() is None
+    assert state.get(NETWORK_PLAYBACK_STATUS) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -756,8 +777,8 @@ def test_get_network_playback_status_none():
 def test_get_network_playback_status(byte_val, expected):
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.NETWORK_PLAYBACK_STATUS] = bytes([byte_val])
-    assert state.get_network_playback_status() == expected
+    state._state[NETWORK_PLAYBACK_STATUS.cc] = bytes([byte_val])
+    assert state.get(NETWORK_PLAYBACK_STATUS) == expected
 
 
 # --- Now Playing Info (0x64) ---
@@ -801,7 +822,7 @@ def test_get_bluetooth_status_none():
 def test_get_bluetooth_status_no_connection():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.BLUETOOTH_STATUS] = bytes([0x00])
+    state._state[BLUETOOTH_STATUS.cc] = bytes([0x00])
     status, track = state.get_bluetooth_status()
     assert status == BluetoothAudioStatus.NO_CONNECTION
     assert track == ""
@@ -810,7 +831,7 @@ def test_get_bluetooth_status_no_connection():
 def test_get_bluetooth_status_playing_with_track():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.BLUETOOTH_STATUS] = bytes([0x03]) + b"My Song"
+    state._state[BLUETOOTH_STATUS.cc] = bytes([0x03]) + b"My Song"
     status, track = state.get_bluetooth_status()
     assert status == BluetoothAudioStatus.PLAYING_AAC
     assert track == "My Song"
@@ -824,7 +845,7 @@ async def test_send_playback():
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_playback(RC5CodePlayback.PLAY)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x35]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x35]), 0)
 
 
 async def test_send_navigation():
@@ -832,7 +853,7 @@ async def test_send_navigation():
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_navigation(RC5CodeNavigation.UP)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x56]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x56]), 0)
 
 
 async def test_send_toggle():
@@ -840,7 +861,7 @@ async def test_send_toggle():
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_toggle(RC5CodeToggle.RADIO)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x5B]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x5B]), 0)
 
 
 async def test_send_playback_unsupported_model():
@@ -891,17 +912,17 @@ def test_rc5_avr_has_navigation(model):
 async def test_inc_bass_equalization():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    await state.inc_bass_equalization()
+    await state.inc(BASS_EQUALIZATION)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x2C]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x2C]), 0)
 
 
 async def test_dec_bass_equalization():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    await state.dec_bass_equalization()
+    await state.dec(BASS_EQUALIZATION)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x38]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x38]), 0)
 
 
 async def test_inc_bass_equalization_unsupported():
@@ -909,7 +930,7 @@ async def test_inc_bass_equalization_unsupported():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APISA_SERIES)
     with pytest.raises(ValueError):
-        await state.inc_bass_equalization()
+        await state.inc(BASS_EQUALIZATION)
 
 
 def test_rc5_bass_table_entries_are_valid():
@@ -925,9 +946,9 @@ def test_rc5_bass_table_entries_are_valid():
 async def test_set_display_brightness():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    await state.set_display_brightness(DisplayBrightness.L2)
+    await state.set(DISPLAY_BRIGHTNESS, DisplayBrightness.L2)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x23]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x23]), 0)
 
 
 async def test_set_hdmi_output():
@@ -935,7 +956,7 @@ async def test_set_hdmi_output():
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
     await state.set_hdmi_output(HdmiOutput.OUT_1_2)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4B]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x4B]), 0)
 
 
 async def test_set_hdmi_output_unsupported():
@@ -963,12 +984,12 @@ def test_rc5_hdmi_output_table_entries_are_valid():
 async def test_set_direct_mode():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    await state.set_direct_mode(True)
+    await state.set(DIRECT_MODE, True)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4E]), 0)
-    await state.set_direct_mode(False)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x4E]), 0)
+    await state.set(DIRECT_MODE, False)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4F]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x4F]), 0)
 
 
 # --- Command support checking ---
@@ -979,8 +1000,8 @@ def test_is_command_supported_universal():
     client = MagicMock(spec=Client)
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "SA30"})
-    assert state._is_command_supported(CommandCodes.POWER) is True
-    assert state._is_command_supported(CommandCodes.VOLUME) is True
+    assert state._is_command_supported(POWER) is True
+    assert state._is_command_supported(VOLUME) is True
 
 
 def test_is_command_supported_matching_model():
@@ -989,9 +1010,9 @@ def test_is_command_supported_matching_model():
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "AVR30"})
     # IMAX_ENHANCED has version=APIVERSION_IMAX_SERIES which includes AVR30
-    assert state._is_command_supported(CommandCodes.IMAX_ENHANCED) is True
+    assert state._is_command_supported(IMAX_ENHANCED) is True
     # BLUETOOTH_STATUS has version=APIVERSION_HDA_SERIES which includes AVR30
-    assert state._is_command_supported(CommandCodes.BLUETOOTH_STATUS) is True
+    assert state._is_command_supported(BLUETOOTH_STATUS) is True
 
 
 def test_is_command_supported_non_matching_model():
@@ -1000,11 +1021,11 @@ def test_is_command_supported_non_matching_model():
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "SA30"})
     # IMAX_ENHANCED is not supported on SA series
-    assert state._is_command_supported(CommandCodes.IMAX_ENHANCED) is False
+    assert state._is_command_supported(IMAX_ENHANCED) is False
     # BLUETOOTH_STATUS is HDA-only
-    assert state._is_command_supported(CommandCodes.BLUETOOTH_STATUS) is False
+    assert state._is_command_supported(BLUETOOTH_STATUS) is False
     # VIDEO_SELECTION is PRE_HDA_AVR only
-    assert state._is_command_supported(CommandCodes.VIDEO_SELECTION) is False
+    assert state._is_command_supported(VIDEO_SELECTION) is False
 
 
 def test_is_command_supported_no_model_is_permissive():
@@ -1013,7 +1034,7 @@ def test_is_command_supported_no_model_is_permissive():
     state = State(client, 1)
     # No AMX discovery yet, model is None
     assert state.model is None
-    assert state._is_command_supported(CommandCodes.IMAX_ENHANCED) is True
+    assert state._is_command_supported(IMAX_ENHANCED) is True
 
 
 def test_is_command_supported_runtime_blocklist():
@@ -1021,9 +1042,9 @@ def test_is_command_supported_runtime_blocklist():
     client = MagicMock(spec=Client)
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "AVR30"})
-    assert state._is_command_supported(CommandCodes.VOLUME) is True
-    state._unsupported_commands.add(CommandCodes.VOLUME)
-    assert state._is_command_supported(CommandCodes.VOLUME) is False
+    assert state._is_command_supported(VOLUME) is True
+    state._unsupported_commands.add(VOLUME.cc)
+    assert state._is_command_supported(VOLUME) is False
 
 
 def test_require_command_raises_for_unsupported():
@@ -1032,8 +1053,8 @@ def test_require_command_raises_for_unsupported():
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "SA30"})
     with pytest.raises(UnsupportedCommand) as exc_info:
-        state._require_command(CommandCodes.IMAX_ENHANCED)
-    assert exc_info.value.cc == CommandCodes.IMAX_ENHANCED
+        state._require_command(IMAX_ENHANCED)
+    assert exc_info.value.cc == IMAX_ENHANCED
     assert exc_info.value.model == "SA30"
 
 
@@ -1042,17 +1063,17 @@ def test_require_command_passes_for_supported():
     client = MagicMock(spec=Client)
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "AVR30"})
-    state._require_command(CommandCodes.POWER)  # should not raise
-    state._require_command(CommandCodes.IMAX_ENHANCED)  # should not raise
+    state._require_command(POWER)  # should not raise
+    state._require_command(IMAX_ENHANCED)  # should not raise
 
 
 def test_require_command_raises_for_runtime_blocked():
     """_require_command raises for commands blocked at runtime."""
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._unsupported_commands.add(CommandCodes.VOLUME)
+    state._unsupported_commands.add(VOLUME.cc)
     with pytest.raises(UnsupportedCommand):
-        state._require_command(CommandCodes.VOLUME)
+        state._require_command(VOLUME)
 
 
 async def test_setter_raises_for_unsupported_command():
@@ -1061,7 +1082,7 @@ async def test_setter_raises_for_unsupported_command():
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "SA30"})
     with pytest.raises(UnsupportedCommand):
-        await state.set_imax_enhanced(ImaxEnhancedMode.AUTO)
+        await state.set(IMAX_ENHANCED, ImaxEnhancedMode.AUTO)
     client.request.assert_not_called()
 
 
@@ -1069,9 +1090,9 @@ async def test_setter_raises_for_runtime_blocked_command():
     """Setter methods raise UnsupportedCommand for runtime-blocked commands."""
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._unsupported_commands.add(CommandCodes.VOLUME)
+    state._unsupported_commands.add(VOLUME.cc)
     with pytest.raises(UnsupportedCommand):
-        await state.set_volume(50)
+        await state.set(VOLUME, 50)
     client.request.assert_not_called()
 
 
@@ -1089,11 +1110,11 @@ async def test_update_skips_unsupported_commands():
     await asyncio.gather(*await state.get_update_tasks())
     requested_commands = [call.args[1] for call in client.request.call_args_list]
     # These commands have version restrictions that exclude SA30
-    assert CommandCodes.IMAX_ENHANCED not in requested_commands
-    assert CommandCodes.BLUETOOTH_STATUS not in requested_commands
-    assert CommandCodes.VIDEO_SELECTION not in requested_commands
+    assert IMAX_ENHANCED.cc not in requested_commands
+    assert BLUETOOTH_STATUS.cc not in requested_commands
+    assert VIDEO_SELECTION.cc not in requested_commands
     # But universal commands like POWER should still be requested
-    assert CommandCodes.POWER in requested_commands
+    assert POWER.cc in requested_commands
 
 
 async def test_update_records_command_not_recognised():
@@ -1102,13 +1123,13 @@ async def test_update_records_command_not_recognised():
 
     client = MagicMock(spec=Client)
     client.connected = True
-    client.request.side_effect = CommandNotRecognised(cc=CommandCodes.MENU)
+    client.request.side_effect = CommandNotRecognised(cc=MENU.cc)
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "AVR450"})
 
-    assert CommandCodes.MENU not in state._unsupported_commands
+    assert MENU.cc not in state._unsupported_commands
     await asyncio.gather(*await state.get_update_tasks())
-    assert CommandCodes.MENU in state._unsupported_commands
+    assert MENU.cc in state._unsupported_commands
 
 
 # --- Video Selection (0x0A) ---
@@ -1117,8 +1138,8 @@ async def test_update_records_command_not_recognised():
 async def test_set_video_selection():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_video_selection(VideoSelection.SAT)
-    client.request.assert_called_with(1, CommandCodes.VIDEO_SELECTION, bytes([0x01]), 0)
+    await state.set(VIDEO_SELECTION, VideoSelection.SAT)
+    client.request.assert_called_with(1, VIDEO_SELECTION.cc, bytes([0x01]), 0)
 
 
 # --- Update conditions / _should_update -----------------------------------
@@ -1127,8 +1148,8 @@ def _state_at_source(source: SourceCodes) -> State:
     """Helper: a fresh State with CURRENT_SOURCE seeded to `source`."""
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.CURRENT_SOURCE] = source.to_bytes(
-        state._api_model, state._zn,
+    state._state[CURRENT_SOURCE.cc] = source.to_bytes(
+        state.api_model, state._zn,
     )
     return state
 
@@ -1136,47 +1157,47 @@ def _state_at_source(source: SourceCodes) -> State:
 def test_should_update_no_update_flag():
     """Commands without the UPDATE flag are never polled."""
     state = State(MagicMock(spec=Client), 1)
-    assert not (CommandCodes.RESTORE_FACTORY_DEFAULT.flags & CommandFlags.UPDATE)
-    assert state._should_update(CommandCodes.RESTORE_FACTORY_DEFAULT) is False
+    assert not (RESTORE_FACTORY_DEFAULT.flags & CommandFlags.UPDATE)
+    assert state._should_update(RESTORE_FACTORY_DEFAULT) is False
 
 
 def test_should_update_pushed_first_pass_polls_even_if_known():
     """Pushed CCs are polled during the initial pass regardless of cache."""
     state = State(MagicMock(spec=Client), 1)
-    state._state[CommandCodes.POWER] = bytes([1])
+    state._state[POWER.cc] = bytes([1])
     assert state._updated.is_set() is False
-    assert state._should_update(CommandCodes.POWER) is True
+    assert state._should_update(POWER) is True
 
 
 def test_should_update_pushed_skipped_after_first_pass():
     state = State(MagicMock(spec=Client), 1)
     state._updated.set()
-    assert CommandCodes.POWER not in state._state
-    assert state._should_update(CommandCodes.POWER) is False
+    assert POWER.cc not in state._state
+    assert state._should_update(POWER) is False
 
 
 def test_should_update_not_pushed_always_polls():
     state = _state_at_source(SourceCodes.NET)
     state._updated.set()
     # NETWORK_PLAYBACK_STATUS is NOT_PUSHED, sources={NET, USB, NET_USB}
-    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is True
+    assert state._should_update(NETWORK_PLAYBACK_STATUS) is True
 
 
 def test_should_update_sources_no_match():
     state = _state_at_source(SourceCodes.CD)
-    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is False
+    assert state._should_update(NETWORK_PLAYBACK_STATUS) is False
 
 
 def test_should_update_sources_match():
     state = _state_at_source(SourceCodes.NET)
-    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is True
+    assert state._should_update(NETWORK_PLAYBACK_STATUS) is True
 
 
 def test_should_update_sources_unknown_is_permissive():
     """When source isn't yet known, fetch source-gated CCs anyway."""
     state = State(MagicMock(spec=Client), 1)
     assert state.get_source() is None
-    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is True
+    assert state._should_update(NETWORK_PLAYBACK_STATUS) is True
 
 
 def test_should_update_zone_2_requires_zone_support():
@@ -1184,9 +1205,9 @@ def test_should_update_zone_2_requires_zone_support():
     client = MagicMock(spec=Client)
     state = State(client, 2)
     # MUTE has ZONE_SUPPORT — ok
-    assert state._should_update(CommandCodes.MUTE) is True
+    assert state._should_update(MUTE) is True
     # INCOMING_AUDIO_FORMAT has no ZONE_SUPPORT
-    assert state._should_update(CommandCodes.INCOMING_AUDIO_FORMAT) is False
+    assert state._should_update(INCOMING_AUDIO_FORMAT) is False
 
 
 async def test_update_skips_commands_for_wrong_source():
@@ -1198,10 +1219,10 @@ async def test_update_skips_commands_for_wrong_source():
     # Run the tasks so we can inspect what got requested
     await asyncio.gather(*tasks)
     requested = [call.args[1] for call in state._client.request.call_args_list]
-    assert CommandCodes.NETWORK_PLAYBACK_STATUS not in requested
-    assert CommandCodes.NOW_PLAYING_INFO not in requested
+    assert NETWORK_PLAYBACK_STATUS.cc not in requested
+    assert NOW_PLAYING_INFO.cc not in requested
     # But POWER (no source gate) should be fetched
-    assert CommandCodes.POWER in requested
+    assert POWER.cc in requested
 
 
 async def test_update_pushed_skipped_after_first_pass():
@@ -1214,47 +1235,47 @@ async def test_update_pushed_skipped_after_first_pass():
     await asyncio.gather(*tasks)
     requested = [call.args[1] for call in state._client.request.call_args_list]
     # POWER is pushed — should NOT appear in a post-first-pass batch
-    assert CommandCodes.POWER not in requested
+    assert POWER.cc not in requested
     # NETWORK_PLAYBACK_STATUS is NOT_PUSHED + source matches — should appear
-    assert CommandCodes.NETWORK_PLAYBACK_STATUS in requested
+    assert NETWORK_PLAYBACK_STATUS.cc in requested
 
 
 # --- Accessor source gating ----------------------------------------------
 
 def test_get_dab_station_returns_none_when_source_mismatch():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.DAB_STATION] = b"BBC R4"
-    assert state.get_dab_station() is None
+    state._state[DAB_STATION.cc] = b"BBC R4"
+    assert state.get(DAB_STATION) is None
 
 
 def test_get_dab_station_returns_value_when_source_unknown():
     state = State(MagicMock(spec=Client), 1)
-    state._state[CommandCodes.DAB_STATION] = b"BBC R4"
-    assert state.get_dab_station() == "BBC R4"
+    state._state[DAB_STATION.cc] = b"BBC R4"
+    assert state.get(DAB_STATION) == "BBC R4"
 
 
 def test_get_dab_station_returns_value_when_source_matches():
     state = _state_at_source(SourceCodes.DAB)
-    state._state[CommandCodes.DAB_STATION] = b"BBC R4"
-    assert state.get_dab_station() == "BBC R4"
+    state._state[DAB_STATION.cc] = b"BBC R4"
+    assert state.get(DAB_STATION) == "BBC R4"
 
 
 def test_get_dls_pdt_gated_by_source():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.DLS_PDT_INFO] = b"Now Playing"
-    assert state.get_dls_pdt() is None
+    state._state[DLS_PDT.cc] = b"Now Playing"
+    assert state.get(DLS_PDT) is None
 
 
 def test_get_rds_information_gated_by_source():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.RDS_INFORMATION] = b"BBC R4"
-    assert state.get_rds_information() is None
+    state._state[RDS_INFORMATION.cc] = b"BBC R4"
+    assert state.get(RDS_INFORMATION) is None
 
 
 def test_get_tuner_preset_gated_by_source():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.TUNER_PRESET] = bytes([3])
-    assert state.get_tuner_preset() is None
+    state._state[TUNER_PRESET.cc] = bytes([3])
+    assert state.get(TUNER_PRESET) is None
 
 
 def test_get_preset_details_gated_by_source():
@@ -1265,13 +1286,13 @@ def test_get_preset_details_gated_by_source():
 
 def test_get_network_playback_status_gated_by_source():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.NETWORK_PLAYBACK_STATUS] = bytes([0x01])
-    assert state.get_network_playback_status() is None
+    state._state[NETWORK_PLAYBACK_STATUS.cc] = bytes([0x01])
+    assert state.get(NETWORK_PLAYBACK_STATUS) is None
 
 
 def test_get_bluetooth_status_gated_by_source():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.BLUETOOTH_STATUS] = bytes([0x01]) + b"Track"
+    state._state[BLUETOOTH_STATUS.cc] = bytes([0x01]) + b"Track"
     assert state.get_bluetooth_status() == (None, None)
 
 
@@ -1283,5 +1304,5 @@ def test_get_now_playing_gated_by_source():
 
 async def test_set_tuner_preset_noops_when_source_mismatch():
     state = _state_at_source(SourceCodes.CD)
-    await state.set_tuner_preset(3)
+    await state.set(TUNER_PRESET, 3)
     state._client.request.assert_not_called()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,10 +1,22 @@
+from arcam.fmj.commands import (
+    BLUETOOTH_STATUS,
+    CURRENT_SOURCE,
+    INCOMING_AUDIO_FORMAT,
+    MENU,
+    NOW_PLAYING_INFO,
+    RESTORE_FACTORY_DEFAULT,
+    SAVE_RESTORE_COPY_OF_SETTINGS,
+    SIMULATE_RC5_IR_COMMAND,
+)
 import asyncio
 import pytest
 from unittest.mock import MagicMock
 from arcam.fmj.client import Client
-from arcam.fmj.state import State, _get_scaled_negative, _set_scaled
+from arcam.fmj.state import State
+from arcam.fmj.codecs import _get_scaled_negative, _set_scaled
 from arcam.fmj.codecs import (
     AnswerCodes,
+    AutoShutdown,
     BluetoothAudioStatus,
     CompressionMode,
     DisplayBrightness,
@@ -19,9 +31,42 @@ from arcam.fmj.codecs import (
     SAVE_RESTORE_CONFIRMATION,
     SaveRestoreSubCommand,
     SourceCodes,
+    TemperatureSensor,
     VideoSelection,
 )
-from arcam.fmj.commands import CommandCodes, CommandFlags, POWER_WRITE_SUPPORTED
+from arcam.fmj.commands import CommandFlags, POWER_WRITE_SUPPORTED
+from arcam.fmj.commands import (
+    AUTO_SHUTDOWN_CONTROL,
+    BALANCE,
+    BASS_EQUALIZATION,
+    COMPRESSION,
+    DAB_STATION,
+    DECODE_MODE_2CH,
+    DECODE_MODE_MCH,
+    DIRECT_MODE,
+    DISPLAY_BRIGHTNESS,
+    DISPLAY_INFO_TYPE,
+    DLS_PDT,
+    DOLBY_AUDIO,
+    HEADPHONES,
+    IMAX_ENHANCED,
+    INCOMING_AUDIO_SAMPLE_RATE,
+    LIPSYNC_DELAY,
+    LIFTER_TEMPERATURE,
+    MUTE,
+    NETWORK_PLAYBACK_STATUS,
+    OUTPUT_TEMPERATURE,
+    POWER,
+    RDS_INFORMATION,
+    ROOM_EQUALIZATION,
+    ROOM_EQ_NAMES,
+    SUBWOOFER_TRIM,
+    SUB_STEREO_TRIM,
+    TREBLE_EQUALIZATION,
+    TUNER_PRESET,
+    VIDEO_SELECTION,
+    VOLUME,
+)
 from arcam.fmj.errors import UnsupportedCommand
 from arcam.fmj.models import ApiModel
 from arcam.fmj.packets import AmxDuetResponse, ResponsePacket
@@ -96,19 +141,19 @@ async def test_power_on(zn, api_model):
     state = make_state(client, zn, api_model)
     response = ResponsePacket(
         zn,
-        CommandCodes.SIMULATE_RC5_IR_COMMAND,
+        SIMULATE_RC5_IR_COMMAND.cc,
         AnswerCodes.STATUS_UPDATE,
         bytes([0x01]),
     )
     client.request.return_value = response
-    await state.set_power(True)
+    await state.set(POWER, True)
     if api_model in POWER_WRITE_SUPPORTED:
-        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x01]), 0)
+        client.request.assert_called_with(zn, POWER.cc, bytes([0x01]), 0)
     else:
         # zn, api_model, power
         code = PARAMS_TO_RC5COMMAND[zn, api_model, True]
         client.request.assert_called_with(
-            zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code, 0)
+            zn, SIMULATE_RC5_IR_COMMAND.cc, code, 0)
 
 
 @pytest.mark.parametrize("zn, api_model", TEST_PARAMS)
@@ -116,15 +161,15 @@ async def test_power_off(zn, api_model):
     client = MagicMock(spec=Client)
     state = make_state(client, zn, api_model)
 
-    assert state.get_power() is None
-    await state.set_power(False)
+    assert state.get(POWER) is None
+    await state.set(POWER, False)
     if api_model in POWER_WRITE_SUPPORTED:
-        client.request.assert_called_with(zn, CommandCodes.POWER, bytes([0x00]), 0)
+        client.request.assert_called_with(zn, POWER.cc, bytes([0x00]), 0)
     else:
         # zn, api_model, power
         code = PARAMS_TO_RC5COMMAND[zn, api_model, False]
-        client.request.assert_called_with(zn, CommandCodes.SIMULATE_RC5_IR_COMMAND, code)
-    assert state.get_power() is False
+        client.request.assert_called_with(zn, SIMULATE_RC5_IR_COMMAND.cc, code, 0)
+    assert state.get(POWER) is False
 
 
 # --- Scaled value encoding ---
@@ -182,42 +227,42 @@ def test_set_scaled():
 def test_get_volume_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_volume() is None
+    assert state.get(VOLUME) is None
 
 
 def test_get_volume():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.VOLUME] = bytes([50])
-    assert state.get_volume() == 50
+    state._state[VOLUME.cc] = bytes([50])
+    assert state.get(VOLUME) == 50
 
 
 @pytest.mark.parametrize("data", [b"", bytes(2)])
 @pytest.mark.parametrize(
-    "command,getter",
+    "command",
     [
-        (CommandCodes.VOLUME, State.get_volume),
-        (CommandCodes.POWER, State.get_power),
-        (CommandCodes.MENU, State.get_menu),
-        (CommandCodes.MUTE, State.get_mute),
-        (CommandCodes.HEADPHONES, State.get_headphones),
-        (CommandCodes.DISPLAY_INFORMATION_TYPE, State.get_display_info_type),
-        (CommandCodes.DECODE_MODE_STATUS_2CH, State.get_decode_mode_2ch),
-        (CommandCodes.DECODE_MODE_STATUS_MCH, State.get_decode_mode_mch),
-        (CommandCodes.ROOM_EQUALIZATION, State.get_room_equalization),
-        (CommandCodes.DOLBY_AUDIO, State.get_dolby_audio),
-        (CommandCodes.COMPRESSION, State.get_compression),
-        (CommandCodes.IMAX_ENHANCED, State.get_imax_enhanced),
-        (CommandCodes.VIDEO_SELECTION, State.get_video_selection),
-        (CommandCodes.TUNER_PRESET, State.get_tuner_preset),
-        (CommandCodes.NETWORK_PLAYBACK_STATUS, State.get_network_playback_status),
-        (CommandCodes.INCOMING_AUDIO_SAMPLE_RATE, State.get_incoming_audio_sample_rate),
+        VOLUME,
+        POWER,
+        MENU,
+        MUTE,
+        HEADPHONES,
+        DISPLAY_INFO_TYPE,
+        DECODE_MODE_2CH,
+        DECODE_MODE_MCH,
+        ROOM_EQUALIZATION,
+        DOLBY_AUDIO,
+        COMPRESSION,
+        IMAX_ENHANCED,
+        VIDEO_SELECTION,
+        TUNER_PRESET,
+        NETWORK_PLAYBACK_STATUS,
+        INCOMING_AUDIO_SAMPLE_RATE,
     ],
 )
-def test_scalar_getter_invalid_length(data, command, getter):
+def test_scalar_getter_invalid_length(data, command):
     state = State(MagicMock(spec=Client), 1)
-    state._state[command] = data
-    assert getter(state) is None
+    state._state[command.cc] = data
+    assert state.get(command) is None
 
 
 # --- Mute ---
@@ -226,7 +271,7 @@ def test_scalar_getter_invalid_length(data, command, getter):
 def test_get_mute_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_mute() is None
+    assert state.get(MUTE) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -236,25 +281,25 @@ def test_get_mute_none():
 def test_get_mute(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.MUTE] = bytes([byte_val])
-    assert state.get_mute() == expected
+    state._state[MUTE.cc] = bytes([byte_val])
+    assert state.get(MUTE) == expected
 
 
 async def test_set_mute_write_supported():
     """SA/PA/ST series use direct MUTE command."""
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APISA_SERIES)
-    await state.set_mute(True)
-    client.request.assert_called_with(1, CommandCodes.MUTE, bytes([0x00]), 0)
+    await state.set(MUTE, True)
+    client.request.assert_called_with(1, MUTE.cc, bytes([0x00]), 0)
 
 
 async def test_set_mute_rc5():
     """450/860/HDA series use RC5 IR command for mute."""
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.API450_SERIES)
-    await state.set_mute(True)
+    await state.set(MUTE, True)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([16, 119]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([16, 119]), 0)
 
 
 # --- Decode mode ---
@@ -270,7 +315,7 @@ async def test_set_mute_rc5():
 def test_get_2ch(fmt, expected):
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.INCOMING_AUDIO_FORMAT] = bytes([fmt, 0x02])
+    state._state[INCOMING_AUDIO_FORMAT.cc] = bytes([fmt, 0x02])
     assert state.get_2ch() == expected
 
 
@@ -284,7 +329,7 @@ def test_get_2ch_no_audio():
 @pytest.mark.parametrize("data", [b"", bytes(1), bytes(3)])
 def test_get_incoming_audio_format_invalid_length(data):
     state = make_state(MagicMock(spec=Client), 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.INCOMING_AUDIO_FORMAT] = data
+    state._state[INCOMING_AUDIO_FORMAT.cc] = data
     assert state.get_incoming_audio_format() == (None, None)
 
 
@@ -294,23 +339,23 @@ def test_get_incoming_audio_format_invalid_length(data):
 def test_listen_status_update():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._listen(ResponsePacket(1, CommandCodes.VOLUME, AnswerCodes.STATUS_UPDATE, bytes([42])))
-    assert state.get_volume() == 42
+    state._listen(ResponsePacket(1, VOLUME.cc, AnswerCodes.STATUS_UPDATE, bytes([42])))
+    assert state.get(VOLUME) == 42
 
 
 def test_listen_ignores_other_zone():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._listen(ResponsePacket(2, CommandCodes.VOLUME, AnswerCodes.STATUS_UPDATE, bytes([42])))
-    assert state.get_volume() is None
+    state._listen(ResponsePacket(2, VOLUME.cc, AnswerCodes.STATUS_UPDATE, bytes([42])))
+    assert state.get(VOLUME) is None
 
 
 def test_listen_clears_on_error():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.VOLUME] = bytes([42])
-    state._listen(ResponsePacket(1, CommandCodes.VOLUME, AnswerCodes.COMMAND_NOT_RECOGNISED, b""))
-    assert state.get_volume() is None
+    state._state[VOLUME.cc] = bytes([42])
+    state._listen(ResponsePacket(1, VOLUME.cc, AnswerCodes.COMMAND_NOT_RECOGNISED, b""))
+    assert state.get(VOLUME) is None
 
 
 def test_listen_amxduet():
@@ -320,7 +365,7 @@ def test_listen_amxduet():
     state._listen(amx)
     assert state.model == "AV860"
     assert state.revision == "1.2.3"
-    assert state._api_model == ApiModel.API860_SERIES
+    assert state.api_model == ApiModel.API860_SERIES
 
 
 def test_amxduet_resolves_api_model_for_every_zone():
@@ -331,27 +376,73 @@ def test_amxduet_resolves_api_model_for_every_zone():
     z1._listen(amx)
     z2._listen(amx)
     assert z1.model == z2.model == "AV41"
-    assert z1._api_model == z2._api_model == ApiModel.APIHDA_SERIES
+    assert z1.api_model == z2.api_model == ApiModel.APIHDA_SERIES
+
+
+@pytest.mark.parametrize(
+    "model, data, expected",
+    [
+        ("SA10", 0x01, AutoShutdown.MINUTES_30),
+        ("SA20", 0x04, AutoShutdown.HOURS_4),
+        ("SA30", 0x01, AutoShutdown.MINUTES_20),
+        ("SA750", 0x05, AutoShutdown.HOURS_4),
+        ("PA720", 0x02, AutoShutdown.MINUTES_30),
+        ("ST60", 0x03, AutoShutdown.HOUR_1),
+    ],
+)
+def test_get_auto_shutdown(model, data, expected):
+    client = MagicMock(spec=Client)
+    state = State(client, 1)
+    state._amxduet = AmxDuetResponse({"Device-Model": model})
+    state._state[AUTO_SHUTDOWN_CONTROL.cc] = bytes([data])
+    assert state.get(AUTO_SHUTDOWN_CONTROL) == expected
+
+
+@pytest.mark.parametrize(
+    "model, value, expected",
+    [
+        ("SA10", AutoShutdown.HOUR_1, 0x02),
+        ("SA30", AutoShutdown.HOUR_1, 0x03),
+        ("PA720", AutoShutdown.HOURS_4, 0x05),
+        ("ST60", AutoShutdown.MINUTES_20, 0x01),
+    ],
+)
+async def test_set_auto_shutdown(model, value, expected):
+    client = MagicMock(spec=Client)
+    state = State(client, 1)
+    state._amxduet = AmxDuetResponse({"Device-Model": model})
+    await state.set(AUTO_SHUTDOWN_CONTROL, value)
+    client.request.assert_called_once_with(
+        1, AUTO_SHUTDOWN_CONTROL.cc, bytes([expected]), 0
+    )
+
+
+async def test_set_auto_shutdown_rejects_unsupported_timeout():
+    client = MagicMock(spec=Client)
+    state = State(client, 1)
+    state._amxduet = AmxDuetResponse({"Device-Model": "SA10"})
+    with pytest.raises(ValueError, match="MINUTES_20 is not supported on SA10"):
+        await state.set(AUTO_SHUTDOWN_CONTROL, AutoShutdown.MINUTES_20)
 
 
 # --- Save/Restore Settings (0x06) ---
 
 
-async def test_save_settings_default_pin():
+async def test_save_settings_uses_zone_one():
     client = MagicMock(spec=Client)
-    state = State(client, 1)
+    state = State(client, 2)
     await state.save_settings()
     client.request.assert_called_with(
-        1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
+        1, SAVE_RESTORE_COPY_OF_SETTINGS.cc,
         bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]), 0)
 
 
-async def test_restore_settings_default_pin():
+async def test_restore_settings_uses_zone_one():
     client = MagicMock(spec=Client)
-    state = State(client, 1)
+    state = State(client, 2)
     await state.restore_settings()
     client.request.assert_called_with(
-        1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
+        1, SAVE_RESTORE_COPY_OF_SETTINGS.cc,
         bytes([SaveRestoreSubCommand.RESTORE, *SAVE_RESTORE_CONFIRMATION, 0x01, 0x02, 0x03, 0x04]), 0)
 
 
@@ -360,7 +451,7 @@ async def test_save_settings_custom_pin():
     state = State(client, 1)
     await state.save_settings(pin=(9, 8, 7, 6))
     client.request.assert_called_with(
-        1, CommandCodes.SAVE_RESTORE_COPY_OF_SETTINGS,
+        1, SAVE_RESTORE_COPY_OF_SETTINGS.cc,
         bytes([SaveRestoreSubCommand.SAVE, *SAVE_RESTORE_CONFIRMATION, 0x09, 0x08, 0x07, 0x06]), 0)
 
 
@@ -370,7 +461,7 @@ async def test_save_settings_custom_pin():
 def test_get_headphones_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_headphones() is None
+    assert state.get(HEADPHONES) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -380,8 +471,8 @@ def test_get_headphones_none():
 def test_get_headphones(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.HEADPHONES] = bytes([byte_val])
-    assert state.get_headphones() == expected
+    state._state[HEADPHONES.cc] = bytes([byte_val])
+    assert state.get(HEADPHONES) == expected
 
 
 # --- Display Information Type (0x09) ---
@@ -390,30 +481,32 @@ def test_get_headphones(byte_val, expected):
 def test_get_display_info_type_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_display_info_type() is None
+    assert state.get(DISPLAY_INFO_TYPE) is None
 
 
 def test_get_display_info_type():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.DISPLAY_INFORMATION_TYPE] = bytes([0x02])
-    assert state.get_display_info_type() == 2
+    state._state[DISPLAY_INFO_TYPE.cc] = bytes([0x02])
+    assert state.get(DISPLAY_INFO_TYPE) == 2
 
 
 async def test_set_display_info_type():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_display_info_type(0x03)
+    await state.set(DISPLAY_INFO_TYPE, 0x03)
     client.request.assert_called_with(
-        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0x03]), 0)
+        1, DISPLAY_INFO_TYPE.cc, bytes([0x03]), 0
+    )
 
 
 async def test_set_display_info_type_cycle():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_display_info_type(0xE0)
+    await state.set(DISPLAY_INFO_TYPE, 0xE0)
     client.request.assert_called_with(
-        1, CommandCodes.DISPLAY_INFORMATION_TYPE, bytes([0xE0]), 0)
+        1, DISPLAY_INFO_TYPE.cc, bytes([0xE0]), 0
+    )
 
 
 # --- Lipsync Delay (0x40) ---
@@ -422,7 +515,7 @@ async def test_set_display_info_type_cycle():
 def test_get_lipsync_delay_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_lipsync_delay() is None
+    assert state.get(LIPSYNC_DELAY) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -433,8 +526,8 @@ def test_get_lipsync_delay_none():
 def test_get_lipsync_delay(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.LIPSYNC_DELAY] = bytes([byte_val])
-    assert state.get_lipsync_delay() == expected
+    state._state[LIPSYNC_DELAY.cc] = bytes([byte_val])
+    assert state.get(LIPSYNC_DELAY) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -445,8 +538,8 @@ def test_get_lipsync_delay(byte_val, expected):
 async def test_set_lipsync_delay(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_lipsync_delay(value)
-    client.request.assert_called_with(1, CommandCodes.LIPSYNC_DELAY, bytes([expected_byte]), 0)
+    await state.set(LIPSYNC_DELAY, value)
+    client.request.assert_called_with(1, LIPSYNC_DELAY.cc, bytes([expected_byte]), 0)
 
 
 # --- Subwoofer Trim (0x3F) ---
@@ -455,7 +548,7 @@ async def test_set_lipsync_delay(value, expected_byte):
 def test_get_subwoofer_trim_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_subwoofer_trim() is None
+    assert state.get(SUBWOOFER_TRIM) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -469,8 +562,8 @@ def test_get_subwoofer_trim_none():
 def test_get_subwoofer_trim(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.SUBWOOFER_TRIM] = bytes([byte_val])
-    assert state.get_subwoofer_trim() == expected
+    state._state[SUBWOOFER_TRIM.cc] = bytes([byte_val])
+    assert state.get(SUBWOOFER_TRIM) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -483,8 +576,8 @@ def test_get_subwoofer_trim(byte_val, expected):
 async def test_set_subwoofer_trim(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_subwoofer_trim(value)
-    client.request.assert_called_with(1, CommandCodes.SUBWOOFER_TRIM, bytes([expected_byte]), 0)
+    await state.set(SUBWOOFER_TRIM, value)
+    client.request.assert_called_with(1, SUBWOOFER_TRIM.cc, bytes([expected_byte]), 0)
 
 
 # --- Sub Stereo Trim (0x45) ---
@@ -493,7 +586,7 @@ async def test_set_subwoofer_trim(value, expected_byte):
 def test_get_sub_stereo_trim_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_sub_stereo_trim() is None
+    assert state.get(SUB_STEREO_TRIM) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -505,8 +598,8 @@ def test_get_sub_stereo_trim_none():
 def test_get_sub_stereo_trim(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.SUB_STEREO_TRIM] = bytes([byte_val])
-    assert state.get_sub_stereo_trim() == expected
+    state._state[SUB_STEREO_TRIM.cc] = bytes([byte_val])
+    assert state.get(SUB_STEREO_TRIM) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -518,8 +611,8 @@ def test_get_sub_stereo_trim(byte_val, expected):
 async def test_set_sub_stereo_trim(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_sub_stereo_trim(value)
-    client.request.assert_called_with(1, CommandCodes.SUB_STEREO_TRIM, bytes([expected_byte]), 0)
+    await state.set(SUB_STEREO_TRIM, value)
+    client.request.assert_called_with(1, SUB_STEREO_TRIM.cc, bytes([expected_byte]), 0)
 
 
 # --- Treble Equalization (0x35) ---
@@ -528,7 +621,7 @@ async def test_set_sub_stereo_trim(value, expected_byte):
 def test_get_treble_equalization_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_treble_equalization() is None
+    assert state.get(TREBLE_EQUALIZATION) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -541,8 +634,8 @@ def test_get_treble_equalization_none():
 def test_get_treble_equalization(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.TREBLE_EQUALIZATION] = bytes([byte_val])
-    assert state.get_treble_equalization() == expected
+    state._state[TREBLE_EQUALIZATION.cc] = bytes([byte_val])
+    assert state.get(TREBLE_EQUALIZATION) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -553,8 +646,8 @@ def test_get_treble_equalization(byte_val, expected):
 async def test_set_treble_equalization(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_treble_equalization(value)
-    client.request.assert_called_with(1, CommandCodes.TREBLE_EQUALIZATION, bytes([expected_byte]), 0)
+    await state.set(TREBLE_EQUALIZATION, value)
+    client.request.assert_called_with(1, TREBLE_EQUALIZATION.cc, bytes([expected_byte]), 0)
 
 
 # --- Bass Equalization (0x36) ---
@@ -563,7 +656,7 @@ async def test_set_treble_equalization(value, expected_byte):
 def test_get_bass_equalization_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_bass_equalization() is None
+    assert state.get(BASS_EQUALIZATION) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -576,8 +669,8 @@ def test_get_bass_equalization_none():
 def test_get_bass_equalization(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.BASS_EQUALIZATION] = bytes([byte_val])
-    assert state.get_bass_equalization() == expected
+    state._state[BASS_EQUALIZATION.cc] = bytes([byte_val])
+    assert state.get(BASS_EQUALIZATION) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -590,8 +683,8 @@ def test_get_bass_equalization(byte_val, expected):
 async def test_set_bass_equalization(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_bass_equalization(value)
-    client.request.assert_called_with(1, CommandCodes.BASS_EQUALIZATION, bytes([expected_byte]), 0)
+    await state.set(BASS_EQUALIZATION, value)
+    client.request.assert_called_with(1, BASS_EQUALIZATION.cc, bytes([expected_byte]), 0)
 
 
 # --- Room EQ (0x37) ---
@@ -600,7 +693,7 @@ async def test_set_bass_equalization(value, expected_byte):
 def test_get_room_equalization_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_room_equalization() is None
+    assert state.get(ROOM_EQUALIZATION) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -612,8 +705,8 @@ def test_get_room_equalization_none():
 def test_get_room_equalization(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.ROOM_EQUALIZATION] = bytes([byte_val])
-    assert state.get_room_equalization() == expected
+    state._state[ROOM_EQUALIZATION.cc] = bytes([byte_val])
+    assert state.get(ROOM_EQUALIZATION) == expected
 
 
 @pytest.mark.parametrize("mode, expected_byte", [
@@ -625,8 +718,8 @@ def test_get_room_equalization(byte_val, expected):
 async def test_set_room_equalization(mode, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_room_equalization(mode)
-    client.request.assert_called_with(1, CommandCodes.ROOM_EQUALIZATION, bytes([expected_byte]), 0)
+    await state.set(ROOM_EQUALIZATION, mode)
+    client.request.assert_called_with(1, ROOM_EQUALIZATION.cc, bytes([expected_byte]), 0)
 
 
 # --- Room EQ Names (0x34) ---
@@ -635,7 +728,7 @@ async def test_set_room_equalization(mode, expected_byte):
 def test_get_room_eq_names_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_room_eq_names() is None
+    assert state.get(ROOM_EQ_NAMES) is None
 
 
 def test_get_room_eq_names():
@@ -643,8 +736,8 @@ def test_get_room_eq_names():
     state = State(client, 1)
     name1 = b"Living Room\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     name2 = b"Flat\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-    state._state[CommandCodes.ROOM_EQ_NAMES] = name1 + name2
-    names = state.get_room_eq_names()
+    state._state[ROOM_EQ_NAMES.cc] = name1 + name2
+    names = state.get(ROOM_EQ_NAMES)
     assert names == ["Living Room", "Flat"]
 
 
@@ -654,7 +747,7 @@ def test_get_room_eq_names():
 def test_get_dolby_audio_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_dolby_audio() is None
+    assert state.get(DOLBY_AUDIO) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -666,15 +759,15 @@ def test_get_dolby_audio_none():
 def test_get_dolby_audio(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.DOLBY_AUDIO] = bytes([byte_val])
-    assert state.get_dolby_audio() == expected
+    state._state[DOLBY_AUDIO.cc] = bytes([byte_val])
+    assert state.get(DOLBY_AUDIO) == expected
 
 
 async def test_set_dolby_audio():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_dolby_audio(DolbyAudioMode.NIGHT)
-    client.request.assert_called_with(1, CommandCodes.DOLBY_AUDIO, bytes([0x03]), 0)
+    await state.set(DOLBY_AUDIO, DolbyAudioMode.NIGHT)
+    client.request.assert_called_with(1, DOLBY_AUDIO.cc, bytes([0x03]), 0)
 
 
 # --- Balance (0x3B) ---
@@ -683,7 +776,7 @@ async def test_set_dolby_audio():
 def test_get_balance_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_balance() is None
+    assert state.get(BALANCE) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -697,8 +790,8 @@ def test_get_balance_none():
 def test_get_balance(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.BALANCE] = bytes([byte_val])
-    assert state.get_balance() == expected
+    state._state[BALANCE.cc] = bytes([byte_val])
+    assert state.get(BALANCE) == expected
 
 
 @pytest.mark.parametrize("value, expected_byte", [
@@ -711,8 +804,8 @@ def test_get_balance(byte_val, expected):
 async def test_set_balance(value, expected_byte):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_balance(value)
-    client.request.assert_called_with(1, CommandCodes.BALANCE, bytes([expected_byte]), 0)
+    await state.set(BALANCE, value)
+    client.request.assert_called_with(1, BALANCE.cc, bytes([expected_byte]), 0)
 
 
 # --- Compression (0x41) ---
@@ -721,7 +814,7 @@ async def test_set_balance(value, expected_byte):
 def test_get_compression_none():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    assert state.get_compression() is None
+    assert state.get(COMPRESSION) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -732,15 +825,15 @@ def test_get_compression_none():
 def test_get_compression(byte_val, expected):
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.COMPRESSION] = bytes([byte_val])
-    assert state.get_compression() == expected
+    state._state[COMPRESSION.cc] = bytes([byte_val])
+    assert state.get(COMPRESSION) == expected
 
 
 async def test_set_compression():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_compression(CompressionMode.HIGH)
-    client.request.assert_called_with(1, CommandCodes.COMPRESSION, bytes([0x02]), 0)
+    await state.set(COMPRESSION, CompressionMode.HIGH)
+    client.request.assert_called_with(1, COMPRESSION.cc, bytes([0x02]), 0)
 
 
 # --- IMAX Enhanced (0x0C) ---
@@ -749,7 +842,7 @@ async def test_set_compression():
 def test_get_imax_enhanced_none():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    assert state.get_imax_enhanced() is None
+    assert state.get(IMAX_ENHANCED) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -760,8 +853,8 @@ def test_get_imax_enhanced_none():
 def test_get_imax_enhanced(byte_val, expected):
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.IMAX_ENHANCED] = bytes([byte_val])
-    assert state.get_imax_enhanced() == expected
+    state._state[IMAX_ENHANCED.cc] = bytes([byte_val])
+    assert state.get(IMAX_ENHANCED) == expected
 
 
 @pytest.mark.parametrize("mode, expected_byte", [
@@ -773,9 +866,9 @@ async def test_set_imax_enhanced(mode, expected_byte):
     """Set values are asymmetric: OFF->0xF3, ON->0xF2, AUTO->0xF1."""
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    await state.set_imax_enhanced(mode)
+    await state.set(IMAX_ENHANCED, mode)
     client.request.assert_called_with(
-        1, CommandCodes.IMAX_ENHANCED, bytes([expected_byte]), 0)
+        1, IMAX_ENHANCED.cc, bytes([expected_byte]), 0)
 
 
 # --- Network Playback Status (0x1C) ---
@@ -784,7 +877,7 @@ async def test_set_imax_enhanced(mode, expected_byte):
 def test_get_network_playback_status_none():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    assert state.get_network_playback_status() is None
+    assert state.get(NETWORK_PLAYBACK_STATUS) is None
 
 
 @pytest.mark.parametrize("byte_val, expected", [
@@ -796,8 +889,8 @@ def test_get_network_playback_status_none():
 def test_get_network_playback_status(byte_val, expected):
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.NETWORK_PLAYBACK_STATUS] = bytes([byte_val])
-    assert state.get_network_playback_status() == expected
+    state._state[NETWORK_PLAYBACK_STATUS.cc] = bytes([byte_val])
+    assert state.get(NETWORK_PLAYBACK_STATUS) == expected
 
 
 # --- Now Playing Info (0x64) ---
@@ -833,8 +926,8 @@ async def test_update_now_playing_invalid_sample_rate_and_encoder(data):
     client.connected = True
     client.request.return_value = data
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.CURRENT_SOURCE] = SourceCodes.NET.to_bytes(
-        state._api_model, state.zn
+    state._state[CURRENT_SOURCE.cc] = SourceCodes.NET.to_bytes(
+        state.api_model, state.zn
     )
     state._updated.set()
 
@@ -860,14 +953,14 @@ def test_get_bluetooth_status_none():
 def test_get_bluetooth_status_empty():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.BLUETOOTH_STATUS] = b""
+    state._state[BLUETOOTH_STATUS.cc] = b""
     assert state.get_bluetooth_status() == (None, None)
 
 
 def test_get_bluetooth_status_no_connection():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.BLUETOOTH_STATUS] = bytes([0x00])
+    state._state[BLUETOOTH_STATUS.cc] = bytes([0x00])
     status, track = state.get_bluetooth_status()
     assert status == BluetoothAudioStatus.NO_CONNECTION
     assert track == ""
@@ -876,10 +969,28 @@ def test_get_bluetooth_status_no_connection():
 def test_get_bluetooth_status_playing_with_track():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.BLUETOOTH_STATUS] = bytes([0x03]) + b"My Song"
+    state._state[BLUETOOTH_STATUS.cc] = bytes([0x03]) + b"My Song"
     status, track = state.get_bluetooth_status()
     assert status == BluetoothAudioStatus.PLAYING_AAC
     assert track == "My Song"
+
+
+@pytest.mark.parametrize(
+    "method, command, response",
+    [
+        ("get_lifter_temperature", LIFTER_TEMPERATURE, bytes([0xF1, 0x4B])),
+        ("get_output_temperature", OUTPUT_TEMPERATURE, bytes([0x4B])),
+    ],
+)
+async def test_get_temperature_sensor(method, command, response):
+    client = MagicMock(spec=Client)
+    client.request.return_value = response
+    state = State(client, 1)
+    value = await getattr(state, method)(TemperatureSensor.SENSOR_2)
+    assert value == 75
+    client.request.assert_called_once_with(
+        1, command.cc, bytes([TemperatureSensor.SENSOR_2]), 0
+    )
 
 
 # --- RC5 typed tables ---
@@ -890,7 +1001,7 @@ async def test_send_playback():
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_playback(RC5CodePlayback.PLAY)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x35]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x35]), 0)
 
 
 async def test_send_navigation():
@@ -898,7 +1009,7 @@ async def test_send_navigation():
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_navigation(RC5CodeNavigation.UP)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x56]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x56]), 0)
 
 
 async def test_send_toggle():
@@ -906,7 +1017,7 @@ async def test_send_toggle():
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
     await state.send_toggle(RC5CodeToggle.RADIO)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x5B]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x5B]), 0)
 
 
 async def test_send_playback_unsupported_model():
@@ -957,17 +1068,17 @@ def test_rc5_avr_has_navigation(model):
 async def test_inc_bass_equalization():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    await state.inc_bass_equalization()
+    await state.inc(BASS_EQUALIZATION)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x2C]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x2C]), 0)
 
 
 async def test_dec_bass_equalization():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    await state.dec_bass_equalization()
+    await state.dec(BASS_EQUALIZATION)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x38]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x38]), 0)
 
 
 async def test_inc_bass_equalization_unsupported():
@@ -975,7 +1086,7 @@ async def test_inc_bass_equalization_unsupported():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APISA_SERIES)
     with pytest.raises(ValueError):
-        await state.inc_bass_equalization()
+        await state.inc(BASS_EQUALIZATION)
 
 
 def test_rc5_bass_table_entries_are_valid():
@@ -991,9 +1102,9 @@ def test_rc5_bass_table_entries_are_valid():
 async def test_set_display_brightness():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    await state.set_display_brightness(DisplayBrightness.L2)
+    await state.set(DISPLAY_BRIGHTNESS, DisplayBrightness.L2)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x23]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x23]), 0)
 
 
 async def test_set_hdmi_output():
@@ -1001,7 +1112,7 @@ async def test_set_hdmi_output():
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
     await state.set_hdmi_output(HdmiOutput.OUT_1_2)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4B]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x4B]), 0)
 
 
 async def test_set_hdmi_output_unsupported():
@@ -1029,12 +1140,12 @@ def test_rc5_hdmi_output_table_entries_are_valid():
 async def test_set_direct_mode():
     client = MagicMock(spec=Client)
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    await state.set_direct_mode(True)
+    await state.set(DIRECT_MODE, True)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4E]), 0)
-    await state.set_direct_mode(False)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x4E]), 0)
+    await state.set(DIRECT_MODE, False)
     client.request.assert_called_with(
-        1, CommandCodes.SIMULATE_RC5_IR_COMMAND, bytes([0x10, 0x4F]), 0)
+        1, SIMULATE_RC5_IR_COMMAND.cc, bytes([0x10, 0x4F]), 0)
 
 
 # --- Command support checking ---
@@ -1045,8 +1156,8 @@ def test_is_command_supported_universal():
     client = MagicMock(spec=Client)
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "SA30"})
-    assert state._is_command_supported(CommandCodes.POWER) is True
-    assert state._is_command_supported(CommandCodes.VOLUME) is True
+    assert state._is_command_supported(POWER) is True
+    assert state._is_command_supported(VOLUME) is True
 
 
 def test_is_command_supported_matching_model():
@@ -1055,9 +1166,9 @@ def test_is_command_supported_matching_model():
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "AVR30"})
     # IMAX_ENHANCED has version=APIVERSION_IMAX_SERIES which includes AVR30
-    assert state._is_command_supported(CommandCodes.IMAX_ENHANCED) is True
+    assert state._is_command_supported(IMAX_ENHANCED) is True
     # BLUETOOTH_STATUS has version=APIVERSION_HDA_SERIES which includes AVR30
-    assert state._is_command_supported(CommandCodes.BLUETOOTH_STATUS) is True
+    assert state._is_command_supported(BLUETOOTH_STATUS) is True
 
 
 def test_is_command_supported_non_matching_model():
@@ -1066,11 +1177,11 @@ def test_is_command_supported_non_matching_model():
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "SA30"})
     # IMAX_ENHANCED is not supported on SA series
-    assert state._is_command_supported(CommandCodes.IMAX_ENHANCED) is False
+    assert state._is_command_supported(IMAX_ENHANCED) is False
     # BLUETOOTH_STATUS is HDA-only
-    assert state._is_command_supported(CommandCodes.BLUETOOTH_STATUS) is False
+    assert state._is_command_supported(BLUETOOTH_STATUS) is False
     # VIDEO_SELECTION is PRE_HDA_AVR only
-    assert state._is_command_supported(CommandCodes.VIDEO_SELECTION) is False
+    assert state._is_command_supported(VIDEO_SELECTION) is False
 
 
 def test_is_command_supported_no_model_is_permissive():
@@ -1079,7 +1190,7 @@ def test_is_command_supported_no_model_is_permissive():
     state = State(client, 1)
     # No AMX discovery yet, model is None
     assert state.model is None
-    assert state._is_command_supported(CommandCodes.IMAX_ENHANCED) is True
+    assert state._is_command_supported(IMAX_ENHANCED) is True
 
 
 def test_is_command_supported_runtime_blocklist():
@@ -1087,9 +1198,9 @@ def test_is_command_supported_runtime_blocklist():
     client = MagicMock(spec=Client)
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "AVR30"})
-    assert state._is_command_supported(CommandCodes.VOLUME) is True
-    state._unsupported_commands.add(CommandCodes.VOLUME)
-    assert state._is_command_supported(CommandCodes.VOLUME) is False
+    assert state._is_command_supported(VOLUME) is True
+    state._unsupported_commands.add(VOLUME.cc)
+    assert state._is_command_supported(VOLUME) is False
 
 
 def test_require_command_raises_for_unsupported():
@@ -1098,8 +1209,8 @@ def test_require_command_raises_for_unsupported():
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "SA30"})
     with pytest.raises(UnsupportedCommand) as exc_info:
-        state._require_command(CommandCodes.IMAX_ENHANCED)
-    assert exc_info.value.cc == CommandCodes.IMAX_ENHANCED
+        state._require_command(IMAX_ENHANCED)
+    assert exc_info.value.cc == IMAX_ENHANCED
     assert exc_info.value.model == "SA30"
 
 
@@ -1108,17 +1219,17 @@ def test_require_command_passes_for_supported():
     client = MagicMock(spec=Client)
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "AVR30"})
-    state._require_command(CommandCodes.POWER)  # should not raise
-    state._require_command(CommandCodes.IMAX_ENHANCED)  # should not raise
+    state._require_command(POWER)  # should not raise
+    state._require_command(IMAX_ENHANCED)  # should not raise
 
 
 def test_require_command_raises_for_runtime_blocked():
     """_require_command raises for commands blocked at runtime."""
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._unsupported_commands.add(CommandCodes.VOLUME)
+    state._unsupported_commands.add(VOLUME.cc)
     with pytest.raises(UnsupportedCommand):
-        state._require_command(CommandCodes.VOLUME)
+        state._require_command(VOLUME)
 
 
 async def test_setter_raises_for_unsupported_command():
@@ -1127,7 +1238,7 @@ async def test_setter_raises_for_unsupported_command():
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "SA30"})
     with pytest.raises(UnsupportedCommand):
-        await state.set_imax_enhanced(ImaxEnhancedMode.AUTO)
+        await state.set(IMAX_ENHANCED, ImaxEnhancedMode.AUTO)
     client.request.assert_not_called()
 
 
@@ -1135,9 +1246,9 @@ async def test_setter_raises_for_runtime_blocked_command():
     """Setter methods raise UnsupportedCommand for runtime-blocked commands."""
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._unsupported_commands.add(CommandCodes.VOLUME)
+    state._unsupported_commands.add(VOLUME.cc)
     with pytest.raises(UnsupportedCommand):
-        await state.set_volume(50)
+        await state.set(VOLUME, 50)
     client.request.assert_not_called()
 
 
@@ -1155,11 +1266,11 @@ async def test_update_skips_unsupported_commands():
     await asyncio.gather(*await state.get_update_tasks())
     requested_commands = [call.args[1] for call in client.request.call_args_list]
     # These commands have version restrictions that exclude SA30
-    assert CommandCodes.IMAX_ENHANCED not in requested_commands
-    assert CommandCodes.BLUETOOTH_STATUS not in requested_commands
-    assert CommandCodes.VIDEO_SELECTION not in requested_commands
+    assert IMAX_ENHANCED.cc not in requested_commands
+    assert BLUETOOTH_STATUS.cc not in requested_commands
+    assert VIDEO_SELECTION.cc not in requested_commands
     # But universal commands like POWER should still be requested
-    assert CommandCodes.POWER in requested_commands
+    assert POWER.cc in requested_commands
 
 
 async def test_update_presets_ignores_empty_payload():
@@ -1167,8 +1278,8 @@ async def test_update_presets_ignores_empty_payload():
     client.connected = True
     client.request.return_value = b""
     state = make_state(client, 1, ApiModel.APIHDA_SERIES)
-    state._state[CommandCodes.CURRENT_SOURCE] = SourceCodes.FM.to_bytes(
-        state._api_model, state.zn
+    state._state[CURRENT_SOURCE.cc] = SourceCodes.FM.to_bytes(
+        state.api_model, state.zn
     )
 
     await asyncio.gather(*await state.get_update_tasks())
@@ -1182,13 +1293,13 @@ async def test_update_records_command_not_recognised():
 
     client = MagicMock(spec=Client)
     client.connected = True
-    client.request.side_effect = CommandNotRecognised(cc=CommandCodes.MENU)
+    client.request.side_effect = CommandNotRecognised(cc=MENU.cc)
     state = State(client, 1)
     state._amxduet = AmxDuetResponse({"Device-Model": "AVR450"})
 
-    assert CommandCodes.MENU not in state._unsupported_commands
+    assert MENU.cc not in state._unsupported_commands
     await asyncio.gather(*await state.get_update_tasks())
-    assert CommandCodes.MENU in state._unsupported_commands
+    assert MENU.cc in state._unsupported_commands
 
 
 # --- Video Selection (0x0A) ---
@@ -1197,8 +1308,8 @@ async def test_update_records_command_not_recognised():
 async def test_set_video_selection():
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    await state.set_video_selection(VideoSelection.SAT)
-    client.request.assert_called_with(1, CommandCodes.VIDEO_SELECTION, bytes([0x01]), 0)
+    await state.set(VIDEO_SELECTION, VideoSelection.SAT)
+    client.request.assert_called_with(1, VIDEO_SELECTION.cc, bytes([0x01]), 0)
 
 
 # --- Update conditions / _should_update -----------------------------------
@@ -1207,8 +1318,8 @@ def _state_at_source(source: SourceCodes) -> State:
     """Helper: a fresh State with CURRENT_SOURCE seeded to `source`."""
     client = MagicMock(spec=Client)
     state = State(client, 1)
-    state._state[CommandCodes.CURRENT_SOURCE] = source.to_bytes(
-        state._api_model, state._zn,
+    state._state[CURRENT_SOURCE.cc] = source.to_bytes(
+        state.api_model, state._zn,
     )
     return state
 
@@ -1216,47 +1327,47 @@ def _state_at_source(source: SourceCodes) -> State:
 def test_should_update_no_update_flag():
     """Commands without the UPDATE flag are never polled."""
     state = State(MagicMock(spec=Client), 1)
-    assert not (CommandCodes.RESTORE_FACTORY_DEFAULT.flags & CommandFlags.UPDATE)
-    assert state._should_update(CommandCodes.RESTORE_FACTORY_DEFAULT) is False
+    assert not (RESTORE_FACTORY_DEFAULT.flags & CommandFlags.UPDATE)
+    assert state._should_update(RESTORE_FACTORY_DEFAULT) is False
 
 
 def test_should_update_pushed_first_pass_polls_even_if_known():
     """Pushed CCs are polled during the initial pass regardless of cache."""
     state = State(MagicMock(spec=Client), 1)
-    state._state[CommandCodes.POWER] = bytes([1])
+    state._state[POWER.cc] = bytes([1])
     assert state._updated.is_set() is False
-    assert state._should_update(CommandCodes.POWER) is True
+    assert state._should_update(POWER) is True
 
 
 def test_should_update_pushed_skipped_after_first_pass():
     state = State(MagicMock(spec=Client), 1)
     state._updated.set()
-    assert CommandCodes.POWER not in state._state
-    assert state._should_update(CommandCodes.POWER) is False
+    assert POWER.cc not in state._state
+    assert state._should_update(POWER) is False
 
 
 def test_should_update_not_pushed_always_polls():
     state = _state_at_source(SourceCodes.NET)
     state._updated.set()
     # NETWORK_PLAYBACK_STATUS is NOT_PUSHED, sources={NET, USB, NET_USB}
-    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is True
+    assert state._should_update(NETWORK_PLAYBACK_STATUS) is True
 
 
 def test_should_update_sources_no_match():
     state = _state_at_source(SourceCodes.CD)
-    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is False
+    assert state._should_update(NETWORK_PLAYBACK_STATUS) is False
 
 
 def test_should_update_sources_match():
     state = _state_at_source(SourceCodes.NET)
-    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is True
+    assert state._should_update(NETWORK_PLAYBACK_STATUS) is True
 
 
 def test_should_update_sources_unknown_is_permissive():
     """When source isn't yet known, fetch source-gated CCs anyway."""
     state = State(MagicMock(spec=Client), 1)
     assert state.get_source() is None
-    assert state._should_update(CommandCodes.NETWORK_PLAYBACK_STATUS) is True
+    assert state._should_update(NETWORK_PLAYBACK_STATUS) is True
 
 
 def test_should_update_zone_2_requires_zone_support():
@@ -1264,9 +1375,9 @@ def test_should_update_zone_2_requires_zone_support():
     client = MagicMock(spec=Client)
     state = State(client, 2)
     # MUTE has ZONE_SUPPORT — ok
-    assert state._should_update(CommandCodes.MUTE) is True
+    assert state._should_update(MUTE) is True
     # INCOMING_AUDIO_FORMAT has no ZONE_SUPPORT
-    assert state._should_update(CommandCodes.INCOMING_AUDIO_FORMAT) is False
+    assert state._should_update(INCOMING_AUDIO_FORMAT) is False
 
 
 async def test_update_skips_commands_for_wrong_source():
@@ -1278,10 +1389,10 @@ async def test_update_skips_commands_for_wrong_source():
     # Run the tasks so we can inspect what got requested
     await asyncio.gather(*tasks)
     requested = [call.args[1] for call in state._client.request.call_args_list]
-    assert CommandCodes.NETWORK_PLAYBACK_STATUS not in requested
-    assert CommandCodes.NOW_PLAYING_INFO not in requested
+    assert NETWORK_PLAYBACK_STATUS.cc not in requested
+    assert NOW_PLAYING_INFO.cc not in requested
     # But POWER (no source gate) should be fetched
-    assert CommandCodes.POWER in requested
+    assert POWER.cc in requested
 
 
 async def test_update_pushed_skipped_after_first_pass():
@@ -1294,47 +1405,47 @@ async def test_update_pushed_skipped_after_first_pass():
     await asyncio.gather(*tasks)
     requested = [call.args[1] for call in state._client.request.call_args_list]
     # POWER is pushed — should NOT appear in a post-first-pass batch
-    assert CommandCodes.POWER not in requested
+    assert POWER.cc not in requested
     # NETWORK_PLAYBACK_STATUS is NOT_PUSHED + source matches — should appear
-    assert CommandCodes.NETWORK_PLAYBACK_STATUS in requested
+    assert NETWORK_PLAYBACK_STATUS.cc in requested
 
 
 # --- Accessor source gating ----------------------------------------------
 
 def test_get_dab_station_returns_none_when_source_mismatch():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.DAB_STATION] = b"BBC R4"
-    assert state.get_dab_station() is None
+    state._state[DAB_STATION.cc] = b"BBC R4"
+    assert state.get(DAB_STATION) is None
 
 
 def test_get_dab_station_returns_value_when_source_unknown():
     state = State(MagicMock(spec=Client), 1)
-    state._state[CommandCodes.DAB_STATION] = b"BBC R4"
-    assert state.get_dab_station() == "BBC R4"
+    state._state[DAB_STATION.cc] = b"BBC R4"
+    assert state.get(DAB_STATION) == "BBC R4"
 
 
 def test_get_dab_station_returns_value_when_source_matches():
     state = _state_at_source(SourceCodes.DAB)
-    state._state[CommandCodes.DAB_STATION] = b"BBC R4"
-    assert state.get_dab_station() == "BBC R4"
+    state._state[DAB_STATION.cc] = b"BBC R4"
+    assert state.get(DAB_STATION) == "BBC R4"
 
 
 def test_get_dls_pdt_gated_by_source():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.DLS_PDT_INFO] = b"Now Playing"
-    assert state.get_dls_pdt() is None
+    state._state[DLS_PDT.cc] = b"Now Playing"
+    assert state.get(DLS_PDT) is None
 
 
 def test_get_rds_information_gated_by_source():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.RDS_INFORMATION] = b"BBC R4"
-    assert state.get_rds_information() is None
+    state._state[RDS_INFORMATION.cc] = b"BBC R4"
+    assert state.get(RDS_INFORMATION) is None
 
 
 def test_get_tuner_preset_gated_by_source():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.TUNER_PRESET] = bytes([3])
-    assert state.get_tuner_preset() is None
+    state._state[TUNER_PRESET.cc] = bytes([3])
+    assert state.get(TUNER_PRESET) is None
 
 
 def test_get_preset_details_gated_by_source():
@@ -1345,13 +1456,13 @@ def test_get_preset_details_gated_by_source():
 
 def test_get_network_playback_status_gated_by_source():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.NETWORK_PLAYBACK_STATUS] = bytes([0x01])
-    assert state.get_network_playback_status() is None
+    state._state[NETWORK_PLAYBACK_STATUS.cc] = bytes([0x01])
+    assert state.get(NETWORK_PLAYBACK_STATUS) is None
 
 
 def test_get_bluetooth_status_gated_by_source():
     state = _state_at_source(SourceCodes.CD)
-    state._state[CommandCodes.BLUETOOTH_STATUS] = bytes([0x01]) + b"Track"
+    state._state[BLUETOOTH_STATUS.cc] = bytes([0x01]) + b"Track"
     assert state.get_bluetooth_status() == (None, None)
 
 
@@ -1363,5 +1474,5 @@ def test_get_now_playing_gated_by_source():
 
 async def test_set_tuner_preset_noops_when_source_mismatch():
     state = _state_at_source(SourceCodes.CD)
-    await state.set_tuner_preset(3)
+    await state.set(TUNER_PRESET, 3)
     state._client.request.assert_not_called()


### PR DESCRIPTION
Today there's several places that need to be updated and kept in sync when adding or maintaining commands. This centralizes all of that into one place, the CommandCodes metadata. Adding a new command is literally just adding the command with the right metadata, and accessors (along with CLI client and test server stuff) gets populated automatically. (Well, almost. There's the .pyi file now, but there's a test that literally gives you the lines to add/remove there.)

Manual accessors are still supported for special cases like power, or for commands with complex or one-off schema where it's cleaner to add custom logic in an accessor rather than create a generic schema for it.

Get, set, inc/dec are generated, depending on metadata. We also support RC5 fallback cases, where we can do a direct set on supported machines and fall back to RC5 on others.

Note that this got rid of a ton of manually-implemented accessors, all auto-implemented now. We also got the following accessors for free, just because we have the metadata:

DISPLAY_BRIGHTNESS (0x01): get
FM_GENRE (0x03): get
DIRECT_MODE (0x0F): get
HEADPHONES_OVERRIDE (0x1F): get, set
DOLBY_LEVELER (0x39): get, set
DOLBY_VOLUME_CALIBRATION_OFFSET (0x3A): get, set
DOLBY_PLIIX_DIMENSION (0x3C): get, set
DOLBY_PLIIX_CENTRE_WIDTH (0x3D): get, set
DOLBY_PLIIX_PANORAMA (0x3E): get
VIDEO_BRIGHTNESS (0x46): get, set
VIDEO_CONTRAST (0x47): get, set
VIDEO_COLOUR (0x48): get, set
VIDEO_FILM_MODE (0x49): get, set
VIDEO_EDGE_ENHANCEMENT (0x4A): get, set
VIDEO_NOISE_REDUCTION (0x4C): get, set
VIDEO_MPEG_NOISE_REDUCTION (0x4D): get, set
ZONE_1_OSD_ON_OFF (0x4E): get, set
VIDEO_OUTPUT_SWITCHING (0x4F): get, set
DC_OFFSET (0x51): get
SHORT_CIRCUIT_STATUS (0x52): get
FRIENDLY_NAME (0x53): get, set
LIFTER_TEMPERATURE (0x56): get
OUTPUT_TEMPERATURE (0x57): get
AUTO_SHUTDOWN_CONTROL (0x58): get, set
INPUT_DETECT (0x5A): get
PROCESSOR_MODE_INPUT (0x5B): get, set
PROCESSOR_MODE_VOLUME (0x5C): get, set
SYSTEM_MODEL (0x5E): get
DAC_FILTER (0x61): get, set
MAX_TURN_ON_VOLUME (0x65): get, set
MAX_VOLUME (0x66): get, set
MAX_STREAMING_VOLUME (0x67): get, set

Note this is built on https://github.com/elupus/arcam_fmj/pull/100 et al