### PR TITLE
fix: zero-pad tuner preset frequencies

### DIFF
--- a/src/arcam/fmj/codecs.py
+++ b/src/arcam/fmj/codecs.py
@@ -230,9 +230,9 @@ class PresetDetail:
         if type == PresetType.FM_RDS_NAME or type == PresetType.DAB:
             name = data[2:].decode("utf8").rstrip()
         elif type == PresetType.FM_FREQUENCY:
-            name = f"{data[2]}.{data[3]:2} MHz"
+            name = f"{data[2]}.{data[3]:02d} MHz"
         elif type == PresetType.AM_FREQUENCY:
-            name = f"{data[2]}{data[3]:2} kHz"
+            name = f"{data[2]}{data[3]:02d} kHz"
         else:
             name = str(data[2:])
         return PresetDetail(data[0], type, name)

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -9,6 +9,8 @@ from arcam.fmj.codecs import (
     AnswerCodes,
     IncomingVideoAspectRatio,
     IncomingVideoColorspace,
+    PresetDetail,
+    PresetType,
     VideoParameters,
 )
 from arcam.fmj.commands import CommandCodes
@@ -161,3 +163,16 @@ def test_video_parameters_7_bytes():
     assert vp.interlaced is False
     assert vp.aspect_ratio == IncomingVideoAspectRatio.ASPECT_16_9
     assert vp.colorspace is None
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (bytes([1, PresetType.FM_FREQUENCY, 85, 5]), "85.05 MHz"),
+        (bytes([2, PresetType.FM_FREQUENCY, 105, 50]), "105.50 MHz"),
+        (bytes([3, PresetType.AM_FREQUENCY, 6, 5]), "605 kHz"),
+        (bytes([4, PresetType.AM_FREQUENCY, 10, 10]), "1010 kHz"),
+    ],
+)
+def test_preset_detail_frequency_padding(data, expected):
+    assert PresetDetail.from_bytes(data).name == expected


### PR DESCRIPTION
Minor format bug: 85.05 -> "85. 5" instead of "85.05"